### PR TITLE
fall when leg is destroyed

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.14-alpha</Version>
+        <Version>0.40.15-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Data/Game/Mechanics/FallReasonType.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/FallReasonType.cs
@@ -1,0 +1,69 @@
+namespace Sanet.MakaMek.Core.Data.Game.Mechanics;
+
+/// <summary>
+/// Represents the different reasons a 'Mech might fall
+/// </summary>
+public enum FallReasonType
+{
+    /// <summary>
+    /// Fall due to gyro hit (requires PSR)
+    /// </summary>
+    GyroHit,
+    
+    /// <summary>
+    /// Fall due to lower leg actuator hit (requires PSR)
+    /// </summary>
+    LowerLegActuatorHit,
+    
+    /// <summary>
+    /// Fall due to heavy damage (requires PSR)
+    /// </summary>
+    HeavyDamage,
+    
+    /// <summary>
+    /// Automatic fall due to destroyed gyro (no PSR)
+    /// </summary>
+    GyroDestroyed,
+    
+    /// <summary>
+    /// Automatic fall due to destroyed leg (no PSR)
+    /// </summary>
+    LegDestroyed
+}
+
+/// <summary>
+/// Extension methods for the FallReasonType enum
+/// </summary>
+public static class FallReasonTypeExtensions
+{
+    /// <summary>
+    /// Maps a FallReasonType to the corresponding PilotingSkillRollType for PSR calculations
+    /// </summary>
+    /// <param name="reasonType">The fall reason type to map</param>
+    /// <returns>The corresponding PilotingSkillRollType</returns>
+    public static PilotingSkillRollType? ToPilotingSkillRollType(this FallReasonType reasonType)
+    {
+        return reasonType switch
+        {
+            FallReasonType.GyroHit => PilotingSkillRollType.GyroHit,
+            FallReasonType.LowerLegActuatorHit => PilotingSkillRollType.LowerLegActuatorHit,
+            FallReasonType.HeavyDamage => PilotingSkillRollType.HeavyDamage,
+            _ => null // PSR is not required for that reason
+        };
+    }
+    
+    /// <summary>
+    /// Determines whether a PSR is required for this fall reason
+    /// </summary>
+    /// <param name="reasonType">The fall reason type to check</param>
+    /// <returns>True if a PSR is required, false if it's an automatic fall</returns>
+    public static bool RequiresPilotingSkillRoll(this FallReasonType reasonType)
+    {
+        return reasonType switch
+        {
+            FallReasonType.GyroDestroyed => false,
+            FallReasonType.LegDestroyed => false,
+            _ => true
+        };
+    }
+}

--- a/src/MakaMek.Core/Data/Game/Mechanics/FallReasonType.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/FallReasonType.cs
@@ -59,11 +59,6 @@ public static class FallReasonTypeExtensions
     /// <returns>True if a PSR is required, false if it's an automatic fall</returns>
     public static bool RequiresPilotingSkillRoll(this FallReasonType reasonType)
     {
-        return reasonType switch
-        {
-            FallReasonType.GyroDestroyed => false,
-            FallReasonType.LegDestroyed => false,
-            _ => true
-        };
+        return reasonType.ToPilotingSkillRollType()!=null;
     }
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
@@ -84,7 +84,7 @@ public class FallProcessor : IFallProcessor
         }
         
         // Check for destroyed legs
-        if (destroyedPartLocations?.Any(IsLegLocation) == true)
+        if (destroyedPartLocations?.Any(location => location.IsLeg()) == true)
         {
             fallReasons.Add(new FallReason(FallReasonType.LegDestroyed));
         }
@@ -99,9 +99,8 @@ public class FallProcessor : IFallProcessor
             
             PilotingSkillRollData? fallPsrData = null;
 
-            if (requiresPsr)
+            if (requiresPsr && reason.ReasonType.ToPilotingSkillRollType() is { } psrRollType)
             {
-                var psrRollType = reason.ReasonType.ToPilotingSkillRollType()!.Value;
                 var psrBreakdown = _pilotingSkillCalculator.GetPsrBreakdown(unit, [psrRollType],
                     battleMap, totalDamage);
                 var diceResults = _diceRoller.Roll2D6();
@@ -162,14 +161,5 @@ public class FallProcessor : IFallProcessor
         }
 
         return commandsToReturn;
-    }
-    
-    /// <summary>
-    /// Checks if a part location is a leg location
-    /// </summary>
-    private bool IsLegLocation(PartLocation location)
-    {
-        // Check if the location represents a leg part
-        return location is PartLocation.LeftLeg or PartLocation.RightLeg;
     }
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
@@ -18,7 +18,7 @@ public class FallProcessor : IFallProcessor
     private readonly IDiceRoller _diceRoller;
     private readonly IFallingDamageCalculator _fallingDamageCalculator;
 
-    private static readonly Dictionary<MakaMekComponent, FallReasonType> FallInducingCriticalsMap = new()
+    private static readonly Dictionary<MakaMekComponent, FallReasonType> ComponentFallReasonMap = new()
     {
         { MakaMekComponent.Gyro, FallReasonType.GyroHit },
         { MakaMekComponent.LowerLegActuator, FallReasonType.LowerLegActuatorHit }
@@ -51,13 +51,13 @@ public class FallProcessor : IFallProcessor
         // Check for component critical hits that may cause falling
         var hitFallInducingComponentTypes = componentHits
             .Select(c => c.Type)
-            .Where(type => FallInducingCriticalsMap.ContainsKey(type))
+            .Where(type => ComponentFallReasonMap.ContainsKey(type))
             .ToList();
 
         // Add reasons from critical hits
         foreach (var componentType in hitFallInducingComponentTypes)
         {
-            var reasonType = FallInducingCriticalsMap[componentType];
+            var reasonType = ComponentFallReasonMap[componentType];
             
             // Special handling for gyro - check if it's destroyed
             if (componentType == MakaMekComponent.Gyro)

--- a/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
@@ -65,7 +65,8 @@ public class FallProcessor : IFallProcessor
             if (componentType == MakaMekComponent.Gyro)
             {
                 var gyro = unit.GetAllComponents<Gyro>().FirstOrDefault();
-                if (gyro is { IsDestroyed: true })
+                if (gyro == null) continue;
+                if (gyro.IsDestroyed)
                 {
                     // If gyro is destroyed, change reason type to automatic fall
                     reasonType = FallReasonType.GyroDestroyed;

--- a/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/FallProcessor.cs
@@ -43,7 +43,8 @@ public class FallProcessor : IFallProcessor
         BattleMap? battleMap,
         List<ComponentHitData> componentHits,
         int totalDamage,
-        Guid gameId)
+        Guid gameId,
+        List<PartLocation>? destroyedPartLocations = null)
     {
         var commandsToReturn = new List<MechFallingCommand>();
 

--- a/src/MakaMek.Core/Models/Game/Mechanics/IFallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/IFallProcessor.cs
@@ -15,11 +15,13 @@ public interface IFallProcessor
     /// <param name="componentHits">A list of component hits sustained by the unit in the current context.</param>
     /// <param name="totalDamage">The total damage sustained by the unit in the current context.</param>
     /// <param name="gameId">The ID of the current game.</param>
+    /// <param name="destroyedPartLocations">The locations of parts that were destroyed.</param>
     /// <returns>A collection of MechFallingCommands if the unit falls, otherwise null.</returns>
     IEnumerable<MechFallingCommand> ProcessPotentialFall(
         Unit unit,
         BattleMap? battleMap,
         List<ComponentHitData> componentHits,
         int totalDamage,
-        Guid gameId);
+        Guid gameId,
+        List<PartLocation>? destroyedPartLocations = null);
 }

--- a/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
@@ -344,23 +344,21 @@ public class WeaponAttackResolutionPhase(ServerGame game) : GamePhase(game)
         
         // Check for fall conditions
         var heavyDamageThreshold = Game.RulesProvider.GetHeavyDamageThreshold();
-        if (allComponentHits.Count > 0 || resolution.HitLocationsData.TotalDamage >= heavyDamageThreshold)
-        {
-            // Use the new FallProcessor
-            var mechFallingCommands = Game.FallProcessor.ProcessPotentialFall(
-                target, 
-                Game.BattleMap, 
-                allComponentHits, 
-                resolution.HitLocationsData.TotalDamage, 
-                Game.Id).ToList();
+        if (allComponentHits.Count <= 0 && resolution.HitLocationsData.TotalDamage < heavyDamageThreshold) return;
+        // Use the new FallProcessor
+        var mechFallingCommands = Game.FallProcessor.ProcessPotentialFall(
+            target, 
+            Game.BattleMap, 
+            allComponentHits, 
+            resolution.HitLocationsData.TotalDamage, 
+            Game.Id).ToList();
 
-            foreach (var fallingCommand in mechFallingCommands)
-            {
-                Game.CommandPublisher.PublishCommand(fallingCommand);
-                if (fallingCommand.DamageData is null || target is not Mech mech) continue;
-                target.ApplyDamage(fallingCommand.DamageData.HitLocations.HitLocations);
-                mech.SetProne();
-            }
+        foreach (var fallingCommand in mechFallingCommands)
+        {
+            Game.CommandPublisher.PublishCommand(fallingCommand);
+            if (fallingCommand.DamageData is null || target is not Mech mech) continue;
+            target.ApplyDamage(fallingCommand.DamageData.HitLocations.HitLocations);
+            mech.SetProne();
         }
     }
     

--- a/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
@@ -343,15 +343,13 @@ public class WeaponAttackResolutionPhase(ServerGame game) : GamePhase(game)
         var allComponentHits = GetAllComponentHits(resolution.HitLocationsData);
         
         // Check for fall conditions
-        var heavyDamageThreshold = Game.RulesProvider.GetHeavyDamageThreshold();
-        if (allComponentHits.Count <= 0 && resolution.HitLocationsData.TotalDamage < heavyDamageThreshold) return;
-        // Use the new FallProcessor
         var mechFallingCommands = Game.FallProcessor.ProcessPotentialFall(
             target, 
             Game.BattleMap, 
             allComponentHits, 
             resolution.HitLocationsData.TotalDamage, 
-            Game.Id).ToList();
+            Game.Id,
+            resolution.DestroyedParts).ToList();
 
         foreach (var fallingCommand in mechFallingCommands)
         {

--- a/src/MakaMek.Core/Models/Units/PartLocation.cs
+++ b/src/MakaMek.Core/Models/Units/PartLocation.cs
@@ -11,3 +11,19 @@ public enum PartLocation
     LeftLeg,
     RightLeg
 }
+
+/// <summary>
+/// Extension methods for the PartLocation enum
+/// </summary>
+public static class PartLocationExtensions
+{
+    /// <summary>
+    /// Determines if the part location is a leg location
+    /// </summary>
+    /// <param name="location">The location to check</param>
+    /// <returns>True if the location is a leg, false otherwise</returns>
+    public static bool IsLeg(this PartLocation location)
+    {
+        return location is PartLocation.LeftLeg or PartLocation.RightLeg;
+    }
+}

--- a/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallReasonTypeTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallReasonTypeTests.cs
@@ -1,0 +1,47 @@
+using Sanet.MakaMek.Core.Data.Game.Mechanics;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Data.Game.Mechanics;
+
+public class FallReasonTypeTests
+{
+    [Theory]
+    [InlineData(FallReasonType.GyroHit, PilotingSkillRollType.GyroHit)]
+    [InlineData(FallReasonType.LowerLegActuatorHit, PilotingSkillRollType.LowerLegActuatorHit)]
+    [InlineData(FallReasonType.HeavyDamage, PilotingSkillRollType.HeavyDamage)]
+    public void ToPilotingSkillRollType_ForTypesRequiringPSR_ReturnsCorrectType(FallReasonType reasonType, PilotingSkillRollType expected)
+    {
+        // Act
+        var result = reasonType.ToPilotingSkillRollType();
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+
+    [Theory]
+    [InlineData(FallReasonType.GyroDestroyed)]
+    [InlineData(FallReasonType.LegDestroyed)]
+    public void ToPilotingSkillRollType_ForTypesWithNoRequiredPSR_ReturnsNull(FallReasonType reasonType)
+    {
+        // Act
+        var result = reasonType.ToPilotingSkillRollType();
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Theory]
+    [InlineData(FallReasonType.GyroHit, true)]
+    [InlineData(FallReasonType.LowerLegActuatorHit, true)]
+    [InlineData(FallReasonType.HeavyDamage, true)]
+    [InlineData(FallReasonType.GyroDestroyed, false)]
+    [InlineData(FallReasonType.LegDestroyed, false)]
+    public void RequiresPilotingSkillRoll_ReturnsCorrectValue(FallReasonType reasonType, bool expected)
+    {
+        // Act
+        var result = reasonType.RequiresPilotingSkillRoll();
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Map/HexDirectionTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Map/HexDirectionTests.cs
@@ -1,4 +1,5 @@
 using Sanet.MakaMek.Core.Models.Map;
+using Shouldly;
 
 namespace Sanet.MakaMek.Core.Tests.Models.Map;
 
@@ -17,7 +18,7 @@ public class HexDirectionTests
         var result = input.GetOppositeDirection();
 
         // Assert
-        Assert.Equal(expected, result);
+        result.ShouldBe(expected);
     }
     
     [Theory]
@@ -39,6 +40,6 @@ public class HexDirectionTests
         var result = startDirection.Rotate(hexsides);
 
         // Assert
-        Assert.Equal(expectedDirection, result);
+        result.ShouldBe(expectedDirection);
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/PartLocationTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/PartLocationTests.cs
@@ -1,0 +1,25 @@
+using Sanet.MakaMek.Core.Models.Units;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Models.Units;
+
+public class PartLocationTests
+{
+    [Theory]
+    [InlineData(PartLocation.LeftLeg, true)]
+    [InlineData(PartLocation.RightLeg, true)]
+    [InlineData(PartLocation.Head, false)]
+    [InlineData(PartLocation.CenterTorso, false)]
+    [InlineData(PartLocation.LeftTorso, false)]
+    [InlineData(PartLocation.RightTorso, false)]
+    [InlineData(PartLocation.LeftArm, false)]
+    [InlineData(PartLocation.RightArm, false)]
+    public void IsLeg_ChecksIfLocationIsLeg_ReturnsCorrectResult(PartLocation location, bool expected)
+    {
+        // Act
+        var result = location.IsLeg();
+
+        // Assert
+        result.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new fall reasons for mechs, including gyro and leg destruction, heavy damage, and specific component hits, improving the detail and accuracy of fall scenarios.
  - Introduced new extension methods to easily determine if a part is a leg and whether a fall reason requires a piloting skill roll.

- **Refactor**
  - Streamlined the fall processing logic for mechs, consolidating checks and improving clarity when resolving falls after attacks.
  - Unified fall reason handling under a single enum and refined piloting skill roll logic.

- **Chores**
  - Updated the version number to 0.40.15-alpha.

- **Tests**
  - Added tests verifying fall reason behaviors and piloting skill roll requirements.
  - Added tests for part location leg identification.
  - Added tests covering automatic falls triggered by destroyed legs.
  - Updated test assertions to use the Shouldly assertion library for clearer test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->