### PR TITLE
destroy cockpit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.38-alpha</Version>
+        <Version>0.40.39-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -7,7 +7,7 @@
 
 - [x] Arm Blown Off (Arm): Occurs on a roll of 12 on the Determining Critical Hits Table for an arm hit. The arm is blown off, and its weapons/equipment are lost. Explosive components in the arm do not explode.
 
-- [ ] Cockpit (Head): Destroys the slot, kills the MechWarrior, and puts the 'Mech out of commission. Small cockpits have the same effect.
+- [x] Cockpit (Head): Destroys the slot, kills the MechWarrior, and puts the 'Mech out of commission. Small cockpits have the same effect.
 
 - [x] Engine (Torso): Fusion engines have 3 shielding points.
   - [x] First hit: Increases heat build-up by 5 points per turn.

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitControl.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitControl.cs
@@ -276,7 +276,7 @@ namespace Sanet.MakaMek.Avalonia.Controls
                 .Subscribe(state =>
                 {
                     // Show/hide destroyed indicator
-                    destroyedCross.IsVisible = _unit.IsDestroyed;
+                    destroyedCross.IsVisible = _unit.IsOutOfCommission;
                     _healthBars.IsVisible = !_unit.IsDestroyed;
                     
                     if (state.Position == null) return; // unit is not deployed, no need to display

--- a/src/MakaMek.Core/Models/Units/Components/Internal/Cockpit.cs
+++ b/src/MakaMek.Core/Models/Units/Components/Internal/Cockpit.cs
@@ -6,4 +6,11 @@ public class Cockpit() : Component("Cockpit", [2])
 {
     public override MakaMekComponent ComponentType => MakaMekComponent.Cockpit;
     public override bool IsRemovable => false;
+
+    public override void Hit()
+    {
+        base.Hit();
+        // Kill the pilot
+        MountedOn?.Unit?.Crew?.Kill();
+    }
 }

--- a/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
@@ -20,12 +20,28 @@ public interface IPilot
     /// </summary>
     int Piloting { get; }
 
+    /// <summary>
+    /// Number of injuries sustained by the pilot
+    /// </summary>
     int Injuries { get; }
+    
+    /// <summary>
+    /// Indicates whether the pilot is unconscious
+    /// </summary>
     bool IsUnconscious { get; }
+    
+    /// <summary>
+    /// Indicates whether the pilot is dead
+    /// </summary>
+    bool IsDead { get; }
 
+    /// <summary>
+    /// Applies a hit to the pilot, increasing the number of injuries
+    /// </summary>
     void Hit();
     
+    /// <summary>
+    /// Kills the pilot, setting injuries to health
+    /// </summary>
     void Kill();
-    
-    bool IsDead { get; }
 }

--- a/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
@@ -25,5 +25,7 @@ public interface IPilot
 
     void Hit();
     
+    void Kill();
+    
     bool IsDead { get; }
 }

--- a/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
@@ -24,4 +24,6 @@ public interface IPilot
     bool IsUnconscious { get; }
 
     void Hit();
+    
+    bool IsDead { get; }
 }

--- a/src/MakaMek.Core/Models/Units/Pilots/MechWarrior.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/MechWarrior.cs
@@ -62,4 +62,6 @@ public class MechWarrior : IPilot
     {
         Injuries++;
     }
+
+    public bool IsDead => Injuries >= Health;
 }

--- a/src/MakaMek.Core/Models/Units/Pilots/MechWarrior.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/MechWarrior.cs
@@ -63,5 +63,10 @@ public class MechWarrior : IPilot
         Injuries++;
     }
 
+    public void Kill()
+    {
+        Injuries = Health;
+    }
+
     public bool IsDead => Injuries >= Health;
 }

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -14,10 +14,10 @@ namespace Sanet.MakaMek.Core.Models.Units;
 
 public abstract class Unit
 {
-    protected readonly List<UnitPart> _parts; 
+    protected readonly List<UnitPart> _parts;
     private readonly Queue<UiEvent> _notifications = new();
     private readonly List<UiEvent> _events = new();
-    
+
     protected Unit(string chassis, string model, int tonnage,
         int walkMp,
         IEnumerable<UnitPart> parts,
@@ -34,6 +34,7 @@ public abstract class Unit
         {
             part.Unit = this;
         }
+
         if (id.HasValue)
         {
             Id = id.Value;
@@ -44,9 +45,9 @@ public abstract class Unit
     public string Model { get; }
     public string Name { get; }
     public int Tonnage { get; }
-    
+
     public IPlayer? Owner { get; internal set; }
-    
+
     private UnitStatus _status;
 
     public UnitStatus Status
@@ -59,6 +60,7 @@ public abstract class Unit
                 _status = UnitStatus.Destroyed;
                 return;
             }
+
             // Once destroyed, prevent any further status changes
             if (IsDestroyed)
                 return;
@@ -86,6 +88,8 @@ public abstract class Unit
     /// Gets whether the unit is immobile. Returns true if the Immobile flag is set, regardless of other flags.
     /// </summary>
     public bool IsImmobile => (_status & UnitStatus.Immobile) == UnitStatus.Immobile;
+
+    public bool IsOutOfCommission => IsDestroyed || Crew?.IsDead==true;
 
     public WeightClass Class => Tonnage switch
     {

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -89,7 +89,7 @@ public abstract class Unit
     /// </summary>
     public bool IsImmobile => (_status & UnitStatus.Immobile) == UnitStatus.Immobile;
 
-    public bool IsOutOfCommission => IsDestroyed || Crew?.IsDead==true;
+    public bool IsOutOfCommission => IsDestroyed || Crew?.IsDead == true;
 
     public WeightClass Class => Tonnage switch
     {

--- a/tests/MakaMek.Core.Tests/Models/Units/Pilots/MechWarriorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Pilots/MechWarriorTests.cs
@@ -120,4 +120,18 @@ public class MechWarriorTests
         // Assert
         sut.IsDead.ShouldBeTrue();
     }
+    
+    [Fact]
+    public void Kill_SetsInjuriesToHealth()
+    {
+        // Arrange
+        var sut = new MechWarrior("John", "Doe");
+
+        // Act
+        sut.Kill();
+
+        // Assert
+        sut.Injuries.ShouldBe(sut.Health);
+        sut.IsDead.ShouldBeTrue();
+    }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Pilots/MechWarriorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Pilots/MechWarriorTests.cs
@@ -63,4 +63,61 @@ public class MechWarriorTests
         // Assert
         sut.Injuries.ShouldBe(3);
     }
+    
+    [Fact]
+    public void IsDead_IsFalse_ByDefault()
+    {
+        // Arrange
+        var sut = new MechWarrior("John", "Doe");
+        
+        // Assert
+        sut.IsDead.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsDead_WhenInjuriesLessThanHealth_ReturnsFalse()
+    {
+        // Arrange
+        var sut = new MechWarrior("John", "Doe");
+
+        // Act
+        sut.Hit();
+
+        // Assert
+        sut.IsDead.ShouldBeFalse();
+    }
+    
+        
+    [Fact]
+    public void IsDead_WhenInjuriesEqualToHealth_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new MechWarrior("John", "Doe");
+
+        // Act
+        do
+        {
+            sut.Hit();
+        } while (sut.Injuries < sut.Health);
+
+        // Assert
+        sut.IsDead.ShouldBeTrue();
+    }
+    
+    [Fact]
+    public void IsDead_WhenInjuriesGreaterThanHealth_ReturnsTrue()
+    {
+        // Arrange
+        var sut = new MechWarrior("John", "Doe");
+
+        // Act
+        do
+        {
+            sut.Hit();
+        } while (sut.Injuries < sut.Health);
+        sut.Hit();
+
+        // Assert
+        sut.IsDead.ShouldBeTrue();
+    }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -1794,6 +1794,41 @@ public class UnitTests
             unit.IsDestroyed.ShouldBeFalse($"IsDestroyed should be false for status combination: {statusCombination}");
         }
     }
+    
+    [Fact]
+    public void IsOutOfCommission_ShouldReturnFalse_ByDefault()
+    {
+        // Arrange
+        var unit = CreateTestUnit();
+
+        // Act & Assert
+        unit.IsOutOfCommission.ShouldBeFalse();
+    }
+    
+    [Fact]
+    public void IsOutOfCommission_ShouldReturnTrue_WhenCrewIsDead()
+    {
+        // Arrange
+        var unit = CreateTestUnit();
+        unit.SetCrew(new MechWarrior("John", "Doe"));
+        unit.Crew?.Kill();
+
+        // Act & Assert
+        unit.IsOutOfCommission.ShouldBeTrue();
+    }
+    
+    [Fact]
+    public void IsOutOfCommission_ShouldReturnTrue_WhenUnitIsDestroyed()
+    {
+        // Arrange
+        var unit = CreateTestUnit();
+
+        // Set the unit as destroyed
+        unit.SetStatusForTesting(UnitStatus.Destroyed);
+
+        // Act & Assert
+        unit.IsOutOfCommission.ShouldBeTrue();
+    }
 
     [Fact]
     public void Status_ShouldBeImmutableAfterDestruction_WhenAttemptingToChangeStatus()

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -7,9 +7,11 @@ using Sanet.MakaMek.Core.Models.Game.Dice;
 using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components;
+using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons.Ballistic;
 using Sanet.MakaMek.Core.Models.Units.Components.Weapons.Missile;
+using Sanet.MakaMek.Core.Models.Units.Mechs;
 using Sanet.MakaMek.Core.Models.Units.Pilots;
 using Sanet.MakaMek.Core.Utils.TechRules;
 using Shouldly;
@@ -1140,6 +1142,28 @@ public class UnitTests
         unit.ApplyDamage([hitLocation]);
         // Assert
         critComponent.IsDestroyed.ShouldBeTrue();
+    }
+    
+    [Fact]
+    public void ApplyDamage_WithCockpitCriticalHit_KillsPilot()
+    {
+        // Arrange
+        var head = new Head("Head", 10, 5);
+        var pilot = new MechWarrior("John", "Doe");
+        var unit = new TestUnit("Test", "Unit", 20, 4, [head]);
+        unit.SetCrew(pilot);
+        var hitLocation = new HitLocationData(PartLocation.Head, 0, [], 
+        [new LocationCriticalHitsData(PartLocation.Head, 10, 1, 
+            [CreateComponentHitData(2)])]);
+        var cockpit = unit.GetAllComponents<Cockpit>().First();
+    
+        // Pre-assert: component is not destroyed
+        cockpit.IsDestroyed.ShouldBeFalse();
+        // Act
+        unit.ApplyDamage([hitLocation]);
+        // Assert
+        cockpit.IsDestroyed.ShouldBeTrue();
+        pilot.IsDead.ShouldBeTrue();
     }
     
     [Fact]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to explicitly mark a pilot as dead and check their death status.
  * Cockpit damage now results in the pilot being marked as dead.
  * Units now have a status indicating when they are out of commission due to destruction or pilot death.
  * Updated unit UI to show out-of-commission status instead of just destruction.
* **Tests**
  * Introduced new tests to verify pilot death functionality and related status checks.
  * Added tests confirming that critical hits to the cockpit kill the pilot.
  * Added tests for unit status reflecting pilot death and destruction.
* **Documentation**
  * Marked the cockpit critical hit effect as implemented in the critical hits tracking document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->