### PR TITLE
allow prone mech to skip movement

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.35-alpha</Version>
+        <Version>0.40.36-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
@@ -133,6 +133,7 @@ public class FakeLocalizationService: ILocalizationService
             "Action_SelectFacingDirection" => "Select facing direction",
             "Action_MoveUnit" => "Move Unit",
             "Action_StandStill" => "Stand Still",
+            "Action_StayProne" => "Stay Prone",
             "Action_AttemptStandup" => "Attempt Standup",
             "Action_ChangeFacing" => "Change Facing | MP: {0}",
             "Action_MovementPoints" => "{0} | MP: {1}",

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -351,7 +351,14 @@ public class MovementState : IUiState
             if (_selectedUnit is Mech { IsProne: true } mech
                 && _viewModel.Game is not null)
             {
-                var proneActions = new List<StateAction>();
+                var proneActions = new List<StateAction>
+                {
+                    // Add stay prone action (equivalent to standing still for prone mechs)
+                    new(
+                        _viewModel.LocalizationService.GetString("Action_StayProne"),
+                        true,
+                        () => HandleMovementTypeSelection(MovementType.StandingStill))
+                };
 
                 // Add standup action if possible
                 if (mech.CanStandup())

--- a/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
@@ -123,6 +123,7 @@ public class FakeLocalizationServiceTests
     [InlineData("Action_SelectFacingDirection", "Select facing direction")]
     [InlineData("Action_MoveUnit", "Move Unit")]
     [InlineData("Action_StandStill", "Stand Still")]
+    [InlineData("Action_StayProne", "Stay Prone")]
     [InlineData("Action_MovementPoints", "{0} | MP: {1}")]
     [InlineData("Action_AttemptStandup", "Attempt Standup")]
     [InlineData("Action_ChangeFacing", "Change Facing | MP: {0}")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Stay Prone" action for prone Mech units, allowing players to explicitly choose to remain prone during movement.
  * The new action is always available for prone Mechs and is clearly labeled using localized text.

* **Bug Fixes**
  * Improved test coverage to ensure the "Stay Prone" action appears and functions correctly for prone Mechs.

* **Chores**
  * Updated version number to 0.40.36-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->