### PR TITLE
psr check when mech jumps with damaged gyro

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.29-alpha</Version>
+        <Version>0.40.30-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
@@ -45,5 +45,6 @@ public enum PilotingSkillRollType
     // Shutdown,
     // EnteringDeepWater,
     // Skid
-    StandupAttempt
+    StandupAttempt,
+    JumpWithDamagedGyro
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
@@ -88,9 +88,9 @@ public class FallProcessor : IFallProcessor
             .Select(f => f.ToMechFallCommand());
     }
 
-    public FallContextData ProcessStandupAttempt(Mech mech, IGame game)
+    public FallContextData ProcessMovementAttempt(Mech mech, FallReasonType possibleFallReason, IGame game)
     {
-        return GetFallContextForReasons([FallReasonType.StandUpAttempt], mech, game).First();
+        return GetFallContextForReasons([possibleFallReason], mech, game).First();
     }
     
     private IEnumerable<FallContextData> GetFallContextForReasons(

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallReasonType.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallReasonType.cs
@@ -45,7 +45,12 @@ public enum FallReasonType
     /// <summary>
     /// Attempt to stand up from prone position (requires PSR)
     /// </summary>
-    StandUpAttempt
+    StandUpAttempt,
+
+    /// <summary>
+    /// Jump attempt with damaged gyro (requires PSR)
+    /// </summary>
+    JumpWithDamagedGyro
 }
 
 /// <summary>
@@ -68,6 +73,7 @@ public static class FallReasonTypeExtensions
             FallReasonType.FootActuatorHit => PilotingSkillRollType.FootActuatorHit,
             FallReasonType.HeavyDamage => PilotingSkillRollType.HeavyDamage,
             FallReasonType.StandUpAttempt => PilotingSkillRollType.StandupAttempt,
+            FallReasonType.JumpWithDamagedGyro => PilotingSkillRollType.JumpWithDamagedGyro,
             _ => null // PSR is not required for that reason
         };
     }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallProcessor.cs
@@ -23,11 +23,11 @@ public interface IFallProcessor
         List<PartLocation>? destroyedPartLocations = null);
 
     /// <summary>
-    /// Processes a standup attempt for a unit
+    /// Processes a movement attempt that may result in a fall for a unit
     /// </summary>
-    /// <param name="mech">The mech attempting to stand up</param>
+    /// <param name="mech">The mech performing the movement attempt</param>
     /// <param name="possibleFallReason">FallReason/PSR type during movement phase</param>
     /// <param name="game">The game instance</param>
-    /// <returns>FallContextData containing the result of the standup attempt</returns>
+    /// <returns>FallContextData containing the result of the movement attempt</returns>
     FallContextData ProcessMovementAttempt(Mech mech, FallReasonType possibleFallReason, IGame game);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallProcessor.cs
@@ -21,12 +21,13 @@ public interface IFallProcessor
         IGame game,
         List<ComponentHitData> componentHits,
         List<PartLocation>? destroyedPartLocations = null);
-        
+
     /// <summary>
     /// Processes a standup attempt for a unit
     /// </summary>
     /// <param name="mech">The mech attempting to stand up</param>
+    /// <param name="possibleFallReason">FallReason/PSR type during movement phase</param>
     /// <param name="game">The game instance</param>
     /// <returns>FallContextData containing the result of the standup attempt</returns>
-    FallContextData ProcessStandupAttempt(Mech mech, IGame game);
+    FallContextData ProcessMovementAttempt(Mech mech, FallReasonType possibleFallReason, IGame game);
 }

--- a/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
@@ -2,7 +2,6 @@ using Sanet.MakaMek.Core.Data.Game.Commands;
 using Sanet.MakaMek.Core.Data.Game.Commands.Client;
 using Sanet.MakaMek.Core.Models.Game.Mechanics.Mechs.Falling;
 using Sanet.MakaMek.Core.Models.Units;
-using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
 
 namespace Sanet.MakaMek.Core.Models.Game.Phases;
@@ -37,8 +36,8 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
         // Check if PSR is required for jumping with damaged gyro
         var player = Game.Players.FirstOrDefault(p => p.Id == moveCommand.PlayerId);
         // Find the unit
-        var unit = player?.Units.FirstOrDefault(u => u.Id == moveCommand.UnitId);
-        if (IsPsrRequired(unit) && moveCommand.MovementType == MovementType.Jump)
+        var unit = player?.Units.FirstOrDefault(u => u.Id == moveCommand.UnitId) as Mech;
+        if (unit?.IsPsrForJumpRequired() == true && moveCommand.MovementType == MovementType.Jump)
         {
             ProcessJumpWithDamagedGyro(moveCommand, unit);
             return;
@@ -48,12 +47,6 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
         broadcastCommand.GameOriginId = Game.Id;
         Game.OnMoveUnit(moveCommand);
         Game.CommandPublisher.PublishCommand(broadcastCommand);
-    }
-
-    private bool IsPsrRequired(Unit? unit)
-    {
-        var gyro = unit?.GetAvailableComponents<Gyro>().FirstOrDefault();
-        return gyro?.Hits ==1;
     }
 
     private void ProcessStandupCommand(TryStandupCommand standupCommand)

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -2,6 +2,7 @@ using Sanet.MakaMek.Core.Data.Game;
 using Sanet.MakaMek.Core.Models.Game.Dice;
 using Sanet.MakaMek.Core.Models.Units.Components;
 using Sanet.MakaMek.Core.Models.Units.Components.Engines;
+using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons;
 using Sanet.MakaMek.Core.Models.Units.Pilots;
 using Sanet.MakaMek.Core.Models.Map;
@@ -165,6 +166,15 @@ public class Mech : Unit
 
             return true;
         }
+    }
+
+    /// <summary>
+    /// Determines if a piloting skill roll is required for jumping due to damage
+    /// </summary>
+    public bool IsPsrForJumpRequired()
+    {
+        var gyro = GetAvailableComponents<Gyro>().FirstOrDefault();
+        return gyro?.Hits ==1;
     }
 
     public void SetProne()

--- a/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
@@ -69,6 +69,7 @@ public class FakeLocalizationService: ILocalizationService
             "PilotingSkillRollType_FallingLevels" => "Falling Levels",
             "PilotingSkillRollType_PilotDamageFromFall" => "Pilot Damage From Fall",
             "PilotingSkillRollType_LowerLegActuatorHit" => "Lower Leg Actuator Hit",
+            "PilotingSkillRollType_JumpWithDamagedGyro" => "Jump with Damaged Gyro",
             
             // Attack direction strings
             "AttackDirection_Left" => "Left",

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -402,11 +402,24 @@ public class MovementState : IUiState
             // Jump
             if (!_selectedUnit.CanJump) return actions;
             var jumpPoints = _selectedUnit.GetMovementPoints(MovementType.Jump);
-                            
+
+            var jumpActionText = string.Format(_viewModel.LocalizationService.GetString("Action_MovementPoints"),
+                _viewModel.LocalizationService.GetString("MovementType_Jump"),
+                jumpPoints);
+
+            // Check if PSR is required for jumping with damaged components and add probability
+            if (_selectedUnit is Mech jumpMech && jumpMech.IsPsrForJumpRequired() && _viewModel.Game is not null)
+            {
+                var psrBreakdown = _viewModel.Game.PilotingSkillCalculator.GetPsrBreakdown(
+                    jumpMech, PilotingSkillRollType.JumpWithDamagedGyro);
+
+                var successProbability = Core.Utils.DiceUtils.Calculate2d6Probability(psrBreakdown.ModifiedPilotingSkill);
+                var probabilityText = $" ({successProbability:0}%)";
+                jumpActionText += probabilityText;
+            }
+
             actions.Add(new StateAction(
-                string.Format(_viewModel.LocalizationService.GetString("Action_MovementPoints"),
-                    _viewModel.LocalizationService.GetString("MovementType_Jump"),
-                    jumpPoints),
+                jumpActionText,
                 true,
                 () => HandleMovementTypeSelection(MovementType.Jump)));
 

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -912,7 +912,7 @@ public class FallProcessorTests
         SetupDiceRolls(7);
 
         // Act
-        var result = _sut.ProcessStandupAttempt(_testMech, _game);
+        var result = _sut.ProcessMovementAttempt(_testMech, FallReasonType.StandUpAttempt, _game);
 
         // Assert
         result.ShouldNotBeNull();
@@ -955,7 +955,7 @@ public class FallProcessorTests
         SetupDiceRolls(5,6);
 
         // Act
-        var result = _sut.ProcessStandupAttempt(_testMech, _game);
+        var result = _sut.ProcessMovementAttempt(_testMech, FallReasonType.StandUpAttempt, _game);
 
         // Assert
         result.ShouldNotBeNull();

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallReasonTypeTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallReasonTypeTests.cs
@@ -11,6 +11,7 @@ public class FallReasonTypeTests
     [InlineData(FallReasonType.LowerLegActuatorHit, PilotingSkillRollType.LowerLegActuatorHit)]
     [InlineData(FallReasonType.HeavyDamage, PilotingSkillRollType.HeavyDamage)]
     [InlineData(FallReasonType.StandUpAttempt, PilotingSkillRollType.StandupAttempt)]
+    [InlineData(FallReasonType.JumpWithDamagedGyro, PilotingSkillRollType.JumpWithDamagedGyro)]
     public void ToPilotingSkillRollType_ForTypesRequiringPSR_ReturnsCorrectType(FallReasonType reasonType, PilotingSkillRollType expected)
     {
         // Act
@@ -41,6 +42,7 @@ public class FallReasonTypeTests
     [InlineData(FallReasonType.GyroDestroyed, false)]
     [InlineData(FallReasonType.LegDestroyed, false)]
     [InlineData(FallReasonType.StandUpAttempt, true)]
+    [InlineData(FallReasonType.JumpWithDamagedGyro, true)]
     public void RequiresPilotingSkillRoll_ReturnsCorrectValue(FallReasonType reasonType, bool expected)
     {
         // Act

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -208,7 +208,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
         
         // Set up the Mock for ProcessStandupAttempt
-        Game.FallProcessor.ProcessStandupAttempt(unit, Game).Returns(successfulStandupData);
+        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.StandUpAttempt, Game).Returns(successfulStandupData);
         
         CommandPublisher.ClearReceivedCalls();
         
@@ -266,7 +266,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
         
         // Set up the Mock for ProcessStandupAttempt
-        Game.FallProcessor.ProcessStandupAttempt(unit, Game).Returns(fallContextData);
+        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.StandUpAttempt, Game).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -1,12 +1,15 @@
 using NSubstitute;
+using Sanet.MakaMek.Core.Data.Game;
 using Sanet.MakaMek.Core.Data.Game.Commands.Client;
 using Sanet.MakaMek.Core.Data.Game.Commands.Server;
 using Sanet.MakaMek.Core.Data.Game.Mechanics;
+using Sanet.MakaMek.Core.Models.Game.Dice;
 using Sanet.MakaMek.Core.Models.Game.Mechanics.Mechs.Falling;
 using Sanet.MakaMek.Core.Models.Game.Phases;
 using Sanet.MakaMek.Core.Models.Game.Players;
 using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
+using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
 using Shouldly;
 
@@ -338,5 +341,113 @@ public class MovementPhaseTests : GamePhaseTestsBase
         CommandPublisher.DidNotReceive().PublishCommand(Arg.Any<MechStandUpCommand>());
         CommandPublisher.DidNotReceive().PublishCommand(Arg.Any<MechFallCommand>());
         unit.StandupAttempts.ShouldBe(0);
+    }
+
+    [Fact]
+    public void HandleCommand_WhenJumpWithDamagedGyroSucceeds_ShouldPublishMoveCommand()
+    {
+        // Arrange
+        _sut.Enter();
+        var unit = Game.ActivePlayer!.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top));
+
+        // Damage the gyro to require PSR
+        var gyro = unit.GetAllComponents<Gyro>().First();
+        gyro.Hit();
+
+        // Mock successful PSR
+        var successfulFallContext = new FallContextData
+        {
+            UnitId = _unit1Id,
+            GameId = Game.Id,
+            IsFalling = false,
+            ReasonType = FallReasonType.JumpWithDamagedGyro,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollType = PilotingSkillRollType.JumpWithDamagedGyro,
+                DiceResults = [6, 6],
+                IsSuccessful = true,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            }
+        };
+
+        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.JumpWithDamagedGyro, Game).Returns(successfulFallContext);
+
+        var moveCommand = new MoveUnitCommand
+        {
+            MovementType = MovementType.Jump,
+            GameOriginId = Game.Id,
+            PlayerId = Game.ActivePlayer!.Id,
+            UnitId = _unit1Id,
+            MovementPath = [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(3, 1, HexDirection.Bottom), 1)
+                    .ToData()
+            ]
+        };
+
+        // Act
+        _sut.HandleCommand(moveCommand);
+
+        // Assert
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
+            cmd.UnitId == _unit1Id && cmd.MovementType == MovementType.Jump));
+        CommandPublisher.DidNotReceive().PublishCommand(Arg.Any<MechFallCommand>());
+    }
+
+    [Fact]
+    public void HandleCommand_WhenJumpWithDamagedGyroFails_ShouldPublishFallCommand()
+    {
+        // Arrange
+        _sut.Enter();
+        var unit = Game.ActivePlayer!.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top));
+
+        // Damage the gyro to require PSR
+        var gyro = unit.GetAllComponents<Gyro>().First();
+        gyro.Hit();
+
+        // Mock failed PSR
+        var failedFallContext = new FallContextData
+        {
+            UnitId = _unit1Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            ReasonType = FallReasonType.JumpWithDamagedGyro,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollType = PilotingSkillRollType.JumpWithDamagedGyro,
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3)
+            )
+        };
+
+        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.JumpWithDamagedGyro, Game).Returns(failedFallContext);
+
+        var moveCommand = new MoveUnitCommand
+        {
+            MovementType = MovementType.Jump,
+            GameOriginId = Game.Id,
+            PlayerId = Game.ActivePlayer!.Id,
+            UnitId = _unit1Id,
+            MovementPath = [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(3, 1, HexDirection.Bottom), 1)
+                    .ToData()
+            ]
+        };
+
+        // Act
+        _sut.HandleCommand(moveCommand);
+
+        // Assert
+        CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd =>
+            cmd.UnitId == _unit1Id && cmd.DamageData != null));
+        CommandPublisher.DidNotReceive().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
+            cmd.UnitId == _unit1Id && cmd.MovementType == MovementType.Jump));
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -7,6 +7,7 @@ using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components;
 using Sanet.MakaMek.Core.Models.Units.Components.Engines;
+using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons.Energy;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
 using Sanet.MakaMek.Core.Models.Units.Pilots;
@@ -842,6 +843,57 @@ public class MechTests
 
         // Act & Assert
         sut.CanJump.ShouldBeTrue("Mech should be able to jump after standing up and resetting turn state");
+    }
+    
+    [Fact]
+    public void IsPsrForJumpRequired_WithUndamagedGyro_ReturnsFalse()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        
+        var gyro = sut.GetAllComponents<Gyro>().First();
+        
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+        
+        // Assert
+        result.ShouldBeFalse();
+        gyro.Hits.ShouldBe(0);
+    }
+    
+    [Fact]
+    public void IsPsrForJumpRequired_WithDamagedGyro_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var gyro = sut.GetAllComponents<Gyro>().First();
+        gyro.Hit(); // Damage the gyro (1 hit)
+        
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+        
+        // Assert
+        result.ShouldBeTrue();
+        gyro.Hits.ShouldBe(1);
+        gyro.IsDestroyed.ShouldBeFalse();
+    }
+    
+    [Fact]
+    public void IsPsrForJumpRequired_WithDestroyedGyro_ReturnsFalse()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var gyro = sut.GetAllComponents<Gyro>().First();
+        gyro.Hit(); // First hit
+        gyro.Hit(); // Second hit - destroys the gyro
+        
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+        
+        // Assert
+        result.ShouldBeFalse();
+        gyro.Hits.ShouldBe(2);
+        gyro.IsDestroyed.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
@@ -66,6 +66,7 @@ public class FakeLocalizationServiceTests
     [InlineData("PilotingSkillRollType_FallingLevels", "Falling Levels")]
     [InlineData("PilotingSkillRollType_PilotDamageFromFall", "Pilot Damage From Fall")]
     [InlineData("PilotingSkillRollType_LowerLegActuatorHit", "Lower Leg Actuator Hit")]
+    [InlineData("PilotingSkillRollType_JumpWithDamagedGyro", "Jump with Damaged Gyro")]
     // Attack modifiers
     [InlineData("AttackDirection_Left", "Left")]
     [InlineData("AttackDirection_Right", "Right")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling jump movements with a damaged gyro, requiring a piloting skill roll (PSR).
  * New fall reason and piloting skill roll types introduced for jumps with damaged gyros.
  * Display of PSR success probability added to jump action descriptions when gyro damage affects jump attempts.
  * Added method to check if a PSR is required for jumps based on gyro damage.

* **Bug Fixes**
  * Improved processing logic for standup and movement attempts to handle new movement scenarios.

* **Tests**
  * Updated and expanded tests to cover the new movement attempt logic and scenarios involving damaged gyros.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->