### PR TITLE
more psr modifiers

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.26-alpha</Version>
+        <Version>0.40.27-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Data/Game/Commands/Server/MechFallCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Server/MechFallCommand.cs
@@ -33,12 +33,12 @@ public record struct MechFallCommand : IGameCommand
     /// <summary>
     /// Whether a piloting skill roll is required for this fall
     /// </summary>
-    public bool IsPilotingSkillRollRequired => FallPilotingSkillRoll != null;
+    public bool IsPilotingSkillRollRequired => FallPilotingSkillRoll is not null;
     
     /// <summary>
     /// Whether the pilot is taking damage from the fall
     /// </summary>
-    public bool IsPilotTakingDamage => PilotDamagePilotingSkillRoll != null;
+    public bool IsPilotTakingDamage => PilotDamagePilotingSkillRoll is { IsSuccessful: false };
 
     /// <summary>
     /// The piloting skill roll data for the fall check

--- a/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
@@ -7,10 +7,10 @@ namespace Sanet.MakaMek.Core.Data.Game.Mechanics;
 public enum PilotingSkillRollType
 {
     /// <summary>
-    /// PSR modifier due to a damaged or destroyed gyro.
+    /// PSR modifiers due to a damaged or destroyed gyro.
     /// </summary>
     GyroHit,
-    
+    GyroDestroyed,
     /// <summary>
     /// PSR for determining if a MechWarrior takes damage when a mech falls.
     /// </summary>
@@ -25,10 +25,23 @@ public enum PilotingSkillRollType
     /// PSR required when a 'Mech takes 20 or more damage points in a single phase.
     /// </summary>
     HeavyDamage,
+
+    /// <summary>
+    /// PSR modifier due to a critical hit on a hip actuator.
+    /// </summary>
+    HipActuatorHit,
+
+    /// <summary>
+    /// PSR modifier due to a critical hit on a foot actuator.
+    /// </summary>
+    FootActuatorHit,
+
+    /// <summary>
+    /// PSR modifier due to a leg being destroyed (for pilot damage during fall).
+    /// </summary>
+    LegDestroyed,
+
     // Add other PSR types here in the future, e.g.:
-    // ActuatorDamage,
-    // PilotDamage,
-    // LegDamage,
     // Shutdown,
     // EnteringDeepWater,
     // Skid

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
@@ -20,7 +20,9 @@ public class FallProcessor : IFallProcessor
     private static readonly Dictionary<MakaMekComponent, FallReasonType> ComponentFallReasonMap = new()
     {
         { MakaMekComponent.Gyro, FallReasonType.GyroHit },
-        { MakaMekComponent.LowerLegActuator, FallReasonType.LowerLegActuatorHit }
+        { MakaMekComponent.LowerLegActuator, FallReasonType.LowerLegActuatorHit },
+        { MakaMekComponent.Hip, FallReasonType.HipActuatorHit },
+        { MakaMekComponent.FootActuator, FallReasonType.FootActuatorHit }
     };
 
     public FallProcessor(
@@ -127,7 +129,7 @@ public class FallProcessor : IFallProcessor
 
             PilotingSkillRollData? pilotDamagePsr = null;
 
-            if (isFallingNow && reasonType != FallReasonType.StandUpAttempt)
+            if (isFallingNow)
             {
                 var pilotPsrBreakdown = _pilotingSkillCalculator.GetPsrBreakdown(
                     mech,

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallReasonType.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallReasonType.cs
@@ -16,7 +16,17 @@ public enum FallReasonType
     /// Fall due to lower leg actuator hit (requires PSR)
     /// </summary>
     LowerLegActuatorHit,
-    
+
+    /// <summary>
+    /// Fall due to hip actuator hit (requires PSR)
+    /// </summary>
+    HipActuatorHit,
+
+    /// <summary>
+    /// Fall due to foot actuator hit (requires PSR)
+    /// </summary>
+    FootActuatorHit,
+
     /// <summary>
     /// Fall due to heavy damage (requires PSR)
     /// </summary>
@@ -54,6 +64,8 @@ public static class FallReasonTypeExtensions
         {
             FallReasonType.GyroHit => PilotingSkillRollType.GyroHit,
             FallReasonType.LowerLegActuatorHit => PilotingSkillRollType.LowerLegActuatorHit,
+            FallReasonType.HipActuatorHit => PilotingSkillRollType.HipActuatorHit,
+            FallReasonType.FootActuatorHit => PilotingSkillRollType.FootActuatorHit,
             FallReasonType.HeavyDamage => PilotingSkillRollType.HeavyDamage,
             FallReasonType.StandUpAttempt => PilotingSkillRollType.StandupAttempt,
             _ => null // PSR is not required for that reason

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
@@ -158,7 +158,7 @@ public class PilotingSkillCalculator : IPilotingSkillCalculator
             {
                 modifiers.Add(new LegDestroyedModifier
                 {
-                    Value = _rules.GetPilotingSkillRollModifier(PilotingSkillRollType.LegDestroyed) * destroyedLegs,
+                    Value = _rules.GetPilotingSkillRollModifier(PilotingSkillRollType.LegDestroyed),
                 });
             }
             

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/FootActuatorHitModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/FootActuatorHitModifier.cs
@@ -1,0 +1,17 @@
+﻿using Sanet.MakaMek.Core.Services.Localization;
+
+namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+/// <summary>
+/// Modifier for a Piloting Skill Roll due to a critical hit on a Foot Actuator.
+/// </summary>
+public record FootActuatorHitModifier : RollModifier
+{
+    // The Value property is inherited from RollModifier and should be set to the specific modifier value (e.g., +1)
+    // by the PilotingSkillCalculator based on game rules.
+    
+    public override string Render(ILocalizationService localizationService)
+    {
+        return string.Format(localizationService.GetString("Modifier_FootActuatorHit"), Value);
+    }
+}

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/HipActuatorHitModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/HipActuatorHitModifier.cs
@@ -1,0 +1,17 @@
+﻿using Sanet.MakaMek.Core.Services.Localization;
+
+namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+/// <summary>
+/// Modifier for a Piloting Skill Roll due to a critical hit on a Hip Actuator.
+/// </summary>
+public record HipActuatorHitModifier : RollModifier
+{
+    // The Value property is inherited from RollModifier and should be set to the specific modifier value (e.g., +2)
+    // by the PilotingSkillCalculator based on game rules.
+    
+    public override string Render(ILocalizationService localizationService)
+    {
+        return string.Format(localizationService.GetString("Modifier_HipActuatorHit"), Value);
+    }
+}

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/LegDestroyedModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/LegDestroyedModifier.cs
@@ -1,0 +1,14 @@
+﻿using Sanet.MakaMek.Core.Services.Localization;
+
+namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+/// <summary>
+/// Modifier for a Piloting Skill Roll due to a leg being destroyed (specifically for pilot damage during fall).
+/// </summary>
+public record LegDestroyedModifier : RollModifier
+{
+    public override string Render(ILocalizationService localizationService)
+    {
+        return string.Format(localizationService.GetString("Modifier_LegDestroyed"), Value);
+    }
+}

--- a/src/MakaMek.Core/Models/Units/Components/Internal/Actuators/HipActuator.cs
+++ b/src/MakaMek.Core/Models/Units/Components/Internal/Actuators/HipActuator.cs
@@ -2,13 +2,8 @@ using Sanet.MakaMek.Core.Data.Community;
 
 namespace Sanet.MakaMek.Core.Models.Units.Components.Internal.Actuators;
 
-public class Hip : Component
+public class HipActuator() : Component("Hip",[0])
 {
-    private static readonly int[] HipSlots = { 0 };
-    public Hip() : base("Hip", HipSlots)
-    {
-    }
-
     public override MakaMekComponent ComponentType => MakaMekComponent.Hip;
     public override bool IsRemovable => false;
 }

--- a/src/MakaMek.Core/Models/Units/Components/Internal/Actuators/ShoulderActuator.cs
+++ b/src/MakaMek.Core/Models/Units/Components/Internal/Actuators/ShoulderActuator.cs
@@ -2,7 +2,7 @@ using Sanet.MakaMek.Core.Data.Community;
 
 namespace Sanet.MakaMek.Core.Models.Units.Components.Internal.Actuators;
 
-public class Shoulder() : Component("Shoulder", [0])
+public class ShoulderActuator() : Component("Shoulder", [0])
 {
     public override MakaMekComponent ComponentType => MakaMekComponent.Shoulder;
     public override bool IsRemovable => false;

--- a/src/MakaMek.Core/Models/Units/Mechs/Arm.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Arm.cs
@@ -8,7 +8,7 @@ public class Arm : UnitPart
         : base(name, location, maxArmor, maxStructure, 12)
     {
         // Add default components
-        TryAddComponent(new Shoulder());
+        TryAddComponent(new ShoulderActuator());
     }
 
     internal override bool CanBeBlownOff => true;

--- a/src/MakaMek.Core/Models/Units/Mechs/Leg.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Leg.cs
@@ -8,7 +8,7 @@ public class Leg : UnitPart
         : base(name, location, maxArmor, maxStructure, 6)
     {
         // Add default components
-        TryAddComponent(new Hip());
+        TryAddComponent(new HipActuator());
         TryAddComponent(new UpperLegActuator());
         TryAddComponent(new LowerLegActuator());
         TryAddComponent(new FootActuator());

--- a/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
@@ -87,6 +87,9 @@ public class FakeLocalizationService: ILocalizationService
             "Modifier_HeavyDamage" => "Heavy Damage ({0} points): +{1}",
             "Modifier_FallingLevels" => "Falling ({0} {1}): +{2}",
             "Modifier_LowerLegActuatorHit" => "Lower Leg Actuator Hit: +{0}",
+            "Modifier_HipActuatorHit" => "Hip Actuator Hit: +{0}",
+            "Modifier_FootActuatorHit" => "Foot Actuator Hit: +{0}",
+            "Modifier_LegDestroyed" => "Leg Destroyed: +{0}",
             "Hits" => "Hits",
             "Levels" => "Levels",
             // Attack information

--- a/src/MakaMek.Core/Utils/MechFactory.cs
+++ b/src/MakaMek.Core/Utils/MechFactory.cs
@@ -101,7 +101,7 @@ public class MechFactory : IMechFactory
             MakaMekComponent.MachineGun => new MachineGun(),
             MakaMekComponent.AC5 => new Ac5(),
             MakaMekComponent.HeatSink => new HeatSink(),
-            MakaMekComponent.Shoulder => new Shoulder(),
+            MakaMekComponent.Shoulder => new ShoulderActuator(),
             MakaMekComponent.UpperArmActuator => new UpperArmActuator(),
             MakaMekComponent.LowerArmActuator => new LowerArmActuator(),
             MakaMekComponent.HandActuator => new HandActuator(),

--- a/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
+++ b/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
@@ -407,8 +407,12 @@ public class ClassicBattletechRulesProvider : IRulesProvider
         return psrType switch
         {
             PilotingSkillRollType.GyroHit => 3,
+            PilotingSkillRollType.GyroDestroyed => 6,
             PilotingSkillRollType.LowerLegActuatorHit => 1,
             PilotingSkillRollType.HeavyDamage => 1, // +1 modifier for taking 20+ damage in a single phase
+            PilotingSkillRollType.HipActuatorHit => 2,
+            PilotingSkillRollType.FootActuatorHit => 1,
+            PilotingSkillRollType.LegDestroyed => 5, // +5 modifier for leg destroyed (pilot damage during fall)
             _ => throw new ArgumentOutOfRangeException(nameof(psrType), "Invalid piloting skill roll type")
         };
     }

--- a/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallContextDataTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallContextDataTests.cs
@@ -71,7 +71,7 @@ public class FallContextDataTests
         result.FallPilotingSkillRoll.ShouldBe(pilotingSkillRoll);
         result.PilotDamagePilotingSkillRoll.ShouldBe(pilotDamageRoll);
         result.IsPilotingSkillRollRequired.ShouldBeTrue();
-        result.IsPilotTakingDamage.ShouldBeTrue();
+        result.IsPilotTakingDamage.ShouldBeFalse();
     }
     
     [Fact]

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallReasonTypeTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallReasonTypeTests.cs
@@ -35,6 +35,8 @@ public class FallReasonTypeTests
     [Theory]
     [InlineData(FallReasonType.GyroHit, true)]
     [InlineData(FallReasonType.LowerLegActuatorHit, true)]
+    [InlineData(FallReasonType.HipActuatorHit, true)]
+    [InlineData(FallReasonType.FootActuatorHit, true)]
     [InlineData(FallReasonType.HeavyDamage, true)]
     [InlineData(FallReasonType.GyroDestroyed, false)]
     [InlineData(FallReasonType.LegDestroyed, false)]

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
@@ -334,6 +334,24 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             // Assert
             result.Modifiers.ShouldContain(m => m is FootActuatorHitModifier && m.Value == 1);
         }
+        
+        [Fact]
+        public void GetPsrBreakdown_BlownOffLeg_ForPilotDamageFromFall_AddsModifier()
+        {
+            // Arrange
+            var torso = new CenterTorso("Test Torso", 10, 3, 5);
+            var leftLeg = new Leg("Left Leg", PartLocation.LeftLeg, 10, 5);
+            leftLeg.BlowOff(); // Blow off the left leg
+
+            var mech = new Mech("Test", "TST-1A", 50, 4, [torso, leftLeg]);
+            _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.LegDestroyed).Returns(5);
+
+            // Act
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.PilotDamageFromFall);
+
+            // Assert
+            result.Modifiers.ShouldContain(m => m is LegDestroyedModifier && m.Value == 5);
+        }
 
         [Fact]
         public void GetPsrBreakdown_TwoDestroyedLegs_ForPilotDamageFromFall_AddsTwoSeparateModifiers()

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/FootActuatorHitModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/FootActuatorHitModifierTests.cs
@@ -1,0 +1,45 @@
+﻿using NSubstitute;
+using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+using Sanet.MakaMek.Core.Services.Localization;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+public class FootActuatorHitModifierTests
+{
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    [Fact]
+    public void Render_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sut = new FootActuatorHitModifier
+        {
+            Value = 1
+        };
+        _localizationService.GetString("Modifier_FootActuatorHit").Returns("Foot Actuator Hit: +{0}");
+
+        // Act
+        var result = sut.Render(_localizationService);
+
+        // Assert
+        result.ShouldBe("Foot Actuator Hit: +1");
+        _localizationService.Received(1).GetString("Modifier_FootActuatorHit");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Value_ShouldBeSetCorrectly(int expectedValue)
+    {
+        // Arrange & Act
+        var sut = new FootActuatorHitModifier
+        {
+            Value = expectedValue
+        };
+
+        // Assert
+        sut.Value.ShouldBe(expectedValue);
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/HipActuatorHitModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/HipActuatorHitModifierTests.cs
@@ -1,0 +1,45 @@
+﻿using NSubstitute;
+using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+using Sanet.MakaMek.Core.Services.Localization;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+public class HipActuatorHitModifierTests
+{
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    [Fact]
+    public void Render_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sut = new HipActuatorHitModifier
+        {
+            Value = 2
+        };
+        _localizationService.GetString("Modifier_HipActuatorHit").Returns("Hip Actuator Hit: +{0}");
+
+        // Act
+        var result = sut.Render(_localizationService);
+
+        // Assert
+        result.ShouldBe("Hip Actuator Hit: +2");
+        _localizationService.Received(1).GetString("Modifier_HipActuatorHit");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public void Value_ShouldBeSetCorrectly(int expectedValue)
+    {
+        // Arrange & Act
+        var sut = new HipActuatorHitModifier
+        {
+            Value = expectedValue
+        };
+
+        // Assert
+        sut.Value.ShouldBe(expectedValue);
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/LegDestroyedModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/LegDestroyedModifierTests.cs
@@ -1,0 +1,45 @@
+﻿using NSubstitute;
+using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+using Sanet.MakaMek.Core.Services.Localization;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+public class LegDestroyedModifierTests
+{
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    [Fact]
+    public void Render_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sut = new LegDestroyedModifier
+        {
+            Value = 5
+        };
+        _localizationService.GetString("Modifier_LegDestroyed").Returns("Leg Destroyed: +{0}");
+
+        // Act
+        var result = sut.Render(_localizationService);
+
+        // Assert
+        result.ShouldBe("Leg Destroyed: +5");
+        _localizationService.Received(1).GetString("Modifier_LegDestroyed");
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public void Value_ShouldBeSetCorrectly(int expectedValue)
+    {
+        // Arrange & Act
+        var sut = new LegDestroyedModifier
+        {
+            Value = expectedValue
+        };
+
+        // Assert
+        sut.Value.ShouldBe(expectedValue);
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Units/Components/Internal/Actuators/HipActuatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Components/Internal/Actuators/HipActuatorTests.cs
@@ -4,20 +4,20 @@ using Sanet.MakaMek.Core.Models.Units.Components.Internal.Actuators;
 
 namespace Sanet.MakaMek.Core.Tests.Models.Units.Components.Internal.Actuators;
 
-public class ShoulderTests
+public class HipActuatorTests
 {
     [Fact]
     public void Constructor_InitializesCorrectly()
     {
         // Arrange & Act
-        var sut = new Shoulder();
+        var sut = new HipActuator();
 
         // Assert
-        sut.Name.ShouldBe("Shoulder");
+        sut.Name.ShouldBe("Hip");
         sut.MountedAtSlots.ToList().Count.ShouldBe(1);
         sut.MountedAtSlots.ShouldBe([0]);
         sut.IsDestroyed.ShouldBeFalse();
-        sut.ComponentType.ShouldBe(MakaMekComponent.Shoulder);
+        sut.ComponentType.ShouldBe(MakaMekComponent.Hip);
         sut.IsRemovable.ShouldBeFalse();
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Components/Internal/Actuators/ShoulderActuatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Components/Internal/Actuators/ShoulderActuatorTests.cs
@@ -4,20 +4,20 @@ using Sanet.MakaMek.Core.Models.Units.Components.Internal.Actuators;
 
 namespace Sanet.MakaMek.Core.Tests.Models.Units.Components.Internal.Actuators;
 
-public class HipTests
+public class ShoulderActuatorTests
 {
     [Fact]
     public void Constructor_InitializesCorrectly()
     {
         // Arrange & Act
-        var sut = new Hip();
+        var sut = new ShoulderActuator();
 
         // Assert
-        sut.Name.ShouldBe("Hip");
+        sut.Name.ShouldBe("Shoulder");
         sut.MountedAtSlots.ToList().Count.ShouldBe(1);
         sut.MountedAtSlots.ShouldBe([0]);
         sut.IsDestroyed.ShouldBeFalse();
-        sut.ComponentType.ShouldBe(MakaMekComponent.Hip);
+        sut.ComponentType.ShouldBe(MakaMekComponent.Shoulder);
         sut.IsRemovable.ShouldBeFalse();
     }
 }

--- a/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
@@ -81,6 +81,9 @@ public class FakeLocalizationServiceTests
     [InlineData("Modifier_HeavyDamage", "Heavy Damage ({0} points): +{1}")]
     [InlineData("Modifier_FallingLevels", "Falling ({0} {1}): +{2}")]
     [InlineData("Modifier_LowerLegActuatorHit", "Lower Leg Actuator Hit: +{0}")]
+    [InlineData("Modifier_HipActuatorHit", "Hip Actuator Hit: +{0}")]
+    [InlineData("Modifier_FootActuatorHit", "Foot Actuator Hit: +{0}")]
+    [InlineData("Modifier_LegDestroyed", "Leg Destroyed: +{0}")]
     [InlineData("Hits", "Hits")]
     [InlineData("Levels", "Levels")]
     // Attack information

--- a/tests/MakaMek.Core.Tests/Utils/TechRules/ClassicBattletechRulesProviderTests.cs
+++ b/tests/MakaMek.Core.Tests/Utils/TechRules/ClassicBattletechRulesProviderTests.cs
@@ -471,8 +471,12 @@ namespace Sanet.MakaMek.Core.Tests.Utils.TechRules
 
         [Theory]
         [InlineData(PilotingSkillRollType.GyroHit, 3)]
+        [InlineData(PilotingSkillRollType.GyroDestroyed, 6)]
         [InlineData(PilotingSkillRollType.LowerLegActuatorHit, 1)]
         [InlineData(PilotingSkillRollType.HeavyDamage, 1)]
+        [InlineData(PilotingSkillRollType.HipActuatorHit, 2)]
+        [InlineData(PilotingSkillRollType.FootActuatorHit, 1)]
+        [InlineData(PilotingSkillRollType.LegDestroyed, 5)]
         public void GetPilotingSkillRollModifier_ValidTypes_ReturnsExpectedValues(PilotingSkillRollType rollType, int expectedModifier)
         {
             _sut.GetPilotingSkillRollModifier(rollType).ShouldBe(expectedModifier);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new piloting skill roll modifiers for hip actuator hit, foot actuator hit, leg destroyed, and destroyed gyro states, providing more detailed feedback on mech damage effects.
  * Introduced localized descriptions for these new modifiers.
  * Expanded fall reason types to include hip and foot actuator hits, triggering corresponding piloting skill rolls.

* **Refactor**
  * Renamed internal component classes for clarity (e.g., Hip → HipActuator, Shoulder → ShoulderActuator).

* **Tests**
  * Added comprehensive tests for new piloting skill roll modifiers, fall scenarios, and localization strings to ensure correct behavior and display.
  * Updated existing fall processing tests to reflect refined pilot damage logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->