### PR TITLE
use explicit IsDestroyed property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.32-alpha</Version>
+        <Version>0.40.33-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitControl.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitControl.cs
@@ -276,16 +276,15 @@ namespace Sanet.MakaMek.Avalonia.Controls
                 .Subscribe(state =>
                 {
                     // Show/hide destroyed indicator
-                    destroyedCross.IsVisible = _unit.Status == UnitStatus.Destroyed;
-                    _healthBars.IsVisible = _unit.Status != UnitStatus.Destroyed;
+                    destroyedCross.IsVisible = _unit.IsDestroyed;
+                    _healthBars.IsVisible = !_unit.IsDestroyed;
                     
                     if (state.Position == null) return; // unit is not deployed, no need to display
                     
                     // Show/hide prone indicator (for mechs only)
                     if (_unit is Mech mech)
                     {
-                        proneIndicator.IsVisible = (mech.Status & UnitStatus.Prone) == UnitStatus.Prone 
-                                                   && mech.Status != UnitStatus.Destroyed;
+                        proneIndicator.IsVisible = mech is { IsProne: true, IsDestroyed: false };
                     }
                     else
                     {
@@ -321,7 +320,7 @@ namespace Sanet.MakaMek.Avalonia.Controls
                     if (isMech)
                     {
                         torsoArrow.IsVisible = state.IsWeaponsPhase
-                                               && _unit.Status != UnitStatus.Destroyed
+                                               && !_unit.IsDestroyed
                                                && state is { TorsoDirection: not null, Position: not null };
                         if (!torsoArrow.IsVisible) return;
                         // Since control is rotated to torso direction, we need opposite delta

--- a/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
@@ -303,7 +303,7 @@ public class WeaponAttackResolutionPhase(ServerGame game) : GamePhase(game)
     {
         // Track destroyed parts before damage
         var destroyedPartsBefore = target.Parts.Where(p => p.IsDestroyed).Select(p => p.Location).ToList();
-        var wasDestroyedBefore = target.Status == UnitStatus.Destroyed;
+        var wasDestroyedBefore = target.IsDestroyed;
         
         // Apply damage to the target
         if (resolution is { IsHit: true, HitLocationsData.HitLocations: not null })
@@ -316,7 +316,7 @@ public class WeaponAttackResolutionPhase(ServerGame game) : GamePhase(game)
         var newlyDestroyedParts = destroyedPartsAfter.Except(destroyedPartsBefore).ToList();
         
         // Check if the unit was destroyed by this attack
-        var unitNewlyDestroyed = !wasDestroyedBefore && target.Status== UnitStatus.Destroyed;
+        var unitNewlyDestroyed = !wasDestroyedBefore && target.IsDestroyed;
         
         // Update the resolution data with destruction information
         resolution = resolution with 

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -1,6 +1,5 @@
 using Sanet.MakaMek.Core.Data.Game;
 using Sanet.MakaMek.Core.Models.Game.Dice;
-using Sanet.MakaMek.Core.Models.Units.Components;
 using Sanet.MakaMek.Core.Models.Units.Components.Engines;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons;
@@ -184,7 +183,7 @@ public class Mech : Unit
 
     public bool CanStandup()
     {
-        if ((Status & UnitStatus.Shutdown)== UnitStatus.Shutdown) return false;
+        if (IsShutdown) return false;
         
         var destroyedLegs = _parts.OfType<Leg>().Count(p=> p.IsDestroyed || p.IsBlownOff);
         if (destroyedLegs >= 2) return false;

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -54,8 +54,13 @@ public abstract class Unit
         get => _status;
         protected set
         {
+            if ((value & UnitStatus.Destroyed) == UnitStatus.Destroyed)
+            {
+                _status = UnitStatus.Destroyed;
+                return;
+            }
             // Once destroyed, prevent any further status changes
-            if (IsDestroyed && value != UnitStatus.Destroyed)
+            if (IsDestroyed)
                 return;
 
             _status = value;

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -47,7 +47,40 @@ public abstract class Unit
     
     public IPlayer? Owner { get; internal set; }
     
-    public UnitStatus Status { get; protected set; }
+    private UnitStatus _status;
+
+    public UnitStatus Status
+    {
+        get => _status;
+        protected set
+        {
+            // Once destroyed, prevent any further status changes
+            if (IsDestroyed && value != UnitStatus.Destroyed)
+                return;
+
+            _status = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets whether the unit is destroyed. Returns true if the Destroyed flag is set, regardless of other flags.
+    /// </summary>
+    public bool IsDestroyed => (_status & UnitStatus.Destroyed) == UnitStatus.Destroyed;
+
+    /// <summary>
+    /// Gets whether the unit is active. Returns true if the Active flag is set, regardless of other flags.
+    /// </summary>
+    public bool IsActive => (_status & UnitStatus.Active) == UnitStatus.Active;
+
+    /// <summary>
+    /// Gets whether the unit is shutdown. Returns true if the Shutdown flag is set, regardless of other flags.
+    /// </summary>
+    public bool IsShutdown => (_status & UnitStatus.Shutdown) == UnitStatus.Shutdown;
+
+    /// <summary>
+    /// Gets whether the unit is immobile. Returns true if the Immobile flag is set, regardless of other flags.
+    /// </summary>
+    public bool IsImmobile => (_status & UnitStatus.Immobile) == UnitStatus.Immobile;
 
     public WeightClass Class => Tonnage switch
     {
@@ -303,14 +336,14 @@ public abstract class Unit
     // Status management
     public virtual void Startup()
     {
-        if ((Status & UnitStatus.Shutdown) != UnitStatus.Shutdown) return;
+        if (!IsShutdown) return;
         Status &= ~UnitStatus.Shutdown;
         Status |= UnitStatus.Active;
     }
 
     public virtual void Shutdown()
     {
-        if ((Status & UnitStatus.Active) != UnitStatus.Active) return;
+        if (!IsActive) return;
         Status &= ~UnitStatus.Active;
         Status |= UnitStatus.Shutdown;
     }
@@ -396,7 +429,7 @@ public abstract class Unit
 
         }
 
-        if (Status == UnitStatus.Destroyed)
+        if (IsDestroyed)
         {
             AddEvent(new UiEvent(UiEventType.UnitDestroyed, Name));
         }

--- a/src/MakaMek.Presentation/UiStates/WeaponsAttackState.cs
+++ b/src/MakaMek.Presentation/UiStates/WeaponsAttackState.cs
@@ -74,7 +74,7 @@ public class WeaponsAttackState : IUiState
     {
         if (_game is { CanActivePlayerAct: false }) return;
         if (unit == null) return;
-        if (unit.Status == UnitStatus.Destroyed) return;
+        if (unit.IsDestroyed) return;
 
         if (CurrentStep is WeaponsAttackStep.SelectingUnit or WeaponsAttackStep.ActionSelection)
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new status properties for units, including indicators for destroyed, active, shutdown, and immobile states.

* **Refactor**
  * Updated logic throughout the app to use new status properties instead of direct status flag checks, improving code clarity and consistency.
  * Centralized and encapsulated unit status checks for improved reliability.

* **Tests**
  * Introduced tests verifying unit status properties and immutability after destruction.

* **Chores**
  * Incremented the application version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->