### PR TITLE
use render instead of format to render text info

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.5-alpha</Version>
+        <Version>0.40.6-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Game/Commands/Client/DeployUnitCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/DeployUnitCommand.cs
@@ -10,10 +10,10 @@ public record struct DeployUnitCommand : IClientCommand
     public required HexCoordinateData Position { get; init; }
     public required int Direction { get; init; }
 
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/JoinGameCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/JoinGameCommand.cs
@@ -8,10 +8,10 @@ public record struct JoinGameCommand: IClientCommand
     public required string PlayerName { get; init; }
     public required List<UnitData> Units { get; init; }
     public required string Tint { get; init; }
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var localizedTemplate = localizationService.GetString("Command_JoinGame"); 
         return string.Format(localizedTemplate, PlayerName, Units.Count);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/MoveUnitCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/MoveUnitCommand.cs
@@ -7,10 +7,10 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Client;
 
 public record struct MoveUnitCommand: IClientCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/PhysicalAttackCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/PhysicalAttackCommand.cs
@@ -4,10 +4,10 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Client;
 
 public record struct PhysicalAttackCommand : IClientCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/RequestGameLobbyStatusCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/RequestGameLobbyStatusCommand.cs
@@ -7,10 +7,10 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Client;
 /// </summary>
 public record struct RequestGameLobbyStatusCommand : IGameCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var localizedTemplate = localizationService.GetString("Command_RequestGameLobbyStatus");
         return string.Format(localizedTemplate, GameOriginId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/RollDiceCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/RollDiceCommand.cs
@@ -4,10 +4,10 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Client;
 
 public record struct RollDiceCommand : IClientCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/TurnEndedCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/TurnEndedCommand.cs
@@ -4,11 +4,11 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Client;
 
 public record struct TurnEndedCommand : IClientCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public Guid PlayerId { get; init; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var playerId = PlayerId;
         var player = game.Players.FirstOrDefault(p => p.Id == playerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/UpdatePlayerStatusCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/UpdatePlayerStatusCommand.cs
@@ -6,10 +6,10 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Client;
 public record struct UpdatePlayerStatusCommand: IClientCommand
 {
     public required PlayerStatus PlayerStatus { get; init; }
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/WeaponAttackDeclarationCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/WeaponAttackDeclarationCommand.cs
@@ -6,10 +6,10 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Client;
 
 public record struct WeaponAttackDeclarationCommand : IClientCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Client/WeaponConfigurationCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Client/WeaponConfigurationCommand.cs
@@ -8,10 +8,10 @@ public record struct WeaponConfigurationCommand : IClientCommand
     public required Guid UnitId { get; init; }
     public required WeaponConfiguration Configuration { get; set; }
 
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/IGameCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/IGameCommand.cs
@@ -6,5 +6,5 @@ public interface IGameCommand
 {
     Guid GameOriginId { get; set; }
     DateTime Timestamp { get; set; } 
-    string Format(ILocalizationService localizationService, IGame game); 
+    string Render(ILocalizationService localizationService, IGame game); 
 }

--- a/src/MakaMek.Core/Models/Game/Commands/Server/ChangeActivePlayerCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/ChangeActivePlayerCommand.cs
@@ -6,10 +6,10 @@ public record struct ChangeActivePlayerCommand : IGameCommand
 {
     public required Guid? PlayerId { get; init; }
     public required int UnitsToPlay { get; init; }
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Server/ChangePhaseCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/ChangePhaseCommand.cs
@@ -6,10 +6,10 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Server;
 public record struct ChangePhaseCommand : IGameCommand
 {
     public required PhaseNames Phase { get; init; }
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var localizedTemplate = localizationService.GetString("Command_ChangePhase"); 
         

--- a/src/MakaMek.Core/Models/Game/Commands/Server/DiceRolledCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/DiceRolledCommand.cs
@@ -6,10 +6,10 @@ public record struct DiceRolledCommand : IGameCommand
 {
     public required Guid PlayerId { get; init; }
     public required int Roll { get; init; }
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Commands/Server/HeatUpdatedCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/HeatUpdatedCommand.cs
@@ -10,10 +10,10 @@ public record struct HeatUpdatedCommand : IGameCommand
     public required HeatData HeatData { get; init; }
     public required int PreviousHeat { get; init; }
     
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var unit = game.Players

--- a/src/MakaMek.Core/Models/Game/Commands/Server/MechFallingCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/MechFallingCommand.cs
@@ -32,7 +32,7 @@ public record struct MechFallingCommand : IGameCommand
     public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var unit = game.Players

--- a/src/MakaMek.Core/Models/Game/Commands/Server/PilotingSkillRollCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/PilotingSkillRollCommand.cs
@@ -34,9 +34,9 @@ public record struct PilotingSkillRollCommand : IGameCommand
     /// </summary>
     public required PsrBreakdown PsrBreakdown { get; init; }
 
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var unit = game.Players
@@ -98,7 +98,7 @@ public record struct PilotingSkillRollCommand : IGameCommand
             {
                 stringBuilder.AppendLine(string.Format(
                     localizationService.GetString("Command_PilotingSkillRoll_Modifier"),
-                    modifier.Format(localizationService),
+                    modifier.Render(localizationService),
                     modifier.Value));
             }
         }

--- a/src/MakaMek.Core/Models/Game/Commands/Server/SetBattleMapCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/SetBattleMapCommand.cs
@@ -8,9 +8,9 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Server;
 /// </summary>
 public record struct SetBattleMapCommand : IGameCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var localizedTemplate = localizationService.GetString("Command_SetBattleMap");
         return string.Format(localizedTemplate);

--- a/src/MakaMek.Core/Models/Game/Commands/Server/SetBattleMapCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/SetBattleMapCommand.cs
@@ -12,8 +12,7 @@ public record struct SetBattleMapCommand : IGameCommand
     public DateTime Timestamp { get; set; }
     public string Render(ILocalizationService localizationService, IGame game)
     {
-        var localizedTemplate = localizationService.GetString("Command_SetBattleMap");
-        return string.Format(localizedTemplate);
+        return string.Format(localizationService.GetString("Command_SetBattleMap"));
     }
 
     public required List<HexData> MapData { get; init; }

--- a/src/MakaMek.Core/Models/Game/Commands/Server/TurnIncrementedCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/TurnIncrementedCommand.cs
@@ -4,11 +4,11 @@ namespace Sanet.MakaMek.Core.Models.Game.Commands.Server;
 
 public record struct TurnIncrementedCommand : IGameCommand
 {
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
     public required int TurnNumber { get; init; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var localizedTemplate = localizationService.GetString("Command_TurnIncremented");
         return string.Format(localizedTemplate, TurnNumber);

--- a/src/MakaMek.Core/Models/Game/Commands/Server/WeaponAttackResolutionCommand.cs
+++ b/src/MakaMek.Core/Models/Game/Commands/Server/WeaponAttackResolutionCommand.cs
@@ -14,10 +14,10 @@ public record struct WeaponAttackResolutionCommand : IGameCommand
     public required Guid TargetId { get; init; }
     public required AttackResolutionData ResolutionData { get; init; }
 
-    public Guid GameOriginId { get; set; }
+    public required Guid GameOriginId { get; set; }
     public DateTime Timestamp { get; set; }
 
-    public string Format(ILocalizationService localizationService, IGame game)
+    public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;
         var player = game.Players.FirstOrDefault(p => p.Id == command.PlayerId);

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/AttackerMovementModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/AttackerMovementModifier.cs
@@ -7,7 +7,7 @@ public record AttackerMovementModifier : RollModifier
 {
     public required MovementType MovementType { get; init; }
 
-    public override string Format(ILocalizationService localizationService) =>
+    public override string Render(ILocalizationService localizationService) =>
         string.Format(localizationService.GetString("Modifier_AttackerMovement"), 
             MovementType, Value);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/GunneryRollModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/GunneryRollModifier.cs
@@ -4,6 +4,6 @@ namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.Attack;
 
 public record GunneryRollModifier : RollModifier
 {
-    public override string Format(ILocalizationService localizationService) => 
+    public override string Render(ILocalizationService localizationService) => 
         string.Format(localizationService.GetString("Modifier_GunnerySkill"), Value);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/HeatRollModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/HeatRollModifier.cs
@@ -6,7 +6,7 @@ public record HeatRollModifier : RollModifier
 {
     public required int HeatLevel { get; init; }
 
-    public override string Format(ILocalizationService localizationService) =>
+    public override string Render(ILocalizationService localizationService) =>
         string.Format(localizationService.GetString("Modifier_Heat"), 
             HeatLevel, Value);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/RangeRollModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/RangeRollModifier.cs
@@ -9,7 +9,7 @@ public record RangeRollModifier : RollModifier
     public required int Distance { get; init; }
     public required string WeaponName { get; init; }
 
-    public override string Format(ILocalizationService localizationService) =>
+    public override string Render(ILocalizationService localizationService) =>
         string.Format(localizationService.GetString("Modifier_Range"), 
             WeaponName, Distance, Range, Value);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/SecondaryTargetModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/SecondaryTargetModifier.cs
@@ -12,7 +12,7 @@ public record SecondaryTargetModifier : RollModifier
     /// </summary>
     public required bool IsInFrontArc { get; init; }
 
-    public override string Format(ILocalizationService localizationService)
+    public override string Render(ILocalizationService localizationService)
     {
         var template = IsInFrontArc
             ? localizationService.GetString("Attack_SecondaryTargetFrontArc")

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/TargetMovementModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/TargetMovementModifier.cs
@@ -6,7 +6,7 @@ public record TargetMovementModifier : RollModifier
 {
     public required int HexesMoved { get; init; }
 
-    public override string Format(ILocalizationService localizationService) =>
+    public override string Render(ILocalizationService localizationService) =>
         string.Format(localizationService.GetString("Modifier_TargetMovement"), 
             HexesMoved, Value);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/TerrainRollModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/Attack/TerrainRollModifier.cs
@@ -9,7 +9,7 @@ public record TerrainRollModifier : RollModifier
     public required HexCoordinates Location { get; init; }
     public required MakaMekTerrains TerrainId { get; init; }
 
-    public override string Format(ILocalizationService localizationService) =>
+    public override string Render(ILocalizationService localizationService) =>
         string.Format(localizationService.GetString("Modifier_Terrain"), 
             TerrainId, Location, Value);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/DamagedGyroModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/DamagedGyroModifier.cs
@@ -9,7 +9,7 @@ public record DamagedGyroModifier : RollModifier
 {
     public required int HitsCount { get; init; }
     
-    public override string Format(ILocalizationService localizationService)
+    public override string Render(ILocalizationService localizationService)
     {
         return string.Format(localizationService.GetString("Modifier_DamagedGyro"),
             HitsCount,

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/FallingLevelsModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/FallingLevelsModifier.cs
@@ -12,7 +12,7 @@ public record FallingLevelsModifier : RollModifier
     /// </summary>
     public required int LevelsFallen { get; init; }
     
-    public override string Format(ILocalizationService localizationService) => 
+    public override string Render(ILocalizationService localizationService) => 
         string.Format(localizationService.GetString("Modifier_FallingLevels"),
             LevelsFallen,
             localizationService.GetString("Levels"),

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/RollModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/RollModifier.cs
@@ -9,5 +9,5 @@ public abstract record RollModifier
 {
     public required int Value { get; init; }
     
-    public abstract string Format(ILocalizationService localizationService);
+    public abstract string Render(ILocalizationService localizationService);
 }

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -137,7 +137,7 @@ public class BattleMapViewModel : BaseViewModel
         _dispatcherService.RunOnUIThread(() =>
         {
             if (Game == null) return;
-            var formattedCommand = command.Format(_localizationService, Game);
+            var formattedCommand = command.Render(_localizationService, Game);
             _commandLog.Add(formattedCommand);
             NotifyPropertyChanged(nameof(CommandLog));
 

--- a/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
@@ -72,6 +72,7 @@ public abstract class NewGameViewModel : BaseViewModel
         
         var readyCommand = new UpdatePlayerStatusCommand
         {
+            GameOriginId = Guid.NewGuid(),
             PlayerId = playerVm.Player.Id,
             PlayerStatus = PlayerStatus.Ready
         };

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
@@ -146,7 +146,7 @@ public class WeaponSelectionViewModel : BindableBase
             {
                 $"{_localizationService.GetString("Attack_TargetNumber")}: {ModifiersBreakdown.Total}"
             };
-            lines.AddRange(ModifiersBreakdown.AllModifiers.Select(modifier => modifier.Format(_localizationService)));
+            lines.AddRange(ModifiersBreakdown.AllModifiers.Select(modifier => modifier.Render(_localizationService)));
             // Add all modifiers using their Format method
             return string.Join(Environment.NewLine, lines);
         }

--- a/tests/MakaMek.Core.Tests/Models/Game/ClientGameTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/ClientGameTests.cs
@@ -142,6 +142,7 @@ public class ClientGameTests
         var player = new Player(Guid.NewGuid(), "Player1");
         var readyCommand = new UpdatePlayerStatusCommand
         {
+            GameOriginId = Guid.NewGuid(),
             PlayerStatus = PlayerStatus.Ready,
             PlayerId = player.Id
         };

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/DeployUnitCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/DeployUnitCommandTests.cs
@@ -39,13 +39,13 @@ public class DeployUnitCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         _localizationService.GetString("Command_DeployUnit").Returns("formatted deploy command");
 
         // Act
-        var result = _sut.Format(_localizationService, _game);
+        var result = _sut.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted deploy command");
@@ -53,26 +53,26 @@ public class DeployUnitCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = _sut with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenUnitNotFound()
+    public void Render_ShouldReturnEmpty_WhenUnitNotFound()
     {
         // Arrange
         var command = _sut with { UnitId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/JoinGameCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/JoinGameCommandTests.cs
@@ -32,7 +32,7 @@ public class JoinGameCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
@@ -40,7 +40,7 @@ public class JoinGameCommandTests
         _localizationService.GetString("Command_JoinGame").Returns("formatted join command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted join command");

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/MoveUnitCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/MoveUnitCommandTests.cs
@@ -45,7 +45,7 @@ public class MoveUnitCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
@@ -53,7 +53,7 @@ public class MoveUnitCommandTests
         _localizationService.GetString("Command_MoveUnit").Returns("formatted move command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted move command");
@@ -61,26 +61,26 @@ public class MoveUnitCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateCommand() with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenUnitNotFound()
+    public void Render_ShouldReturnEmpty_WhenUnitNotFound()
     {
         // Arrange
         var command = CreateCommand() with { UnitId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/RequestGameLobbyStatusCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/RequestGameLobbyStatusCommandTests.cs
@@ -22,7 +22,7 @@ public class RequestGameLobbyStatusCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
@@ -32,7 +32,7 @@ public class RequestGameLobbyStatusCommandTests
         _localizationService.GetString("Command_RequestGameLobbyStatus").Returns(expectedFormat);
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe(expectedResult);

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/RollDiceCommadTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/RollDiceCommadTests.cs
@@ -29,14 +29,14 @@ public class RollDiceCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
         _localizationService.GetString("Command_RollDice").Returns("formatted dice command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted dice command");
@@ -44,13 +44,13 @@ public class RollDiceCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateCommand() with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/TurnEndedCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/TurnEndedCommandTests.cs
@@ -32,13 +32,13 @@ public class TurnEndedCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("Player 1 has ended their turn.");
@@ -46,13 +46,13 @@ public class TurnEndedCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmptyPlayerName_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmptyPlayerName_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateCommand() with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe(" has ended their turn.");

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/UpdatePlayerStatusCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/UpdatePlayerStatusCommandTests.cs
@@ -30,14 +30,14 @@ public class UpdatePlayerStatusCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
         _localizationService.GetString("Command_UpdatePlayerStatus").Returns("formatted status command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted status command");
@@ -45,13 +45,13 @@ public class UpdatePlayerStatusCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateCommand() with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/WeaponAttackDeclarationCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/WeaponAttackDeclarationCommandTests.cs
@@ -74,40 +74,40 @@ public class WeaponAttackDeclarationCommandTests
     }
     
     [Fact]
-    public void Format_ReturnsEmpty_WhenPlayerNotFound()
+    public void Render_ReturnsEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateCommand() with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ReturnsEmpty_WhenAttackerNotFound()
+    public void Render_ReturnsEmpty_WhenAttackerNotFound()
     {
         // Arrange
         var command = CreateCommand() with { AttackerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ReturnsNoAttacksMessage_WhenNoWeaponTargets()
+    public void Render_ReturnsNoAttacksMessage_WhenNoWeaponTargets()
     {
         // Arrange
         var command = CreateCommand() with { WeaponTargets = new List<WeaponTargetData>() };
         _attacker.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top));
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponAttackDeclaration_NoAttacks");
@@ -115,7 +115,7 @@ public class WeaponAttackDeclarationCommandTests
     }
 
     [Fact]
-    public void Format_SkipsInvalidTargets_WhenTargetNotFound()
+    public void Render_SkipsInvalidTargets_WhenTargetNotFound()
     {
         // Arrange
         var command = CreateCommand();
@@ -135,7 +135,7 @@ public class WeaponAttackDeclarationCommandTests
         _target.Deploy(new HexPosition(new HexCoordinates(2, 2), HexDirection.Top));
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponAttackDeclaration_Header");
@@ -148,7 +148,7 @@ public class WeaponAttackDeclarationCommandTests
     }
     
     [Fact]
-    public void Format_ReturnsNoAttacksMessage_WhenTargetsNotFound()
+    public void Render_ReturnsNoAttacksMessage_WhenTargetsNotFound()
     {
         // Arrange
         var command = CreateCommand();
@@ -158,7 +158,7 @@ public class WeaponAttackDeclarationCommandTests
         _target.Deploy(new HexPosition(new HexCoordinates(2, 2), HexDirection.Top));
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponAttackDeclaration_NoAttacks");
@@ -169,7 +169,7 @@ public class WeaponAttackDeclarationCommandTests
     }
 
     [Fact]
-    public void Format_ReturnsAttackDeclarationMessage_WhenAllDataIsValid()
+    public void Render_ReturnsAttackDeclarationMessage_WhenAllDataIsValid()
     {
         // Arrange
         var command = CreateCommand();
@@ -177,7 +177,7 @@ public class WeaponAttackDeclarationCommandTests
         _target.Deploy(new HexPosition(new HexCoordinates(2, 2), HexDirection.Top));
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponAttackDeclaration_Header");
@@ -190,7 +190,7 @@ public class WeaponAttackDeclarationCommandTests
     }
 
     [Fact]
-    public void Format_ReturnsMultipleWeaponLines_WhenMultipleWeaponsTarget()
+    public void Render_ReturnsMultipleWeaponLines_WhenMultipleWeaponsTarget()
     {
         // Arrange
         var command = CreateCommand();
@@ -211,7 +211,7 @@ public class WeaponAttackDeclarationCommandTests
         _target.Deploy(new HexPosition(new HexCoordinates(2, 2), HexDirection.Top));
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponAttackDeclaration_Header");

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/WeaponConfigurationCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Client/WeaponConfigurationCommandTests.cs
@@ -53,46 +53,46 @@ public class WeaponConfigurationCommandTests
     }
 
     [Fact]
-    public void Format_ReturnsEmpty_WhenPlayerNotFound()
+    public void Render_ReturnsEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateCommand() with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ReturnsEmpty_WhenUnitNotFound()
+    public void Render_ReturnsEmpty_WhenUnitNotFound()
     {
         // Arrange
         var command = CreateCommand() with { UnitId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ReturnsEmpty_WhenUnitNotDeployed()
+    public void Render_ReturnsEmpty_WhenUnitNotDeployed()
     {
         // Arrange
         var command = CreateCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ReturnsTorsoRotationMessage_WhenConfigurationIsTorsoRotation()
+    public void Render_ReturnsTorsoRotationMessage_WhenConfigurationIsTorsoRotation()
     {
         // Arrange
         var command = CreateCommand();
@@ -100,7 +100,7 @@ public class WeaponConfigurationCommandTests
         var expectedHex = _unit.Position!.Coordinates.Neighbor(HexDirection.Bottom);
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponConfiguration_TorsoRotation");
@@ -108,7 +108,7 @@ public class WeaponConfigurationCommandTests
     }
 
     [Fact]
-    public void Format_ReturnsArmsFlipMessage_WhenConfigurationIsArmsFlip()
+    public void Render_ReturnsArmsFlipMessage_WhenConfigurationIsArmsFlip()
     {
         // Arrange
         var command = CreateCommand();
@@ -120,7 +120,7 @@ public class WeaponConfigurationCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponConfiguration_ArmsFlip");
@@ -128,7 +128,7 @@ public class WeaponConfigurationCommandTests
     }
 
     [Fact]
-    public void Format_ReturnsArmsFlipBackwardMessage_WhenConfigurationIsArmsFlipZero()
+    public void Render_ReturnsArmsFlipBackwardMessage_WhenConfigurationIsArmsFlipZero()
     {
         // Arrange
         var command = CreateCommand();
@@ -140,7 +140,7 @@ public class WeaponConfigurationCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         _localizationService.Received(1).GetString("Command_WeaponConfiguration_ArmsFlip");

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/ChangeActivePlayerCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/ChangeActivePlayerCommandTests.cs
@@ -30,7 +30,7 @@ public class ChangeActivePlayerCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
@@ -38,7 +38,7 @@ public class ChangeActivePlayerCommandTests
         _localizationService.GetString("Command_ChangeActivePlayerUnits").Returns("formatted active player command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted active player command");
@@ -46,7 +46,7 @@ public class ChangeActivePlayerCommandTests
     }
     
     [Fact]
-    public void Format_ShouldFormatCorrectly_WhenNoUnits()
+    public void Render_ShouldFormatCorrectly_WhenNoUnits()
     {
         // Arrange
         var command = new ChangeActivePlayerCommand
@@ -59,7 +59,7 @@ public class ChangeActivePlayerCommandTests
         _localizationService.GetString("Command_ChangeActivePlayer").Returns("formatted active player command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted active player command");
@@ -67,7 +67,7 @@ public class ChangeActivePlayerCommandTests
     }
     
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = new ChangeActivePlayerCommand
@@ -78,7 +78,7 @@ public class ChangeActivePlayerCommandTests
         };
         
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
         
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/ChangePhaseCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/ChangePhaseCommandTests.cs
@@ -24,14 +24,14 @@ public class ChangePhaseCommandTests
 
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
         _localizationService.GetString("Command_ChangePhase").Returns("formatted phase command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted phase command");

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/DiceRolledCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/DiceRolledCommandTests.cs
@@ -30,14 +30,14 @@ public class DiceRolledCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand();
         _localizationService.GetString("Command_DiceRolled").Returns("formatted dice command");
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("formatted dice command");
@@ -45,13 +45,13 @@ public class DiceRolledCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/HeatUpdatedCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/HeatUpdatedCommandTests.cs
@@ -54,7 +54,7 @@ public class HeatUpdatedCommandTests
     }
 
     [Fact]
-    public void Format_WithNoHeatSources_ReturnsExpectedString()
+    public void Render_WithNoHeatSources_ReturnsExpectedString()
     {
         // Arrange
         var heatData = new HeatData
@@ -79,7 +79,7 @@ public class HeatUpdatedCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldContain($"Heat update for {_unit.Name} (Previous: 0)");
@@ -89,7 +89,7 @@ public class HeatUpdatedCommandTests
     }
 
     [Fact]
-    public void Format_WithMovementHeat_ReturnsExpectedString()
+    public void Render_WithMovementHeat_ReturnsExpectedString()
     {
         // Arrange
         var movementHeatSources = new List<MovementHeatData>
@@ -119,7 +119,7 @@ public class HeatUpdatedCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldContain($"Heat update for {_unit.Name} (Previous: 0)");
@@ -130,7 +130,7 @@ public class HeatUpdatedCommandTests
     }
 
     [Fact]
-    public void Format_WithWeaponHeat_ReturnsExpectedString()
+    public void Render_WithWeaponHeat_ReturnsExpectedString()
     {
         // Arrange
         var weaponHeatSources = new List<WeaponHeatData>
@@ -161,7 +161,7 @@ public class HeatUpdatedCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldContain($"Heat update for {_unit.Name} (Previous: 0)");
@@ -173,7 +173,7 @@ public class HeatUpdatedCommandTests
     }
 
     [Fact]
-    public void Format_WithCombinedHeatSources_ReturnsExpectedString()
+    public void Render_WithCombinedHeatSources_ReturnsExpectedString()
     {
         // Arrange
         var movementHeatSources = new List<MovementHeatData>
@@ -209,7 +209,7 @@ public class HeatUpdatedCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldContain($"Heat update for {_unit.Name} (Previous: 5)");
@@ -222,7 +222,7 @@ public class HeatUpdatedCommandTests
     }
 
     [Fact]
-    public void Format_WithUnitNotFound_ReturnsEmptyString()
+    public void Render_WithUnitNotFound_ReturnsEmptyString()
     {
         // Arrange
         var heatData = new HeatData
@@ -247,7 +247,7 @@ public class HeatUpdatedCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/MechFallingCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/MechFallingCommandTests.cs
@@ -152,13 +152,13 @@ public class MechFallingCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatBasicFall_Correctly()
+    public void Render_ShouldFormatBasicFall_Correctly()
     {
         // Arrange
         var command = CreateBasicFallingCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -170,13 +170,13 @@ public class MechFallingCommandTests
     }
 
     [Fact]
-    public void Format_ShouldIncludeLevelsFallen_WhenApplicable()
+    public void Render_ShouldIncludeLevelsFallen_WhenApplicable()
     {
         // Arrange
         var command = CreateFallingWithLevelsCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -186,13 +186,13 @@ public class MechFallingCommandTests
     }
 
     [Fact]
-    public void Format_ShouldIncludeJumpingStatus_WhenApplicable()
+    public void Render_ShouldIncludeJumpingStatus_WhenApplicable()
     {
         // Arrange
         var command = CreateJumpingFallCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -202,13 +202,13 @@ public class MechFallingCommandTests
     }
 
     [Fact]
-    public void Format_ShouldIncludePilotInjury_WhenApplicable()
+    public void Render_ShouldIncludePilotInjury_WhenApplicable()
     {
         // Arrange
         var command = CreatePilotInjuryCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -218,13 +218,13 @@ public class MechFallingCommandTests
     }
 
     [Fact]
-    public void Format_ShouldIncludeAllElements_ForComplexFall()
+    public void Render_ShouldIncludeAllElements_ForComplexFall()
     {
         // Arrange
         var command = CreateComplexFallCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -236,13 +236,13 @@ public class MechFallingCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenUnitNotFound()
+    public void Render_ShouldReturnEmpty_WhenUnitNotFound()
     {
         // Arrange
         var command = CreateBasicFallingCommand() with { UnitId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/PilotingSkillRollCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/PilotingSkillRollCommandTests.cs
@@ -119,13 +119,13 @@ public class PilotingSkillRollCommandTests
     }
     
     [Fact]
-    public void Format_ShouldFormatSuccessfulRoll_Correctly()
+    public void Render_ShouldFormatSuccessfulRoll_Correctly()
     {
         // Arrange
         var sut = CreateSuccessfulCommand();
         
         // Act
-        var result = sut.Format(_localizationService, _game);
+        var result = sut.Render(_localizationService, _game);
         
         // Assert
         result.ShouldContain("Test Player's Locust LCT-1V succeeds Gyro Hit check");
@@ -137,13 +137,13 @@ public class PilotingSkillRollCommandTests
     }
     
     [Fact]
-    public void Format_ShouldFormatFailedRoll_Correctly()
+    public void Render_ShouldFormatFailedRoll_Correctly()
     {
         // Arrange
         var sut = CreateFailedCommand();
         
         // Act
-        var result = sut.Format(_localizationService, _game);
+        var result = sut.Render(_localizationService, _game);
         
         // Assert
         result.ShouldContain("Test Player's Locust LCT-1V fails Gyro Hit check");
@@ -155,13 +155,13 @@ public class PilotingSkillRollCommandTests
     }
     
     [Fact]
-    public void Format_ShouldFormatImpossibleRoll_Correctly()
+    public void Render_ShouldFormatImpossibleRoll_Correctly()
     {
         // Arrange
         var sut = CreateImpossibleCommand();
         
         // Act
-        var result = sut.Format(_localizationService, _game);
+        var result = sut.Render(_localizationService, _game);
         
         // Assert
         result.ShouldContain("Test Player's Locust LCT-1V automatically fails Gyro Hit check (impossible roll)");
@@ -173,14 +173,14 @@ public class PilotingSkillRollCommandTests
     }
     
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenUnitNotFound()
+    public void Render_ShouldReturnEmpty_WhenUnitNotFound()
     {
         // Arrange
         var sut = CreateSuccessfulCommand();
         sut = sut with { UnitId = Guid.NewGuid() }; // Set to a non-existent unit ID
         
         // Act
-        var result = sut.Format(_localizationService, _game);
+        var result = sut.Render(_localizationService, _game);
         
         // Assert
         result.ShouldBeEmpty();
@@ -191,7 +191,7 @@ public class PilotingSkillRollCommandTests
     {
         public required string Name { get; init; }
         
-        public override string Format(ILocalizationService localizationService)
+        public override string Render(ILocalizationService localizationService)
         {
             return Name;
         }

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/SetBattleMapCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/SetBattleMapCommandTests.cs
@@ -25,14 +25,14 @@ public class SetBattleMapCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var sut = CreateCommand();
         _localizationService.GetString("Command_SetBattleMap").Returns("Battle map has been set.");
 
         // Act
-        var result = sut.Format(_localizationService, _game);
+        var result = sut.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("Battle map has been set.");

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/TurnIncrementedCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/TurnIncrementedCommandTests.cs
@@ -28,13 +28,13 @@ public class TurnIncrementedCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var command = CreateCommand(2);
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe("Turn 2 has started.");
@@ -45,13 +45,13 @@ public class TurnIncrementedCommandTests
     [InlineData(1)]
     [InlineData(5)]
     [InlineData(10)]
-    public void Format_ShouldIncludeTurnNumber(int turnNumber)
+    public void Render_ShouldIncludeTurnNumber(int turnNumber)
     {
         // Arrange
         var command = CreateCommand(turnNumber);
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBe($"Turn {turnNumber} has started.");

--- a/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/WeaponAttackResolutionCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Commands/Server/WeaponAttackResolutionCommandTests.cs
@@ -205,13 +205,13 @@ public class WeaponAttackResolutionCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatHit_Correctly()
+    public void Render_ShouldFormatHit_Correctly()
     {
         // Arrange
         var command = CreateHitCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -222,13 +222,13 @@ public class WeaponAttackResolutionCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatMiss_Correctly()
+    public void Render_ShouldFormatMiss_Correctly()
     {
         // Arrange
         var command = CreateMissCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -237,13 +237,13 @@ public class WeaponAttackResolutionCommandTests
     }
 
     [Fact]
-    public void Format_ShouldFormatClusterWeapon_Correctly()
+    public void Render_ShouldFormatClusterWeapon_Correctly()
     {
         // Arrange
         var command = CreateClusterHitCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -259,52 +259,52 @@ public class WeaponAttackResolutionCommandTests
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenPlayerNotFound()
+    public void Render_ShouldReturnEmpty_WhenPlayerNotFound()
     {
         // Arrange
         var command = CreateHitCommand() with { PlayerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenAttackerNotFound()
+    public void Render_ShouldReturnEmpty_WhenAttackerNotFound()
     {
         // Arrange
         var command = CreateHitCommand() with { AttackerId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ShouldReturnEmpty_WhenTargetNotFound()
+    public void Render_ShouldReturnEmpty_WhenTargetNotFound()
     {
         // Arrange
         var command = CreateHitCommand() with { TargetId = Guid.NewGuid() };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldBeEmpty();
     }
 
     [Fact]
-    public void Format_ShouldIncludeAttackDirection_WhenHit()
+    public void Render_ShouldIncludeAttackDirection_WhenHit()
     {
         // Arrange
         var command = CreateHitCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -312,13 +312,13 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_ShouldIncludeAttackDirection_WithClusterWeapon()
+    public void Render_ShouldIncludeAttackDirection_WithClusterWeapon()
     {
         // Arrange
         var command = CreateClusterHitCommand();
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -329,7 +329,7 @@ public class WeaponAttackResolutionCommandTests
     [InlineData(FiringArc.Left, "Attack Direction: Left")]
     [InlineData(FiringArc.Right, "Attack Direction: Right")]
     [InlineData(FiringArc.Rear, "Attack Direction: Rear")]
-    public void Format_ShouldDisplayCorrectAttackDirection(FiringArc direction, string expectedDirectionText)
+    public void Render_ShouldDisplayCorrectAttackDirection(FiringArc direction, string expectedDirectionText)
     {
         // Arrange
         var hitLocations = new List<HitLocationData>
@@ -362,7 +362,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -370,7 +370,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_Includes_CriticalHitsData_When_It_Present_ButNotHitSlots()
+    public void Render_Includes_CriticalHitsData_When_It_Present_ButNotHitSlots()
     {
         // Arrange: create a hit with a critical hit in slot 2, with a component
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -409,7 +409,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical roll: 7");
@@ -418,7 +418,7 @@ public class WeaponAttackResolutionCommandTests
     }
 
     [Fact]
-    public void Format_Includes_CriticalHit_Info_When_CriticalHits_Present()
+    public void Render_Includes_CriticalHit_Info_When_CriticalHits_Present()
     {
         // Arrange: create a hit with a critical hit in slot 2, with a component
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -459,14 +459,14 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical hit in LeftArm slot 3: Machine Gun");
     }
 
     [Fact]
-    public void Format_Includes_HitLocationTransfer_Info_When_Transfers_Present()
+    public void Render_Includes_HitLocationTransfer_Info_When_Transfers_Present()
     {
         // Arrange: create a hit with a transfer from LeftArm to LeftTorso
         var hitLocations = new List<HitLocationData>
@@ -505,14 +505,14 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("LeftArm → LeftTorso: 5 damage");
     }
 
     [Fact]
-    public void Format_Includes_BlownOff_Message_When_Location_Is_Blown_Off()
+    public void Render_Includes_BlownOff_Message_When_Location_Is_Blown_Off()
     {
         // Arrange: create a hit with a blown-off location (head)
         var hitLocations = new List<HitLocationData>
@@ -550,7 +550,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("LOCATION BLOWN OFF: Head");
@@ -559,7 +559,7 @@ public class WeaponAttackResolutionCommandTests
     }
 
     [Fact]
-    public void Format_Includes_CriticalHits_In_Different_Location()
+    public void Render_Includes_CriticalHits_In_Different_Location()
     {
         // Arrange: create a hit with critical hits in a different location than the primary hit
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -605,7 +605,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("CenterTorso: 5 damage");
@@ -614,7 +614,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_Handles_Multiple_Critical_Hits_In_Different_Slots()
+    public void Render_Handles_Multiple_Critical_Hits_In_Different_Slots()
     {
         // Arrange: create a hit with multiple critical hits in different slots
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -663,7 +663,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical roll: 10");
@@ -673,7 +673,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_Handles_Multiple_Critical_Hits_In_Different_Locations()
+    public void Render_Handles_Multiple_Critical_Hits_In_Different_Locations()
     {
         // Arrange: create a hit with critical hits in multiple locations
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -723,7 +723,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical hits in LeftArm:");
@@ -735,7 +735,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_Handles_Multiple_Blown_Off_Locations()
+    public void Render_Handles_Multiple_Blown_Off_Locations()
     {
         // Arrange: create a hit with multiple blown-off locations
         var hitLocations = new List<HitLocationData>
@@ -776,7 +776,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("LOCATION BLOWN OFF: LeftArm");
@@ -784,7 +784,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_Handles_Null_CriticalHits_Array()
+    public void Render_Handles_Null_CriticalHits_Array()
     {
         // Arrange: create a hit with null critical hits array
         var hitLocations = new List<HitLocationData>
@@ -822,7 +822,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical roll: 10");
@@ -831,7 +831,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_Handles_Component_Lookup_Failure()
+    public void Render_Handles_Component_Lookup_Failure()
     {
         // Arrange: create a hit with a critical hit in a slot that doesn't have a component
         var hitLocations = new List<HitLocationData>
@@ -870,7 +870,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical roll: 10");
@@ -880,7 +880,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_Includes_Explosion_Message_When_Component_Can_Explode()
+    public void Render_Includes_Explosion_Message_When_Component_Can_Explode()
     {
         // Arrange: create a hit with a critical hit on an explodable component
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -925,7 +925,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical hit in LeftArm slot 3: AC5 Ammo");
@@ -933,7 +933,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_DoesNotInclude_Explosion_Message_When_Component_Cannot_Explode()
+    public void Render_DoesNotInclude_Explosion_Message_When_Component_Cannot_Explode()
     {
         // Arrange: create a hit with a critical hit on a non-explodable component
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -976,7 +976,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical hit in LeftArm slot 3: Machine Gun");
@@ -984,7 +984,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_DoesNotInclude_Explosion_Message_When_Component_Has_Already_Exploded()
+    public void Render_DoesNotInclude_Explosion_Message_When_Component_Has_Already_Exploded()
     {
         // Arrange: create a hit with a critical hit on an ammo component that has already exploded
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -1030,7 +1030,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical hit in LeftArm slot 3: AC5 Ammo");
@@ -1038,7 +1038,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_DoesNotInclude_Explosion_Message_When_Component_Has_Zero_Explosion_Damage()
+    public void Render_DoesNotInclude_Explosion_Message_When_Component_Has_Zero_Explosion_Damage()
     {
         // Arrange: create a hit with a critical hit on an ammo component with no remaining shots
         var leftArm = _target.Parts.First(p => p.Location == PartLocation.LeftArm);
@@ -1083,7 +1083,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var output = command.Format(_localizationService, _game);
+        var output = command.Render(_localizationService, _game);
 
         // Assert
         output.ShouldContain("Critical hit in LeftArm slot 3: AC5 Ammo");
@@ -1091,7 +1091,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_ShouldIncludeDestroyedParts_WhenPartsAreDestroyed()
+    public void Render_ShouldIncludeDestroyedParts_WhenPartsAreDestroyed()
     {
         // Arrange
         var hitLocations = new List<HitLocationData>
@@ -1127,7 +1127,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();
@@ -1137,7 +1137,7 @@ public class WeaponAttackResolutionCommandTests
     }
     
     [Fact]
-    public void Format_ShouldIncludeUnitDestroyed_WhenUnitIsDestroyed()
+    public void Render_ShouldIncludeUnitDestroyed_WhenUnitIsDestroyed()
     {
         // Arrange
         var hitLocations = new List<HitLocationData>
@@ -1172,7 +1172,7 @@ public class WeaponAttackResolutionCommandTests
         };
 
         // Act
-        var result = command.Format(_localizationService, _game);
+        var result = command.Render(_localizationService, _game);
 
         // Assert
         result.ShouldNotBeEmpty();

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/FallingDamageCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/FallingDamageCalculatorTests.cs
@@ -57,7 +57,7 @@ public class FallingDamageCalculatorTests
     {
         public required string Name { get; init; }
         
-        public override string Format(ILocalizationService localizationService)
+        public override string Render(ILocalizationService localizationService)
         {
             return Name;
         }

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/AttackerMovementModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/AttackerMovementModifierTests.cs
@@ -21,13 +21,13 @@ public class AttackerMovementModifierTests
     }
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         _localizationService.GetString("Modifier_AttackerMovement").Returns("Attacker Movement ({0}): +{1}");
 
         // Act
-        var result = _sut.Format(_localizationService);
+        var result = _sut.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Attacker Movement (Run): +2");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/GunneryRollModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/GunneryRollModifierTests.cs
@@ -10,7 +10,7 @@ public class GunneryRollModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new GunneryRollModifier
@@ -20,7 +20,7 @@ public class GunneryRollModifierTests
         _localizationService.GetString("Modifier_GunnerySkill").Returns("Gunnery Skill: +{0}");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Gunnery Skill: +4");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/HeatRollModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/HeatRollModifierTests.cs
@@ -10,7 +10,7 @@ public class HeatRollModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new HeatRollModifier
@@ -21,7 +21,7 @@ public class HeatRollModifierTests
         _localizationService.GetString("Modifier_Heat").Returns("Heat Level ({0}): {1}");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Heat Level (15): 2");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/RangeRollModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/RangeRollModifierTests.cs
@@ -11,7 +11,7 @@ public class RangeRollModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new RangeRollModifier
@@ -24,7 +24,7 @@ public class RangeRollModifierTests
         _localizationService.GetString("Modifier_Range").Returns("{0} at {1} hexes ({2} range): +{3}");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Medium Laser at 7 hexes (Medium range): +2");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/SecondaryTargetModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/SecondaryTargetModifierTests.cs
@@ -10,7 +10,7 @@ public class SecondaryTargetModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_FrontArc_ShouldFormatCorrectly()
+    public void Render_FrontArc_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new SecondaryTargetModifier
@@ -21,7 +21,7 @@ public class SecondaryTargetModifierTests
         _localizationService.GetString("Attack_SecondaryTargetFrontArc").Returns("Secondary target (front arc): +{0}");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Secondary target (front arc): +1");
@@ -29,7 +29,7 @@ public class SecondaryTargetModifierTests
     }
 
     [Fact]
-    public void Format_OtherArc_ShouldFormatCorrectly()
+    public void Render_OtherArc_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new SecondaryTargetModifier
@@ -40,7 +40,7 @@ public class SecondaryTargetModifierTests
         _localizationService.GetString("Attack_SecondaryTargetOtherArc").Returns("Secondary target (other arc): +{0}");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Secondary target (other arc): +2");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/TargetMovementModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/TargetMovementModifierTests.cs
@@ -10,7 +10,7 @@ public class TargetMovementModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new TargetMovementModifier
@@ -21,7 +21,7 @@ public class TargetMovementModifierTests
         _localizationService.GetString("Modifier_TargetMovement").Returns("Target Movement ({0} hexes): +{1}");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Target Movement (5 hexes): +3");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/TerrainRollModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/Attack/TerrainRollModifierTests.cs
@@ -12,7 +12,7 @@ public class TerrainRollModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var hexCoordinates = new HexCoordinates(3, 4);
@@ -25,7 +25,7 @@ public class TerrainRollModifierTests
         _localizationService.GetString("Modifier_Terrain").Returns("{0} at {1}: {2}");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("LightWoods at 0304: 1");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/DamagedGyroModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/DamagedGyroModifierTests.cs
@@ -10,7 +10,7 @@ public class DamagedGyroModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new DamagedGyroModifier
@@ -22,7 +22,7 @@ public class DamagedGyroModifierTests
         _localizationService.GetString("Hits").Returns("Hits");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Damaged Gyro (1 Hits): +3");

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/FallingLevelsModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/FallingLevelsModifierTests.cs
@@ -10,7 +10,7 @@ public class FallingLevelsModifierTests
     private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
 
     [Fact]
-    public void Format_ShouldFormatCorrectly()
+    public void Render_ShouldFormatCorrectly()
     {
         // Arrange
         var modifier = new FallingLevelsModifier
@@ -22,7 +22,7 @@ public class FallingLevelsModifierTests
         _localizationService.GetString("Levels").Returns("Levels");
 
         // Act
-        var result = modifier.Format(_localizationService);
+        var result = modifier.Render(_localizationService);
 
         // Assert
         result.ShouldBe("Falling (2 Levels): +2");

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/EndPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/EndPhaseTests.cs
@@ -126,6 +126,7 @@ public class EndPhaseTests : GamePhaseTestsBase
         
         var turnEndedCommand = new TurnEndedCommand
         {
+            GameOriginId = Game.Id,
             PlayerId = _player1Id,
             Timestamp = DateTime.UtcNow
         };
@@ -175,6 +176,7 @@ public class EndPhaseTests : GamePhaseTestsBase
         
         var turnEndedCommand = new TurnEndedCommand
         {
+            GameOriginId = Game.Id,
             PlayerId = _player1Id,
             Timestamp = DateTime.UtcNow
         };

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
@@ -1220,7 +1220,7 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
     {
         public required string Name { get; init; }
         
-        public override string Format(Sanet.MakaMek.Core.Services.Localization.ILocalizationService localizationService)
+        public override string Render(Sanet.MakaMek.Core.Services.Localization.ILocalizationService localizationService)
         {
             return Name;
         }

--- a/tests/MakaMek.Core.Tests/Services/Transport/CommandTransportAdapterTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Transport/CommandTransportAdapterTests.cs
@@ -278,6 +278,7 @@ public class CommandTransportAdapterTests
             sut.Initialize(_ => { }); // Initialize should be safe
             sut.PublishCommand(new TurnIncrementedCommand
             {
+                GameOriginId = Guid.NewGuid(),
                 TurnNumber = 1
             }); // Publish should be safe (no-op)
         });
@@ -304,7 +305,11 @@ public class CommandTransportAdapterTests
         ((IDisposable)disposablePublisher2).Received(1).Dispose();
         
         // Verify publishers list is empty by publishing a command (should not be received)
-        var command = new TurnIncrementedCommand{ TurnNumber = 1};
+        var command = new TurnIncrementedCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            TurnNumber = 1
+        };
         sut.PublishCommand(command);
         
         disposablePublisher1.DidNotReceive().PublishMessage(Arg.Any<TransportMessage>());
@@ -348,7 +353,11 @@ public class CommandTransportAdapterTests
         ((IDisposable)normalPublisher).Received(1).Dispose();
         
         // Verify that the publishers list was cleared
-        var command = new TurnIncrementedCommand {TurnNumber = 1};
+        var command = new TurnIncrementedCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            TurnNumber = 1
+        };
         sut.PublishCommand(command);
         
         throwingPublisher.DidNotReceive().PublishMessage(Arg.Any<TransportMessage>());

--- a/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
@@ -227,7 +227,7 @@ public class BattleMapViewModelTests
 
         // Assert
         _sut.CommandLog.Count.ShouldBe(1);
-        _sut.CommandLog.First().ShouldBeEquivalentTo(joinCommand.Format(_localizationService, clientGame));
+        _sut.CommandLog.First().ShouldBeEquivalentTo(joinCommand.Render(_localizationService, clientGame));
     }
 
     [Fact]
@@ -266,8 +266,8 @@ public class BattleMapViewModelTests
 
         // Assert
         _sut.CommandLog.Count.ShouldBe(2);
-        _sut.CommandLog.First().ShouldBeEquivalentTo(joinCommand.Format(_localizationService,clientGame));
-        _sut.CommandLog.Last().ShouldBeEquivalentTo(phaseCommand.Format(_localizationService,clientGame));
+        _sut.CommandLog.First().ShouldBeEquivalentTo(joinCommand.Render(_localizationService,clientGame));
+        _sut.CommandLog.Last().ShouldBeEquivalentTo(phaseCommand.Render(_localizationService,clientGame));
     }
 
     [Fact]
@@ -1595,6 +1595,7 @@ public class BattleMapViewModelTests
         _sut.Game = clientGame;
         clientGame.HandleCommand(new ChangeActivePlayerCommand
         {
+            GameOriginId = Guid.NewGuid(),
             PlayerId = player.Id,
             UnitsToPlay = 1
         });

--- a/tests/MakaMek.Presentation.Tests/ViewModels/JoinGameViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/JoinGameViewModelTests.cs
@@ -263,6 +263,7 @@ public class JoinGameViewModelTests
         // Create status update command
         var statusCommand = new UpdatePlayerStatusCommand
         {
+            GameOriginId = Guid.NewGuid(),
             PlayerId = playerId,
             PlayerStatus = PlayerStatus.Ready
         };
@@ -285,6 +286,7 @@ public class JoinGameViewModelTests
         var remotePlayerId = Guid.NewGuid();
         var joinCommand = new JoinGameCommand
         {
+            GameOriginId = Guid.NewGuid(),
             PlayerId = remotePlayerId,
             PlayerName = "Remote Player",
             Units = [MechFactoryTests.CreateDummyMechData()],
@@ -314,6 +316,7 @@ public class JoinGameViewModelTests
         // Create join command for the existing local player
         var joinCommand = new JoinGameCommand
         {
+            GameOriginId = Guid.NewGuid(),
             PlayerId = playerId,
             PlayerName = player.Player.Name,
             Units = [MechFactoryTests.CreateDummyMechData()],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Renamed the method for generating localized command descriptions from `Format` to `Render` for consistency across the application.
  - Updated multiple commands to require a unique game identifier (`GameOriginId`) upon creation.
- **Bug Fixes**
  - Ensured all relevant commands and actions properly include a unique game identifier to maintain correct game context.
- **Tests**
  - Updated tests to reflect the method renaming and enforce the requirement of the game identifier in command instances.
- **Chores**
  - Incremented the application version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->