### PR TITLE
jumping with damaged actuators psr

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.33-alpha</Version>
+        <Version>0.40.34-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
@@ -46,5 +46,5 @@ public enum PilotingSkillRollType
     // EnteringDeepWater,
     // Skid
     StandupAttempt,
-    JumpWithDamagedGyro
+    JumpWithDamage
 }

--- a/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollType.cs
@@ -22,6 +22,11 @@ public enum PilotingSkillRollType
     LowerLegActuatorHit,
     
     /// <summary>
+    /// PSR modifier due to a critical hit on a upper leg actuator.
+    /// </summary>
+    UpperLegActuatorHit,
+    
+    /// <summary>
     /// PSR required when a 'Mech takes 20 or more damage points in a single phase.
     /// </summary>
     HeavyDamage,

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallReasonType.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallReasonType.cs
@@ -48,9 +48,9 @@ public enum FallReasonType
     StandUpAttempt,
 
     /// <summary>
-    /// Jump attempt with damaged gyro (requires PSR)
+    /// Jump attempt with damaged gyro or foot/leg/hip actuators (requires PSR)
     /// </summary>
-    JumpWithDamagedGyro
+    JumpWithDamage
 }
 
 /// <summary>
@@ -73,7 +73,7 @@ public static class FallReasonTypeExtensions
             FallReasonType.FootActuatorHit => PilotingSkillRollType.FootActuatorHit,
             FallReasonType.HeavyDamage => PilotingSkillRollType.HeavyDamage,
             FallReasonType.StandUpAttempt => PilotingSkillRollType.StandupAttempt,
-            FallReasonType.JumpWithDamagedGyro => PilotingSkillRollType.JumpWithDamagedGyro,
+            FallReasonType.JumpWithDamage => PilotingSkillRollType.JumpWithDamage,
             _ => null // PSR is not required for that reason
         };
     }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
@@ -119,6 +119,19 @@ public class PilotingSkillCalculator : IPilotingSkillCalculator
             }
         }
 
+        // Upper leg actuator hit modifier
+        var upperLegActuators = mech.GetAllComponents<UpperLegActuator>();
+        foreach (var actuator in upperLegActuators)
+        {
+            if (actuator.IsDestroyed)
+            {
+                modifiers.Add(new UpperLegActuatorHitModifier
+                {
+                    Value = _rules.GetPilotingSkillRollModifier(PilotingSkillRollType.UpperLegActuatorHit)
+                });
+            }
+        }
+
         // Heavy damage modifier
         if (mech.TotalPhaseDamage > _rules.GetHeavyDamageThreshold())
         {

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/UpperLegActuatorHitModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/UpperLegActuatorHitModifier.cs
@@ -1,0 +1,17 @@
+﻿using Sanet.MakaMek.Core.Services.Localization;
+
+namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+/// <summary>
+/// Modifier for a Piloting Skill Roll due to a critical hit on an Upper Leg Actuator.
+/// </summary>
+public record UpperLegActuatorHitModifier : RollModifier
+{
+    // The Value property is inherited from RollModifier and should be set to the specific modifier value (e.g., +1)
+    // by the PilotingSkillCalculator based on game rules.
+    
+    public override string Render(ILocalizationService localizationService)
+    {
+        return string.Format(localizationService.GetString("Modifier_UpperLegActuatorHit"), Value);
+    }
+}

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -5,6 +5,7 @@ using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons;
 using Sanet.MakaMek.Core.Models.Units.Pilots;
 using Sanet.MakaMek.Core.Models.Map;
+using Sanet.MakaMek.Core.Models.Units.Components.Internal.Actuators;
 
 namespace Sanet.MakaMek.Core.Models.Units.Mechs;
 
@@ -172,6 +173,19 @@ public class Mech : Unit
     /// </summary>
     public bool IsPsrForJumpRequired()
     {
+        var destroyedFootActuators = GetAllComponents<FootActuator>()
+            .Where(a=>a.IsDestroyed);
+        if (destroyedFootActuators.Any()) return true;
+        var destroyedHipActuators = GetAllComponents<HipActuator>()
+            .Where(a=>a.IsDestroyed);
+        if (destroyedHipActuators.Any()) return true;
+        var destroyedLowerLegActuators = GetAllComponents<LowerLegActuator>()
+            .Where(a=>a.IsDestroyed);
+        if (destroyedLowerLegActuators.Any()) return true;
+        var destroyedUpperLegActuators = GetAllComponents<UpperLegActuator>()
+            .Where(a=>a.IsDestroyed);
+        if (destroyedUpperLegActuators.Any()) return true;
+        
         var gyro = GetAvailableComponents<Gyro>().FirstOrDefault();
         return gyro?.Hits ==1;
     }

--- a/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
@@ -74,7 +74,7 @@ public class FakeLocalizationService: ILocalizationService
             "PilotingSkillRollType_FootActuatorHit" => "Foot Actuator Hit",
             "PilotingSkillRollType_LegDestroyed" => "Leg Destroyed",
             "PilotingSkillRollType_StandupAttempt" => "Standup Attempt",
-            "PilotingSkillRollType_JumpWithDamagedGyro" => "Jump with Damaged Gyro",
+            "PilotingSkillRollType_JumpWithDamage" => "Jump with damage",
             
             // Attack direction strings
             "AttackDirection_Left" => "Left",

--- a/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
@@ -95,6 +95,7 @@ public class FakeLocalizationService: ILocalizationService
             "Modifier_LowerLegActuatorHit" => "Lower Leg Actuator Hit: +{0}",
             "Modifier_HipActuatorHit" => "Hip Actuator Hit: +{0}",
             "Modifier_FootActuatorHit" => "Foot Actuator Hit: +{0}",
+            "Modifier_UpperLegActuatorHit" => "Upper Leg Actuator Hit: +{0}",
             "Modifier_LegDestroyed" => "Leg Destroyed: +{0}",
             "Hits" => "Hits",
             "Levels" => "Levels",

--- a/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
+++ b/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
@@ -412,6 +412,7 @@ public class ClassicBattletechRulesProvider : IRulesProvider
             PilotingSkillRollType.HeavyDamage => 1, // +1 modifier for taking 20+ damage in a single phase
             PilotingSkillRollType.HipActuatorHit => 2,
             PilotingSkillRollType.FootActuatorHit => 1,
+            PilotingSkillRollType.UpperLegActuatorHit => 1,
             PilotingSkillRollType.LegDestroyed => 5, // +5 modifier for leg destroyed (pilot damage during fall)
             _ => throw new ArgumentOutOfRangeException(nameof(psrType), "Invalid piloting skill roll type")
         };

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -411,7 +411,7 @@ public class MovementState : IUiState
             if (_selectedUnit is Mech jumpMech && jumpMech.IsPsrForJumpRequired() && _viewModel.Game is not null)
             {
                 var psrBreakdown = _viewModel.Game.PilotingSkillCalculator.GetPsrBreakdown(
-                    jumpMech, PilotingSkillRollType.JumpWithDamagedGyro);
+                    jumpMech, PilotingSkillRollType.JumpWithDamage);
 
                 var successProbability = Core.Utils.DiceUtils.Calculate2d6Probability(psrBreakdown.ModifiedPilotingSkill);
                 var probabilityText = $" ({successProbability:0}%)";

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallReasonTypeTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallReasonTypeTests.cs
@@ -11,7 +11,7 @@ public class FallReasonTypeTests
     [InlineData(FallReasonType.LowerLegActuatorHit, PilotingSkillRollType.LowerLegActuatorHit)]
     [InlineData(FallReasonType.HeavyDamage, PilotingSkillRollType.HeavyDamage)]
     [InlineData(FallReasonType.StandUpAttempt, PilotingSkillRollType.StandupAttempt)]
-    [InlineData(FallReasonType.JumpWithDamagedGyro, PilotingSkillRollType.JumpWithDamagedGyro)]
+    [InlineData(FallReasonType.JumpWithDamage, PilotingSkillRollType.JumpWithDamage)]
     public void ToPilotingSkillRollType_ForTypesRequiringPSR_ReturnsCorrectType(FallReasonType reasonType, PilotingSkillRollType expected)
     {
         // Act
@@ -42,7 +42,7 @@ public class FallReasonTypeTests
     [InlineData(FallReasonType.GyroDestroyed, false)]
     [InlineData(FallReasonType.LegDestroyed, false)]
     [InlineData(FallReasonType.StandUpAttempt, true)]
-    [InlineData(FallReasonType.JumpWithDamagedGyro, true)]
+    [InlineData(FallReasonType.JumpWithDamage, true)]
     public void RequiresPilotingSkillRoll_ReturnsCorrectValue(FallReasonType reasonType, bool expected)
     {
         // Act

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
@@ -271,7 +271,26 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             // Assert
             result.Modifiers.ShouldNotContain(m => m is LowerLegActuatorHitModifier);
         }
-        
+
+        [Fact]
+        public void GetPsrBreakdown_DestroyedUpperLegActuator_AddsModifier()
+        {
+            // Arrange
+            var torso = new CenterTorso("Test Torso", 10, 3, 5);
+            var leg = new Leg("Right Leg", PartLocation.RightLeg, 10, 5);
+            var actuator = leg.GetComponents<UpperLegActuator>().First();
+            actuator.Hit(); // Destroy the actuator (assuming 1 health point)
+
+            var mech = new Mech("Test", "TST-1A", 50, 4, [torso,leg]);
+            _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.UpperLegActuatorHit).Returns(1);
+
+            // Act
+            var result = _sut.GetPsrBreakdown(mech, PilotingSkillRollType.GyroHit);
+
+            // Assert
+            result.Modifiers.ShouldContain(m => m is UpperLegActuatorHitModifier);
+        }
+
         [Fact]
         public void GetPsrBreakdown_ShouldReturnNoModifiers_ForNonMech()
         {

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/UpperLegActuatorHitModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/UpperLegActuatorHitModifierTests.cs
@@ -1,0 +1,29 @@
+﻿using NSubstitute;
+using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+using Sanet.MakaMek.Core.Services.Localization;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+public class UpperLegActuatorHitModifierTests
+{
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    [Fact]
+    public void Render_ShouldFormatCorrectly()
+    {
+        // Arrange
+        var sut = new UpperLegActuatorHitModifier
+        {
+            Value = 1
+        };
+        _localizationService.GetString("Modifier_UpperLegActuatorHit").Returns("Upper Leg Actuator Hit: +{0}");
+
+        // Act
+        var result = sut.Render(_localizationService);
+
+        // Assert
+        result.ShouldBe("Upper Leg Actuator Hit: +1");
+        _localizationService.Received(1).GetString("Modifier_UpperLegActuatorHit");
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -361,17 +361,17 @@ public class MovementPhaseTests : GamePhaseTestsBase
             UnitId = _unit1Id,
             GameId = Game.Id,
             IsFalling = false,
-            ReasonType = FallReasonType.JumpWithDamagedGyro,
+            ReasonType = FallReasonType.JumpWithDamage,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollType = PilotingSkillRollType.JumpWithDamagedGyro,
+                RollType = PilotingSkillRollType.JumpWithDamage,
                 DiceResults = [6, 6],
                 IsSuccessful = true,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
             }
         };
 
-        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.JumpWithDamagedGyro, Game).Returns(successfulFallContext);
+        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.JumpWithDamage, Game).Returns(successfulFallContext);
 
         var moveCommand = new MoveUnitCommand
         {
@@ -412,10 +412,10 @@ public class MovementPhaseTests : GamePhaseTestsBase
             UnitId = _unit1Id,
             GameId = Game.Id,
             IsFalling = true,
-            ReasonType = FallReasonType.JumpWithDamagedGyro,
+            ReasonType = FallReasonType.JumpWithDamage,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollType = PilotingSkillRollType.JumpWithDamagedGyro,
+                RollType = PilotingSkillRollType.JumpWithDamage,
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -427,7 +427,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.JumpWithDamagedGyro, Game).Returns(failedFallContext);
+        Game.FallProcessor.ProcessMovementAttempt(unit, FallReasonType.JumpWithDamage, Game).Returns(failedFallContext);
 
         var moveCommand = new MoveUnitCommand
         {
@@ -447,7 +447,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         // Assert
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd =>
             cmd.UnitId == _unit1Id && cmd.DamageData != null));
-        CommandPublisher.DidNotReceive().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
             cmd.UnitId == _unit1Id && cmd.MovementType == MovementType.Jump));
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -8,6 +8,7 @@ using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components;
 using Sanet.MakaMek.Core.Models.Units.Components.Engines;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal;
+using Sanet.MakaMek.Core.Models.Units.Components.Internal.Actuators;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons.Energy;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
 using Sanet.MakaMek.Core.Models.Units.Pilots;
@@ -886,14 +887,162 @@ public class MechTests
         var gyro = sut.GetAllComponents<Gyro>().First();
         gyro.Hit(); // First hit
         gyro.Hit(); // Second hit - destroys the gyro
-        
+
         // Act
         var result = sut.IsPsrForJumpRequired();
-        
+
         // Assert
         result.ShouldBeFalse();
         gyro.Hits.ShouldBe(2);
         gyro.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithOneDestroyedFootActuator_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var footActuator = sut.GetAllComponents<FootActuator>().First();
+        footActuator.Hit(); // Destroy the foot actuator
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        footActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithMultipleDestroyedFootActuators_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var footActuators = sut.GetAllComponents<FootActuator>().ToList();
+
+        // Destroy all foot actuators
+        foreach (var actuator in footActuators)
+        {
+            actuator.Hit();
+        }
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        footActuators.ShouldAllBe(actuator => actuator.IsDestroyed);
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithOneDestroyedHipActuator_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var hipActuator = sut.GetAllComponents<HipActuator>().First();
+        hipActuator.Hit(); // Destroy the hip actuator
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        hipActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithMultipleDestroyedHipActuators_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var hipActuators = sut.GetAllComponents<HipActuator>().ToList();
+
+        // Destroy all hip actuators
+        foreach (var actuator in hipActuators)
+        {
+            actuator.Hit();
+        }
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        hipActuators.ShouldAllBe(actuator => actuator.IsDestroyed);
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithOneDestroyedLowerLegActuator_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var lowerLegActuator = sut.GetAllComponents<LowerLegActuator>().First();
+        lowerLegActuator.Hit(); // Destroy the lower leg actuator
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        lowerLegActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithMultipleDestroyedLowerLegActuators_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var lowerLegActuators = sut.GetAllComponents<LowerLegActuator>().ToList();
+
+        // Destroy all lower leg actuators
+        foreach (var actuator in lowerLegActuators)
+        {
+            actuator.Hit();
+        }
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        lowerLegActuators.ShouldAllBe(actuator => actuator.IsDestroyed);
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithOneDestroyedUpperLegActuator_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var upperLegActuator = sut.GetAllComponents<UpperLegActuator>().First();
+        upperLegActuator.Hit(); // Destroy the upper leg actuator
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        upperLegActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsPsrForJumpRequired_WithMultipleDestroyedUpperLegActuators_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        var upperLegActuators = sut.GetAllComponents<UpperLegActuator>().ToList();
+
+        // Destroy all upper leg actuators
+        foreach (var actuator in upperLegActuators)
+        {
+            actuator.Hit();
+        }
+
+        // Act
+        var result = sut.IsPsrForJumpRequired();
+
+        // Assert
+        result.ShouldBeTrue();
+        upperLegActuators.ShouldAllBe(actuator => actuator.IsDestroyed);
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
@@ -71,7 +71,7 @@ public class FakeLocalizationServiceTests
     [InlineData("PilotingSkillRollType_FootActuatorHit", "Foot Actuator Hit")]
     [InlineData("PilotingSkillRollType_LegDestroyed", "Leg Destroyed")]
     [InlineData("PilotingSkillRollType_StandupAttempt", "Standup Attempt")]
-    [InlineData("PilotingSkillRollType_JumpWithDamagedGyro", "Jump with Damaged Gyro")]
+    [InlineData("PilotingSkillRollType_JumpWithDamage", "Jump with damage")]
     // Attack modifiers
     [InlineData("AttackDirection_Left", "Left")]
     [InlineData("AttackDirection_Right", "Right")]

--- a/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
@@ -89,6 +89,7 @@ public class FakeLocalizationServiceTests
     [InlineData("Modifier_LowerLegActuatorHit", "Lower Leg Actuator Hit: +{0}")]
     [InlineData("Modifier_HipActuatorHit", "Hip Actuator Hit: +{0}")]
     [InlineData("Modifier_FootActuatorHit", "Foot Actuator Hit: +{0}")]
+    [InlineData("Modifier_UpperLegActuatorHit", "Upper Leg Actuator Hit: +{0}")]
     [InlineData("Modifier_LegDestroyed", "Leg Destroyed: +{0}")]
     [InlineData("Hits", "Hits")]
     [InlineData("Levels", "Levels")]

--- a/tests/MakaMek.Core.Tests/Utils/TechRules/ClassicBattletechRulesProviderTests.cs
+++ b/tests/MakaMek.Core.Tests/Utils/TechRules/ClassicBattletechRulesProviderTests.cs
@@ -476,6 +476,7 @@ namespace Sanet.MakaMek.Core.Tests.Utils.TechRules
         [InlineData(PilotingSkillRollType.HeavyDamage, 1)]
         [InlineData(PilotingSkillRollType.HipActuatorHit, 2)]
         [InlineData(PilotingSkillRollType.FootActuatorHit, 1)]
+        [InlineData(PilotingSkillRollType.UpperLegActuatorHit, 1)]
         [InlineData(PilotingSkillRollType.LegDestroyed, 5)]
         public void GetPilotingSkillRollModifier_ValidTypes_ReturnsExpectedValues(PilotingSkillRollType rollType, int expectedModifier)
         {

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -976,7 +976,7 @@ public class MovementStateTests
         };
 
         _pilotingSkillCalculator
-            .GetPsrBreakdown(mech, PilotingSkillRollType.JumpWithDamagedGyro)
+            .GetPsrBreakdown(mech, PilotingSkillRollType.JumpWithDamage)
             .Returns(psrBreakdown);
 
         // Act


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new piloting skill roll modifier for mechs with destroyed upper leg actuators, affecting jump actions.

* **Bug Fixes**
  * Enhanced detection of actuator damage to require piloting skill rolls when any leg actuator is destroyed.

* **Refactor**
  * Renamed "JumpWithDamagedGyro" to "JumpWithDamage" for improved clarity and consistency.
  * Simplified jump movement processing logic related to damaged components.

* **Tests**
  * Added and updated tests covering actuator damage scenarios, piloting skill roll modifiers, and localization updates.

* **Chores**
  * Incremented application version to 0.40.34-alpha.
  * Updated localization keys and strings for piloting skill roll types and new modifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->