### PR TITLE
calculate psrs once at the end of the phase

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.24-alpha</Version>
+        <Version>0.40.25-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
@@ -715,7 +715,8 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
                 Arg.Any<Mech>(),
                 Arg.Any<IGame>(),
                 Arg.Any<List<ComponentHitData>>(),
-                Arg.Any<int>())
+                Arg.Any<int>(),
+                Arg.Any<List<PartLocation>>())
             .Returns(new List<MechFallCommand> { mechFallingCommand });
         
         // Act
@@ -727,7 +728,8 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
             Arg.Is<Mech>(u => u == _player1Unit1), // Target unit
             Arg.Is<IGame>(m => m == Game),
             Arg.Any<List<ComponentHitData>>(),
-            Arg.Any<int>());
+            Arg.Any<int>(),
+            Arg.Any<List<PartLocation>>());
         
         // Verify that the MechFallingCommand was published
         CommandPublisher.Received().PublishCommand(
@@ -766,7 +768,8 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
                 Arg.Any<Mech>(),
                 Arg.Any<IGame>(),
                 Arg.Any<List<ComponentHitData>>(),
-                Arg.Any<int>())
+                Arg.Any<int>(),
+                Arg.Any<List<PartLocation>>())
             .Returns(new List<MechFallCommand> { mechFallingCommand });
         
         // Get initial armor value to verify damage is applied
@@ -799,7 +802,8 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
                 Arg.Any<Mech>(),
                 Arg.Any<IGame>(),
                 Arg.Any<List<ComponentHitData>>(),
-                Arg.Any<int>())
+                Arg.Any<int>(),
+                Arg.Any<List<PartLocation>>())
             .Returns(new List<MechFallCommand>());
         
         // Act


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved damage tracking during weapon attack resolution phases by accumulating all damage and destroyed parts for each unit, with fall checks now processed at the end of the phase rather than after each attack.

* **Chores**
  * Updated the application version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->