### PR TITLE
all psr modifiers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.23-alpha</Version>
+        <Version>0.40.24-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
@@ -112,8 +112,8 @@ public class FallProcessor : IFallProcessor
 
             if (requiresPsr && reasonType.ToPilotingSkillRollType() is { } psrRollType)
             {
-                var psrBreakdown = _pilotingSkillCalculator.GetPsrBreakdown(mech, [psrRollType],
-                    game.BattleMap, totalDamage);
+                var psrBreakdown = _pilotingSkillCalculator.GetPsrBreakdown(mech, psrRollType,
+                    game, totalDamage);
                 var diceResults = _diceRoller.Roll2D6();
                 var rollTotal = diceResults.Sum(d => d.Result);
                 isFallingNow = rollTotal < psrBreakdown.ModifiedPilotingSkill;
@@ -133,8 +133,8 @@ public class FallProcessor : IFallProcessor
             {
                 var pilotPsrBreakdown = _pilotingSkillCalculator.GetPsrBreakdown(
                     mech,
-                    [PilotingSkillRollType.PilotDamageFromFall],
-                    game.BattleMap,
+                    PilotingSkillRollType.PilotDamageFromFall,
+                    game,
                     totalDamage);
 
                 if (pilotPsrBreakdown.Modifiers.Any())

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IPilotingSkillCalculator.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IPilotingSkillCalculator.cs
@@ -1,5 +1,5 @@
 using Sanet.MakaMek.Core.Data.Game.Mechanics;
-using Sanet.MakaMek.Core.Models.Map;
+using Sanet.MakaMek.Core.Models.Game;
 using Sanet.MakaMek.Core.Models.Units;
 
 namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Mechs.Falling;
@@ -13,9 +13,9 @@ public interface IPilotingSkillCalculator
     /// Gets a detailed breakdown of all modifiers affecting the piloting skill roll.
     /// </summary>
     /// <param name="unit">The unit making the piloting skill roll.</param>
-    /// <param name="rollTypes">A collection of specific Piloting Skill Roll types to consider. If null or empty, all relevant modifiers are calculated.</param>
-    /// <param name="map">The battle map, used for terrain-based modifiers</param>
+    /// <param name="rollType">The specific Piloting Skill Roll type to consider.</param>
+    /// <param name="game">The game instance, used for accessing the map and other game state.</param>
     /// <param name="totalDamage">The total damage taken by the unit, used specifically for the HeavyDamage modifier check.</param>
     /// <returns>A breakdown of the piloting skill roll calculation</returns>
-    PsrBreakdown GetPsrBreakdown(Unit unit, IEnumerable<PilotingSkillRollType> rollTypes, BattleMap? map = null, int totalDamage = 0);
+    PsrBreakdown GetPsrBreakdown(Unit unit, PilotingSkillRollType rollType, IGame? game = null, int totalDamage = 0);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
@@ -1,7 +1,6 @@
 using Sanet.MakaMek.Core.Data.Game.Mechanics;
 using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers;
 using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
-using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
@@ -24,14 +23,15 @@ public class PilotingSkillCalculator : IPilotingSkillCalculator
     /// Gets a detailed breakdown of all modifiers affecting the piloting skill roll with additional context
     /// </summary>
     /// <param name="unit">The unit making the piloting skill roll</param>
-    /// <param name="rollTypes">A collection of specific Piloting Skill Roll types to consider. If null or empty, all relevant modifiers are calculated.</param>
-    /// <param name="map">The battle map, used for terrain-based modifiers</param>
+    /// <param name="rollType">The specific Piloting Skill Roll type to consider</param>
+    /// <param name="game">The game instance, used for accessing the map and other game state</param>
     /// <param name="totalDamage">The total damage taken by the unit, used specifically for the HeavyDamage modifier check.</param>
     /// <returns>A breakdown of the piloting skill roll calculation</returns>
     public PsrBreakdown GetPsrBreakdown(
         Unit unit, 
-        IEnumerable<PilotingSkillRollType> rollTypes,
-        BattleMap? map = null, int totalDamage=0)
+        PilotingSkillRollType rollType,
+        IGame? game = null, 
+        int totalDamage = 0)
     {
         if (unit.Crew == null)
         {
@@ -39,12 +39,16 @@ public class PilotingSkillCalculator : IPilotingSkillCalculator
         }
 
         var modifiers = new List<RollModifier>();
-        var relevantRollTypes = rollTypes.ToList();
-        if (unit is Mech mech)
-        {
-            // Add damaged gyro modifier if applicable
-            if (relevantRollTypes.Contains(PilotingSkillRollType.GyroHit))
+
+        if (unit is not Mech mech)
+            return new PsrBreakdown
             {
+                BasePilotingSkill = unit.Crew.Piloting,
+                Modifiers = modifiers
+            };
+        switch (rollType)
+        {
+            case PilotingSkillRollType.GyroHit:
                 // Check for damaged gyro
                 var gyroHits = GetGyroHits(mech);
                 if (gyroHits == 1)
@@ -55,50 +59,38 @@ public class PilotingSkillCalculator : IPilotingSkillCalculator
                         HitsCount = gyroHits
                     });
                 }
-            }
-
-            // Add Lower Leg Actuator Hit modifier if applicable
-            if (relevantRollTypes.Contains(PilotingSkillRollType.LowerLegActuatorHit))
-            {
+                break;
+                    
+            case PilotingSkillRollType.LowerLegActuatorHit:
                 modifiers.Add(new LowerLegActuatorHitModifier
                 {
                     Value = _rules.GetPilotingSkillRollModifier(PilotingSkillRollType.LowerLegActuatorHit)
                 });
-            }
-            
-            // Add Heavy Damage modifier if applicable
-            if (relevantRollTypes.Contains(PilotingSkillRollType.HeavyDamage))
-            {
+                break;
+                    
+            case PilotingSkillRollType.HeavyDamage:
                 modifiers.Add(new HeavyDamageModifier
                 {
                     Value = _rules.GetPilotingSkillRollModifier(PilotingSkillRollType.HeavyDamage),
                     DamageTaken = totalDamage 
                 });
-            }
+                break;
+                    
+            case PilotingSkillRollType.PilotDamageFromFall:
+                // Calculate levels fallen if game with map is provided
+                var levelsFallen = 0;
+                    
+                // Add modifiers for levels fallen
+                // According to the rules, there's a +1 modifier for every level above 1 fallen
+                modifiers.Add(new FallingLevelsModifier
+                {
+                    Value = Math.Max(0, levelsFallen - 1), // +1 for each level above 1
+                    LevelsFallen = levelsFallen
+                });
+                break;
+                    
+            // Add cases for other roll types as needed
         }
-
-
-
-        // Add MechWarrior damage from fall modifiers if applicable
-        if (relevantRollTypes.Contains(PilotingSkillRollType.PilotDamageFromFall))
-        {
-            // TODO: Calculate levels fallen if map is provided
-            var levelsFallen = 0;
-            
-            // Add modifiers for levels fallen
-            // According to the rules, there's a +1 modifier for every level above 1 fallen
-            modifiers.Add(new FallingLevelsModifier
-            {
-                Value = Math.Max(0, levelsFallen - 1), // +1 for each level above 1
-                LevelsFallen = levelsFallen
-            });
-        }
-        
-        // Future PSR modifiers can be added here following the same pattern:
-        // if (relevantRollTypes.Contains(PilotingSkillRollType.SomeOtherCondition))
-        // {
-        //     // logic to calculate and add SomeOtherConditionModifier
-        // }
 
         return new PsrBreakdown
         {

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -157,6 +157,10 @@ public class Mech : Unit
     public bool CanStandup()
     {
         if ((Status & UnitStatus.Shutdown)== UnitStatus.Shutdown) return false;
+        
+        var destroyedLegs = _parts.OfType<Leg>().Count(p=> p.IsDestroyed || p.IsBlownOff);
+        if (destroyedLegs >= 2) return false;
+        
         // Check if the Mech has at least one movement point available
         if (GetMovementPoints(MovementType.Walk) < 1) return false;
 

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -351,26 +351,29 @@ public class MovementState : IUiState
             if (_selectedUnit is Mech { IsProne: true } mech
                 && _viewModel.Game is not null)
             {
-                // Calculate piloting skill roll breakdown and success probability
+                // If Mech can't stand up, return empty actions list
+                if (!mech.CanStandup()) return [];
+                // Calculate piloting skill roll breakdown and success probability for standing up
                 var psrBreakdown = _viewModel.Game.PilotingSkillCalculator.GetPsrBreakdown(
-                    mech, PilotingSkillRollType.GyroHit);
-                
-                var successProbability = Core.Utils.DiceUtils.Calculate2d6Probability(psrBreakdown.ModifiedPilotingSkill);
-                
+                    mech, PilotingSkillRollType.StandupAttempt);
+
+                var successProbability =
+                    Core.Utils.DiceUtils.Calculate2d6Probability(psrBreakdown.ModifiedPilotingSkill);
+
                 // Format the probability as percentage
                 var probabilityText = $" ({successProbability:0}%)";
-                
+
                 // If the Mech is prone, only offer the "Attempt Standup" action if it can stand up
-                if (mech.CanStandup())
-                {
-                    return [new StateAction(
+
+                return
+                [
+                    new StateAction(
                         _viewModel.LocalizationService.GetString("Action_AttemptStandup") + probabilityText,
                         true,
-                        () => HandleStandupAttempt(mech))];
-                }
+                        () => HandleStandupAttempt(mech))
+                ];
+
                 
-                // If Mech can't stand up, return empty actions list
-                return [];
             }
 
             var actions = new List<StateAction>

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -1,5 +1,6 @@
 using Sanet.MakaMek.Core.Data.Game.Commands.Client.Builders;
 using Sanet.MakaMek.Core.Data.Game.Commands.Client;
+using Sanet.MakaMek.Core.Data.Game.Mechanics;
 using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
@@ -352,8 +353,7 @@ public class MovementState : IUiState
             {
                 // Calculate piloting skill roll breakdown and success probability
                 var psrBreakdown = _viewModel.Game.PilotingSkillCalculator.GetPsrBreakdown(
-                    mech,
-                    []);
+                    mech, PilotingSkillRollType.GyroHit);
                 
                 var successProbability = Core.Utils.DiceUtils.Calculate2d6Probability(psrBreakdown.ModifiedPilotingSkill);
                 

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -364,20 +364,21 @@ public class FallProcessorTests
         results.ShouldBeEmpty("No commands should be returned when no fall conditions are met.");
 
         // Verify no PSR calculations for fall reasons were attempted
+        // Verify no PSR calculations for fall reasons were attempted
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
-            _testMech,
+            Arg.Is<Unit>(u => u == _testMech),
             Arg.Is<PilotingSkillRollType>(type => 
-                types.Is(PilotingSkillRollType.GyroHit) || 
-                types.Contains(PilotingSkillRollType.LowerLegActuatorHit) || 
-                types.Contains(PilotingSkillRollType.HeavyDamage)),
-            _map,
-            totalDamageDealt);
+                type == PilotingSkillRollType.GyroHit || 
+                type == PilotingSkillRollType.LowerLegActuatorHit || 
+                type == PilotingSkillRollType.HeavyDamage),
+            Arg.Any<IGame>(),
+            Arg.Any<int>());
 
         // Verify no pilot damage PSR was attempted
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             _testMech,
             Arg.Any<PilotingSkillRollType>(),
-            _map,
+            _game,
             totalDamageDealt);
 
         _mockFallingDamageCalculator.DidNotReceive().CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
@@ -426,14 +427,14 @@ public class FallProcessorTests
 
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.HeavyDamage)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type==PilotingSkillRollType.HeavyDamage),
+            _game,
             Arg.Any<int>());
         
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type==PilotingSkillRollType.PilotDamageFromFall),
+            _game,
             Arg.Any<int>()); // totalDamageDealt is passed for context, even if not directly used by PilotDamage PSR modifiers in this setup
 
         _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 0, false);

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -264,20 +264,20 @@ public class FallProcessorTests
         command.PilotDamagePilotingSkillRoll.DiceResults.Sum().ShouldBe(7);
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.GyroHit)),
-            Arg.Any<BattleMap>(),
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.GyroHit),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
 
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.HeavyDamage)),
-            Arg.Any<BattleMap>(),
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.HeavyDamage),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
 
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            Arg.Any<BattleMap>(),
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.PilotDamageFromFall),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
 
         _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
@@ -327,20 +327,20 @@ public class FallProcessorTests
 
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.GyroHit)),
-            Arg.Any<BattleMap>(),
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.GyroHit),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
 
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.HeavyDamage)),
-            Arg.Any<BattleMap>(),
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.HeavyDamage),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
 
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            Arg.Any<BattleMap>(),
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.PilotDamageFromFall),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
 
         _mockFallingDamageCalculator.DidNotReceive().CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
@@ -473,14 +473,14 @@ public class FallProcessorTests
 
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.HeavyDamage)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type==PilotingSkillRollType.HeavyDamage),
+            _game,
             Arg.Any<int>());
         
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type==PilotingSkillRollType.PilotDamageFromFall),
+            _game,
             Arg.Any<int>());
 
         _mockFallingDamageCalculator.DidNotReceive().CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
@@ -520,16 +520,15 @@ public class FallProcessorTests
         // Ensure no PSR was attempted for a GyroHit because the mech has no gyro
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             _testMech, 
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => 
-                types.Contains(PilotingSkillRollType.GyroHit)), 
-            Arg.Any<BattleMap>(), 
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.GyroHit), 
+            Arg.Any<IGame>(), 
             Arg.Any<int>());
         
         // Also ensure no pilot damage PSR was attempted as no fall should be processed
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             _testMech, 
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)), 
-            Arg.Any<BattleMap>(), 
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.PilotDamageFromFall), 
+            Arg.Any<IGame>(), 
             Arg.Any<int>());
     }
 
@@ -584,15 +583,15 @@ public class FallProcessorTests
         // Verify GetPsrBreakdown was called for GyroHit
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.GyroHit)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.GyroHit),
+            _game,
             Arg.Any<int>());
 
         // Verify GetPsrBreakdown was called for PilotDamageFromFall
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.PilotDamageFromFall),
+            _game,
             Arg.Any<int>());
             
         _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 0, false);
@@ -650,15 +649,15 @@ public class FallProcessorTests
         // Verify GetPsrBreakdown was called for LowerLegActuatorHit
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.LowerLegActuatorHit)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.LowerLegActuatorHit),
+            _game,
             Arg.Any<int>());
 
         // Verify GetPsrBreakdown was called for PilotDamageFromFall
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.PilotDamageFromFall),
+            _game,
             Arg.Any<int>());
             
         _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 0, false);
@@ -699,8 +698,8 @@ public class FallProcessorTests
 
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.LowerLegActuatorHit)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.LowerLegActuatorHit),
+            _game,
             totalDamageDealt);
             
         _mockFallingDamageCalculator.DidNotReceive().CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
@@ -751,9 +750,8 @@ public class FallProcessorTests
         // Verify that GetPsrBreakdown was called for PilotDamageFromFall
         _mockPilotingSkillCalculator.Received().GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => 
-                types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            Arg.Any<BattleMap>(),
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.PilotDamageFromFall),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
         
         // Verify falling damage was calculated
@@ -796,8 +794,8 @@ public class FallProcessorTests
         // Verify GetPsrBreakdown was called for StandupAttempt
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.StandupAttempt)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.StandupAttempt),
+            _game,
             Arg.Is<int>(i => i == 0)); // totalDamage should be 0 for standup attempts
             
         // Verify no falling damage calculation occurred
@@ -839,8 +837,8 @@ public class FallProcessorTests
         // Verify GetPsrBreakdown was called for StandupAttempt
         _mockPilotingSkillCalculator.Received(1).GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.StandupAttempt)),
-            _map,
+            Arg.Is<PilotingSkillRollType>(type => type == PilotingSkillRollType.StandupAttempt),
+            _game,
             Arg.Is<int>(i => i == 0)); // totalDamage should be 0 for standup attempts
             
         // Verify falling damage calculation occurred
@@ -852,8 +850,8 @@ public class FallProcessorTests
     {
         _mockPilotingSkillCalculator.GetPsrBreakdown(
                 Arg.Any<Unit>(),
-                Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(psrType)),
-                Arg.Any<BattleMap>(),
+                Arg.Is<PilotingSkillRollType>(type => type == psrType),
+                Arg.Any<IGame>(),
                 Arg.Any<int>())
             .Returns(new PsrBreakdown
             {

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -134,9 +134,8 @@ public class FallProcessorTests
         // from the initial damage event, as this can influence pilot damage PSR modifiers.
         _mockPilotingSkillCalculator.Received().GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types =>
-                types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
-            Arg.Any<BattleMap>(),
+            Arg.Any<PilotingSkillRollType>(),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
     }
     
@@ -215,9 +214,8 @@ public class FallProcessorTests
         // Verify GetPsrBreakdown was called for GyroHit
         _mockPilotingSkillCalculator.Received().GetPsrBreakdown(
             Arg.Any<Unit>(),
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types =>
-                types.Contains(PilotingSkillRollType.GyroHit)),
-            Arg.Any<BattleMap>(),
+            Arg.Any<PilotingSkillRollType>(),
+            Arg.Any<IGame>(),
             Arg.Any<int>());
 
         // Verify no FallingDamage calculation occurred
@@ -368,8 +366,8 @@ public class FallProcessorTests
         // Verify no PSR calculations for fall reasons were attempted
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => 
-                types.Contains(PilotingSkillRollType.GyroHit) || 
+            Arg.Is<PilotingSkillRollType>(type => 
+                types.Is(PilotingSkillRollType.GyroHit) || 
                 types.Contains(PilotingSkillRollType.LowerLegActuatorHit) || 
                 types.Contains(PilotingSkillRollType.HeavyDamage)),
             _map,
@@ -378,7 +376,7 @@ public class FallProcessorTests
         // Verify no pilot damage PSR was attempted
         _mockPilotingSkillCalculator.DidNotReceive().GetPsrBreakdown(
             _testMech,
-            Arg.Is<IEnumerable<PilotingSkillRollType>>(types => types.Contains(PilotingSkillRollType.PilotDamageFromFall)),
+            Arg.Any<PilotingSkillRollType>(),
             _map,
             totalDamageDealt);
 

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
@@ -37,7 +37,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
 
             // Act
-            var result = _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.GyroHit]);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit);
 
             // Assert
             result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
@@ -60,7 +60,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             var mech = new Mech("Test", "TST-1A", 50, 4, [torso]);
 
             // Act
-            var result = _sut.GetPsrBreakdown(mech, []);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit);
 
             // Assert
             result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
@@ -84,7 +84,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(10);
 
             // Act
-            var result = _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.GyroHit]);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit);
 
             // Assert
             // The base piloting skill + 10 should be >= 13, which is impossible on 2d6
@@ -108,7 +108,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
 
             // Act & Assert
-            Should.Throw<ArgumentException>(() => _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.GyroHit]))
+            Should.Throw<ArgumentException>(() => _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit))
                 .Message.ShouldContain("No gyro found");
         }
 
@@ -119,7 +119,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             var mech = new Mech("Test", "TST-1A", 50, 4, []);
             
             // Act
-            var result = _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.PilotDamageFromFall]);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.PilotDamageFromFall);
 
             // Assert
             result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
@@ -130,45 +130,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             fallingModifier.LevelsFallen.ShouldBe(0);
             result.ModifiedPilotingSkill.ShouldBe(mech.Crew.Piloting); // No change to difficulty
         }
-
-        [Fact]
-        public void GetPsrBreakdown_MultipleRollTypes_CalculatesAllRequestedModifiers()
-        {
-            // Arrange
-            var torso = new CenterTorso("Test Torso", 10, 3, 5);
-            var gyro = torso.GetComponent<Gyro>()!;
-            gyro.Hit(); // Apply 1 hit to the gyro
-            var mech = new Mech("Test", "TST-1A", 50, 4, [torso]);
-            
-            // Set up the rules provider to return a modifier value for gyro hits
-            _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
-
-            // Act - request both GyroHit and PilotDamageFromFall modifiers
-            var result = _sut.GetPsrBreakdown(
-                mech, 
-                [PilotingSkillRollType.GyroHit, PilotingSkillRollType.PilotDamageFromFall]
-            );
-
-            // Assert
-            result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
-            result.Modifiers.Count.ShouldBe(2); // Both modifiers should be present
-            
-            // Check for gyro modifier
-            result.Modifiers.ShouldContain(m => m is DamagedGyroModifier);
-            var gyroModifier = result.Modifiers.OfType<DamagedGyroModifier>().First();
-            gyroModifier.Value.ShouldBe(3);
-            gyroModifier.HitsCount.ShouldBe(1);
-            
-            // Check for falling levels modifier
-            result.Modifiers.ShouldContain(m => m is FallingLevelsModifier);
-            var fallingModifier = result.Modifiers.OfType<FallingLevelsModifier>().First();
-            fallingModifier.Value.ShouldBe(0); // 0 levels fallen = no modifier
-            fallingModifier.LevelsFallen.ShouldBe(0);
-            
-            // Total modifier should be sum of both
-            result.ModifiedPilotingSkill.ShouldBe(mech.Crew.Piloting + 3); // Only gyro modifier affects the total
-        }
-
+        
         [Fact]
         public void GetPsrBreakdown_OnlyRequestedModifiersAreApplied()
         {
@@ -182,7 +144,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
 
             // Act - only request PilotDamageFromFall, not GyroHit
-            var result = _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.PilotDamageFromFall]);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.PilotDamageFromFall);
 
             // Assert
             result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
@@ -205,7 +167,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
 
             // Act - provide an empty list of roll types
-            var result = _sut.GetPsrBreakdown(mech, []);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit);
 
             // Assert
             result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
@@ -221,7 +183,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.LowerLegActuatorHit).Returns(1);
 
             // Act
-            var result = _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.LowerLegActuatorHit]);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.LowerLegActuatorHit);
 
             // Assert
             result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
@@ -231,40 +193,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             actuatorModifier.Value.ShouldBe(1);
             result.ModifiedPilotingSkill.ShouldBe(mech.Crew.Piloting + 1);
         }
-
-        [Fact]
-        public void GetPsrBreakdown_LowerLegActuatorHitAndGyroHitRequested_AddsBothModifiers()
-        {
-            // Arrange
-            var torso = new CenterTorso("Test Torso", 10, 3, 5);
-            var gyro = torso.GetComponent<Gyro>()!;
-            gyro.Hit(); // Apply 1 hit to the gyro
-            var mech = new Mech("Test", "TST-1A", 50, 4, [torso]);
-            
-            _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.LowerLegActuatorHit).Returns(1);
-            _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
-
-            // Act
-            var result = _sut.GetPsrBreakdown(mech, 
-                [PilotingSkillRollType.LowerLegActuatorHit, PilotingSkillRollType.GyroHit]
-            );
-
-            // Assert
-            result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
-            result.Modifiers.Count.ShouldBe(2);
-            
-            result.Modifiers.ShouldContain(m => m is LowerLegActuatorHitModifier);
-            var actuatorModifier = result.Modifiers.OfType<LowerLegActuatorHitModifier>().First();
-            actuatorModifier.Value.ShouldBe(1);
-            
-            result.Modifiers.ShouldContain(m => m is DamagedGyroModifier);
-            var gyroModifier = result.Modifiers.OfType<DamagedGyroModifier>().First();
-            gyroModifier.Value.ShouldBe(3);
-            gyroModifier.HitsCount.ShouldBe(1);
-            
-            result.ModifiedPilotingSkill.ShouldBe(mech.Crew.Piloting + 1 + 3);
-        }
-
+        
         [Fact]
         public void GetPsrBreakdown_OnlyGyroHitRequested_LowerLegActuatorHitModifierNotAdded()
         {
@@ -278,7 +207,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             // No setup for LowerLegActuatorHit, to ensure it's not called or added if not requested
 
             // Act
-            var result = _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.GyroHit]);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit);
 
             // Assert
             result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
@@ -298,7 +227,7 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             const int specificDamage = 33;
 
             // Act
-            var result = _sut.GetPsrBreakdown(mech, [PilotingSkillRollType.HeavyDamage], null, specificDamage);
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.HeavyDamage, null, specificDamage);
 
             // Assert
             var heavyDamageModifier = result.Modifiers.OfType<HeavyDamageModifier>().FirstOrDefault();

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
@@ -155,27 +155,6 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
         }
 
         [Fact]
-        public void GetPsrBreakdown_EmptyRollTypesList_NoModifiersApplied()
-        {
-            // Arrange
-            var torso = new CenterTorso("Test Torso", 10, 3, 5);
-            var gyro = torso.GetComponent<Gyro>()!;
-            gyro.Hit(); // Apply 1 hit to the gyro
-            var mech = new Mech("Test", "TST-1A", 50, 4, [torso]);
-            
-            // Set up the rules provider to return a modifier value for gyro hits
-            _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
-
-            // Act - provide an empty list of roll types
-            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit);
-
-            // Assert
-            result.BasePilotingSkill.ShouldBe(mech.Crew!.Piloting);
-            result.Modifiers.Count.ShouldBe(0); // No modifiers should be applied
-            result.ModifiedPilotingSkill.ShouldBe(mech.Crew.Piloting); // No change to difficulty
-        }
-
-        [Fact]
         public void GetPsrBreakdown_LowerLegActuatorHitRequested_AddsModifier()
         {
             // Arrange

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
@@ -6,6 +6,8 @@ using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal.Actuators;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
+using Sanet.MakaMek.Core.Models.Units.Pilots;
+using Sanet.MakaMek.Core.Tests.Models.Units;
 using Sanet.MakaMek.Core.Utils.TechRules;
 using Shouldly;
 
@@ -264,6 +266,31 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
 
             // Assert
             result.Modifiers.ShouldNotContain(m => m is LowerLegActuatorHitModifier);
+        }
+        
+        [Fact]
+        public void GetPsrBreakdown_ShouldReturnNoModifiers_ForNonMech()
+        {
+            // Arrange
+            var notMech = new UnitTests.TestUnit("Test", "TST-1A", 50, 4, []);
+            notMech.SetCrew(new MechWarrior("Test", "Test"));
+
+            // Act
+            var result = _sut.GetPsrBreakdown(notMech, PilotingSkillRollType.GyroHit);
+
+            // Assert
+            result.Modifiers.Count.ShouldBe(0);
+        }
+        
+        [Fact]
+        public void GetPsrBreakdown_ShouldThrow_WhenNoCrew()
+        {
+            // Arrange
+            var notMech = new UnitTests.TestUnit("Test", "TST-1A", 50, 4, []);
+
+            // Act & Assert
+            Should.Throw<ArgumentException>(() => _sut.GetPsrBreakdown(notMech, PilotingSkillRollType.GyroHit))
+                .Message.ShouldContain("crew");
         }
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1054,7 +1054,7 @@ public class MechTests
         var canStandup = mech.CanStandup();
 
         // Assert
-        canStandup.ShouldBeFalse("Mech should not be able to stand up when it has movement points and pilot is conscious but shutdown");
+        canStandup.ShouldBeFalse("Mech should not be able to stand up when both legs are destroyed");
     }
     
     [Fact]
@@ -1076,7 +1076,7 @@ public class MechTests
         var canStandup = mech.CanStandup();
 
         // Assert
-        canStandup.ShouldBeFalse("Mech should not be able to stand up when it has movement points and pilot is conscious but shutdown");
+        canStandup.ShouldBeFalse("Mech should not be able to stand up when both legs are blown off");
     }
     
     [Fact]
@@ -1098,6 +1098,6 @@ public class MechTests
         var canStandup = mech.CanStandup();
 
         // Assert
-        canStandup.ShouldBeFalse("Mech should not be able to stand up when it has movement points and pilot is conscious but shutdown");
+        canStandup.ShouldBeFalse("Mech should not be able to stand up when both legs are not available");
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1034,4 +1034,70 @@ public class MechTests
         // Assert
         canStandup.ShouldBeFalse("Mech should not be able to stand up when it has movement points and pilot is conscious but shutdown");
     }
+    
+    [Fact]
+    public void CanStandup_WhenBothLegsDestroyed_ShouldReturnFalse()
+    {
+        // Arrange
+        var parts = CreateBasicPartsData();
+        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
+        mech.SetProne();
+        
+        var leftLeg = mech.Parts.First(p=> p.Location == PartLocation.LeftLeg);
+        leftLeg.ApplyDamage(100);
+        leftLeg.IsDestroyed.ShouldBeTrue();
+        var rightLeg = mech.Parts.First(p=> p.Location == PartLocation.RightLeg);
+        rightLeg.ApplyDamage(100);
+        rightLeg.IsDestroyed.ShouldBeTrue();
+        
+        // Act
+        var canStandup = mech.CanStandup();
+
+        // Assert
+        canStandup.ShouldBeFalse("Mech should not be able to stand up when it has movement points and pilot is conscious but shutdown");
+    }
+    
+    [Fact]
+    public void CanStandup_WhenBothLegsBlownOff_ShouldReturnFalse()
+    {
+        // Arrange
+        var parts = CreateBasicPartsData();
+        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
+        mech.SetProne();
+        
+        var leftLeg = mech.Parts.First(p=> p.Location == PartLocation.LeftLeg);
+        leftLeg.BlowOff();
+        leftLeg.IsBlownOff.ShouldBeTrue();
+        var rightLeg = mech.Parts.First(p=> p.Location == PartLocation.RightLeg);
+        rightLeg.BlowOff();
+        rightLeg.IsBlownOff.ShouldBeTrue();
+        
+        // Act
+        var canStandup = mech.CanStandup();
+
+        // Assert
+        canStandup.ShouldBeFalse("Mech should not be able to stand up when it has movement points and pilot is conscious but shutdown");
+    }
+    
+    [Fact]
+    public void CanStandup_WhenOneLegIsBlownOffAndAnotherIsDestroyed_ShouldReturnFalse()
+    {
+        // Arrange
+        var parts = CreateBasicPartsData();
+        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
+        mech.SetProne();
+        
+        var leftLeg = mech.Parts.First(p=> p.Location == PartLocation.LeftLeg);
+        leftLeg.BlowOff();
+        leftLeg.IsBlownOff.ShouldBeTrue();
+        var rightLeg = mech.Parts.First(p=> p.Location == PartLocation.RightLeg);
+        rightLeg.ApplyDamage(100);
+        rightLeg.IsDestroyed.ShouldBeTrue();
+        
+        // Act
+        var canStandup = mech.CanStandup();
+
+        // Assert
+        canStandup.ShouldBeFalse("Mech should not be able to stand up when it has movement points and pilot is conscious but shutdown");
+    }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -10,6 +10,7 @@ using Sanet.MakaMek.Core.Models.Units.Components;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons.Ballistic;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons.Missile;
+using Sanet.MakaMek.Core.Models.Units.Pilots;
 using Sanet.MakaMek.Core.Utils.TechRules;
 using Shouldly;
 
@@ -78,6 +79,11 @@ public class UnitTests
             {
                 Status = UnitStatus.Destroyed;
             }
+        }
+
+        public void SetCrew(IPilot pilot)
+        {
+            Crew = pilot;
         }
     }
     

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -699,7 +699,7 @@ public class MovementStateTests
     {
         // Arrange
         var proneMech = _unit1 as Mech;
-        _pilotingSkillCalculator.GetPsrBreakdown(proneMech!, [])
+        _pilotingSkillCalculator.GetPsrBreakdown(proneMech!, PilotingSkillRollType.StandupAttempt)
             .Returns(new PsrBreakdown
             {
                 BasePilotingSkill = 4,
@@ -720,7 +720,7 @@ public class MovementStateTests
     public void GetAvailableActions_ProneMech_CannotStandup_ReturnsEmptyList()
     {
         // Arrange
-        _pilotingSkillCalculator.GetPsrBreakdown(Arg.Any<Mech>(), [])
+        _pilotingSkillCalculator.GetPsrBreakdown(Arg.Any<Mech>(), PilotingSkillRollType.StandupAttempt)
             .Returns(new PsrBreakdown
             {
                 BasePilotingSkill = 4,
@@ -880,7 +880,7 @@ public class MovementStateTests
 
         // Set up a prone Mech
         var proneMech = _unit1 as Mech;
-        _pilotingSkillCalculator.GetPsrBreakdown(proneMech!, [])
+        _pilotingSkillCalculator.GetPsrBreakdown(proneMech!, PilotingSkillRollType.StandupAttempt)
             .Returns(new PsrBreakdown
             {
                 BasePilotingSkill = 4,
@@ -909,7 +909,7 @@ public class MovementStateTests
         
         // Set up a prone Mech
         var proneMech = _unit1 as Mech;
-        _pilotingSkillCalculator.GetPsrBreakdown(proneMech!, [])
+        _pilotingSkillCalculator.GetPsrBreakdown(proneMech!, PilotingSkillRollType.StandupAttempt)
             .Returns(new PsrBreakdown
             {
                 BasePilotingSkill = 4,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mechs can no longer stand up if both legs are destroyed or blown off.

* **Bug Fixes**
  * Improved accuracy of available actions for prone Mechs, preventing standup attempts when not possible.

* **Refactor**
  * Simplified piloting skill roll calculations to use a single roll type and broader game context for improved clarity and maintainability.

* **Tests**
  * Added and updated unit tests to verify standup restrictions and piloting skill calculations.
  * Removed outdated tests for multiple or empty piloting skill roll types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->