### PR TITLE
critical hits movement penalties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.39-alpha</Version>
+        <Version>0.40.40-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -31,7 +31,7 @@
   - [x] First hit: Adds +2 modifier to 'Mech's weapon to-hit numbers.
   - [x] Second hit: Makes it impossible to fire weapons.
 
-- [ ] Head Blown Off: Occurs on a roll of 12 on the Determining Critical Hits Table for a head hit. 
+- [x] Head Blown Off: Occurs on a roll of 12 on the Determining Critical Hits Table for a head hit. 
   - [ ] Destroys the 'Mech's head, kills the MechWarrior, and puts the 'Mech out of commission.
 
 - [ ] Life Support: System is permanently knocked out.
@@ -44,8 +44,8 @@
 - [x] Upper Leg Actuator: Destroys the actuator. Requires a PSR with a +1 modifier at the end of the phase and for subsequent PSRs.
   - [x] Reduces Walking MP by 1 (recalculate Running MP).
 
-- [ ] Hip: Freezes the affected leg. Requires a PSR with a +2 modifier at the end of the phase and for subsequent PSRs. Walking MP is halved (recalculate Running MP). 'Mech cannot make kick attacks. Ignores previous critical hit modifiers to that leg.
-  - [ ] Second hip hit: Reduces 'Mech's MP to 0 and adds another +2 modifier to PSR (not immobile).
+- [x] Hip: Freezes the affected leg. Requires a PSR with a +2 modifier at the end of the phase and for subsequent PSRs. Walking MP is halved (recalculate Running MP). 'Mech cannot make kick attacks. Ignores previous critical hit modifiers to that leg.
+  - [x] Second hip hit: Reduces 'Mech's MP to 0 and adds another +2 modifier to PSR (not immobile).
 
 - [x] Foot Actuator: Destroys the foot muscle. Requires a Piloting Skill Roll (PSR) with a +1 modifier at the end of the phase and for subsequent PSRs.
   - [x] Reduces Walking MP by 1 (recalculate Running MP).

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -39,20 +39,20 @@
 
 ### Legs
 - [x] Lower Leg Actuator: Destroys the actuator. Requires a PSR with a +1 modifier at the end of the phase and for subsequent PSRs.
-  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
+  - [x] Reduces Walking MP by 1 (recalculate Running MP).
 
 - [x] Upper Leg Actuator: Destroys the actuator. Requires a PSR with a +1 modifier at the end of the phase and for subsequent PSRs.
-  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
+  - [x] Reduces Walking MP by 1 (recalculate Running MP).
 
 - [ ] Hip: Freezes the affected leg. Requires a PSR with a +2 modifier at the end of the phase and for subsequent PSRs. Walking MP is halved (recalculate Running MP). 'Mech cannot make kick attacks. Ignores previous critical hit modifiers to that leg.
   - [ ] Second hip hit: Reduces 'Mech's MP to 0 and adds another +2 modifier to PSR (not immobile).
 
 - [x] Foot Actuator: Destroys the foot muscle. Requires a Piloting Skill Roll (PSR) with a +1 modifier at the end of the phase and for subsequent PSRs.
-  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
+  - [x] Reduces Walking MP by 1 (recalculate Running MP).
 
 - [x] Leg Blown Off: Occurs on a roll of 12 on the Determining Critical Hits Table for a leg hit. The leg is blown off, and the 'Mech automatically falls (takes normal falling damage). Explosive components do not explode.
   - [ ] Single Attempt to stand up that counts as running.
-  - [ ] Only one MP if mech is standing up, no run
+  - [x] Only one MP if mech is standing up, no run
 
 ### Arms
 - [ ] Lower Arm Actuator: Destroys the actuator. Adds +1 modifier to weapons firing from that arm;

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -1,58 +1,64 @@
 ﻿## Mech Critical Hit Effects Implementation Tracking
 **Version 0.40.x**
 
+### General
 - [x] Ammunition: If a critical hit destroys a slot with explosive ammunition, the ammo explodes. The 'Mech takes internal structure damage based on the total Damage Value of the ammo in the slot, multiplied by shots remaining.
   - [ ] If the location has CASE, excess damage dissipates.
   - [ ] The MechWarrior automatically takes 2 points of damage and requires a Consciousness Roll.
 
-- [x] Arm Blown Off (Arm): Occurs on a roll of 12 on the Determining Critical Hits Table for an arm hit. The arm is blown off, and its weapons/equipment are lost. Explosive components in the arm do not explode.
+- [x] Weapons: The first critical hit to a weapon (even multi-slot ones) knocks out the weapon. Additional hits to multi-slot weapons have no further effect.
+  - [ ] Explosive components (e.g., Gauss rifles) explode similarly to ammunition explosions
 
-- [x] Cockpit (Head): Destroys the slot, kills the MechWarrior, and puts the 'Mech out of commission. Small cockpits have the same effect.
+- [x] Jump Jet: That jump jet can no longer deliver thrust. Reduces the 'Mech's Jumping MP by 1 for each hit.
 
+- [x] Heat Sinks: Destroys the heat sink, reducing heat dissipation by 1 point (or 2 for a double heat sink). Destroyed heat sinks do not dissipate heat in the current Heat Phase.
+
+### Torso
 - [x] Engine (Torso): Fusion engines have 3 shielding points.
   - [x] First hit: Increases heat build-up by 5 points per turn.
   - [x] Second hit: Increases heat build-up to 10 total points per turn.
   - [x] Third hit: Shuts down the engine and puts the BattleMech out of commission.
-
-- [x] Foot Actuator (Leg): Destroys the foot muscle. Requires a Piloting Skill Roll (PSR) with a +1 modifier at the end of the phase and for subsequent PSRs.
-  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
 
 - [x] Gyro (Torso): Can survive only one critical hit; the second destroys it.
   - [x] First hit: Requires a PSR with a +3 modifier when applied and every time the 'Mech runs or jumps.
   - [x] Second hit: Gyro is destroyed, the 'Mech automatically falls (if standing)
   - [ ] and becomes immobile (cannot stand, cannot move, only hexside changes possible).
 
-- [ ] Hand Actuator (Arm): Destroys wrist/hand muscles. Adds +1 to-hit modifier to all punches with that arm. 'Mech cannot make physical weapon or clubbing attacks with that arm.
+### Head
+- [x] Cockpit: Destroys the slot, kills the MechWarrior, and puts the 'Mech out of commission. Small cockpits have the same effect.
 
-- [ ] Head Blown Off (Head): Occurs on a roll of 12 on the Determining Critical Hits Table for a head hit. Destroys the 'Mech's head, kills the MechWarrior, and puts the 'Mech out of commission.
-
-- [ ] Heat Sinks: Destroys the heat sink, reducing heat dissipation by 1 point (or 2 for a double heat sink). Destroyed heat sinks do not dissipate heat in the current Heat Phase.
-
-- [ ] Hip (Leg): Freezes the affected leg. Requires a PSR with a +2 modifier at the end of the phase and for subsequent PSRs. Walking MP is halved (recalculate Running MP). 'Mech cannot make kick attacks. Ignores previous critical hit modifiers to that leg.
-  - [ ] Second hip hit: Reduces 'Mech's MP to 0 and adds another +2 modifier to PSR (not immobile).
-
-- [ ] Jump Jet (Leg/Torso): That jump jet can no longer deliver thrust. Reduces the 'Mech's Jumping MP by 1 for each hit.
-
-- [x] Leg Blown Off (Leg): Occurs on a roll of 12 on the Determining Critical Hits Table for a leg hit. The leg is blown off, and the 'Mech automatically falls (takes normal falling damage). Explosive components do not explode.
-
-- [ ] Life Support (Head): System is permanently knocked out. 
-  - [ ] Pilot takes 1 point of damage at the end of every Heat Phase if heat is 15-25, or 2 points of damage if heat is 26+.
-
-- [ ] Lower Arm Actuator (Arm): Destroys the actuator. Adds +1 modifier to weapons firing from that arm;
-
-- [x] Lower Leg Actuator (Leg): Destroys the actuator. Requires a PSR with a +1 modifier at the end of the phase and for subsequent PSRs.
-  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
-
-- [x] Upper Leg Actuator (Leg): Destroys the actuator. Requires a PSR with a +1 modifier at the end of the phase and for subsequent PSRs.
-  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
-
-- [x] Sensors (Head):
+- [x] Sensors:
   - [x] First hit: Adds +2 modifier to 'Mech's weapon to-hit numbers.
   - [x] Second hit: Makes it impossible to fire weapons.
 
-- [ ] Shoulder (Arm): Freezes the shoulder joint. Adds +4 modifier to weapon attacks made with weapons mounted on that arm, ignoring other arm critical hit weapon modifiers.
+- [ ] Head Blown Off: Occurs on a roll of 12 on the Determining Critical Hits Table for a head hit. 
+  - [ ] Destroys the 'Mech's head, kills the MechWarrior, and puts the 'Mech out of commission.
 
-- [ ] Upper Arm Actuator (Arm): Destroys the actuator. Adds +1 modifier to weapons firing from that arm
+- [ ] Life Support: System is permanently knocked out.
+  - [ ] Pilot takes 1 point of damage at the end of every Heat Phase if heat is 15-25, or 2 points of damage if heat is 26+.
 
-- [x] Weapons: The first critical hit to a weapon (even multi-slot ones) knocks out the weapon. Additional hits to multi-slot weapons have no further effect.
-  - [ ] Explosive components (e.g., Gauss rifles) explode similarly to ammunition explosions
+### Legs
+- [x] Lower Leg Actuator: Destroys the actuator. Requires a PSR with a +1 modifier at the end of the phase and for subsequent PSRs.
+  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
+
+- [x] Upper Leg Actuator: Destroys the actuator. Requires a PSR with a +1 modifier at the end of the phase and for subsequent PSRs.
+  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
+
+- [ ] Hip: Freezes the affected leg. Requires a PSR with a +2 modifier at the end of the phase and for subsequent PSRs. Walking MP is halved (recalculate Running MP). 'Mech cannot make kick attacks. Ignores previous critical hit modifiers to that leg.
+  - [ ] Second hip hit: Reduces 'Mech's MP to 0 and adds another +2 modifier to PSR (not immobile).
+
+- [x] Foot Actuator: Destroys the foot muscle. Requires a Piloting Skill Roll (PSR) with a +1 modifier at the end of the phase and for subsequent PSRs.
+  - [ ] Reduces Walking MP by 1 (recalculate Running MP).
+
+- [x] Leg Blown Off: Occurs on a roll of 12 on the Determining Critical Hits Table for a leg hit. The leg is blown off, and the 'Mech automatically falls (takes normal falling damage). Explosive components do not explode.
+  - [ ] Single Attempt to stand up that counts as running.
+  - [ ] Only one MP if mech is standing up, no run
+
+### Arms
+- [ ] Lower Arm Actuator: Destroys the actuator. Adds +1 modifier to weapons firing from that arm;
+
+- [x] Arm Blown Off: Occurs on a roll of 12 on the Determining Critical Hits Table for an arm hit. The arm is blown off, and its weapons/equipment are lost. Explosive components in the arm do not explode.
+
+- [ ] Shoulder: Freezes the shoulder joint. Adds +4 modifier to weapon attacks made with weapons mounted on that arm, ignoring other arm critical hit weapon modifiers.
+
+- [ ] Upper Arm Actuator: Destroys the actuator. Adds +1 modifier to weapons firing from that arm

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -101,11 +101,12 @@ public abstract class Unit
     };
 
     // Base movement (walking)
-    private int BaseMovement { get; }
+    protected int BaseMovement { get; }
     
     // Modified movement after applying effects (defaults to base movement)
-    private int ModifiedMovement => Math.Max(0, BaseMovement - MovementHeatPenalty - MovementPointsSpent);
-    
+    protected int ModifiedMovement => Math.Max(0, DamageReducedMovement - MovementHeatPenalty - MovementPointsSpent);
+    public virtual int DamageReducedMovement => BaseMovement;
+
     // Movement heat penalty
     public virtual int MovementHeatPenalty => 0;
     
@@ -116,26 +117,15 @@ public abstract class Unit
     public virtual int EngineHeatPenalty => 0;
     
     // Movement capabilities
-    public virtual int GetMovementPoints(MovementType type)
+    public virtual int GetMovementPoints(MovementType _)
     {
-        return type switch
-        {
-            MovementType.Walk => ModifiedMovement,
-            MovementType.Run => (int)Math.Ceiling(ModifiedMovement * 1.5),
-            MovementType.Jump => GetAvailableComponents<JumpJets>().Sum(j => j.JumpMp),
-            _ => 0
-        };
+        return ModifiedMovement;
     }
 
     /// <summary>
     /// Determines if the unit can move backward with the given movement type
     /// </summary>
     public abstract bool CanMoveBackward(MovementType type);
-
-    /// <summary>
-    /// Determines if the unit can perform jump movement
-    /// </summary>
-    public virtual bool CanJump => false;
 
     // Location and facing
     public virtual HexPosition? Position { get; protected set; }

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -416,7 +416,7 @@ public class MovementState : IUiState
             };
 
             // Jump
-            if (!_selectedUnit.CanJump) return actions;
+            if (!(_selectedUnit is Mech {CanJump:true })) return actions;
             var jumpPoints = _selectedUnit.GetMovementPoints(MovementType.Jump);
 
             var jumpActionText = string.Format(_viewModel.LocalizationService.GetString("Action_MovementPoints"),

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -847,6 +847,52 @@ public class MechTests
     }
     
     [Fact]
+    public void CanRun_ShouldReturnTrue_ForNewMech()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        
+        // Act & Assert
+        sut.CanRun.ShouldBeTrue();
+    }
+    
+    [Fact]
+    public void CanRun_WhenMechIsProne_ShouldReturnFalse()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5,CreateBasicPartsData());
+        sut.SetProne();
+
+        // Act & Assert
+        sut.CanRun.ShouldBeFalse();
+    }
+    
+    [Fact]
+    public void CanRun_ShouldReturnFalse_WhenLegIsBlownOff()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 0, CreateBasicPartsData());
+        var leg = sut.Parts.First(p => p.Location == PartLocation.LeftLeg);
+        leg.BlowOff();
+        
+        // Act & Assert
+        sut.CanRun.ShouldBeFalse();
+    }
+    
+    [Fact]
+    public void CanRun_ShouldReturnFalse_WhenLegIsDestroyed()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 0, CreateBasicPartsData());
+        var leg = sut.Parts.First(p => p.Location == PartLocation.LeftLeg);
+        leg.ApplyDamage(100);
+        leg.IsDestroyed.ShouldBeTrue();
+        
+        // Act & Assert
+        sut.CanRun.ShouldBeFalse();
+    }
+    
+    [Fact]
     public void IsPsrForJumpRequired_WithUndamagedGyro_ReturnsFalse()
     {
         // Arrange

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1601,15 +1601,15 @@ public class MechTests
 
         // Assert
         sut.GetMovementPoints(MovementType.Walk).ShouldBe(1, "Blown off leg should set walking MP to 1");
-        sut.GetMovementPoints(MovementType.Run).ShouldBe(1, "Blown off leg should prevent running (MP stays at 1)");
+        sut.CanRun.ShouldBeFalse();
         leftLeg.IsBlownOff.ShouldBeTrue();
     }
 
     [Theory]
-    [InlineData(6, 3, 2, 1, 1, 2)] // Base 6 MP: Hip halves to 3, foot -1 = 2, heat -1 = 1, run = 2
-    [InlineData(4, 2, 1, 0, 0, 0)] // Base 4 MP: Hip halves to 2, foot -1 = 1, heat -1 = 0, run = 0
-    [InlineData(8, 4, 3, 2, 2, 3)] // Base 8 MP: Hip halves to 4, foot -1 = 3, heat -1 = 2, run = 3
-    public void MovementPoints_ScenarioTest_HipFootAndHeatDamage(int baseMp, int afterHip, int afterFoot, int afterHeat, int expectedWalk, int expectedRun)
+    [InlineData(6, 3, 2, 1, 2)] // Base 6 MP: Hip halves to 3, foot -1 = 2, heat -1 = 1, run = 2
+    [InlineData(4, 2, 1, 0, 0)] // Base 4 MP: Hip halves to 2, foot -1 = 1, heat -1 = 0, run = 0
+    [InlineData(8, 4, 3, 2, 3)] // Base 8 MP: Hip halves to 4, foot -1 = 3, heat -1 = 2, run = 3
+    public void MovementPoints_ScenarioTest_HipFootAndHeatDamage(int baseMp, int afterHip, int afterFoot, int expectedWalk, int expectedRun)
     {
         // Arrange - Scenario: Destroyed Hip, Destroyed Foot, Heat Level 6 Points
         var sut = new Mech("Test", "TST-1A", 50, baseMp, CreateBasicPartsData());

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -416,9 +416,9 @@ public class MechTests
 
 
     [Theory]
-    [InlineData(5, 8, 2)] // Standard mech without jump jets
-    [InlineData(4, 6, 0)] // Fast mech with jump jets
-    [InlineData(3, 5, 2)] // Slow mech with lots of jump jets
+    [InlineData(5, 8, 2)] 
+    [InlineData(4, 6, 0)] 
+    [InlineData(3, 5, 2)] 
     public void GetMovement_ReturnsCorrectMPs(int walkMp, int runMp, int jumpMp)
     {
         // Arrange
@@ -1636,7 +1636,7 @@ public class MechTests
     }
 
     [Fact]
-    public void MovementPoints_WithBlownOffLeg_ShouldSetWalkingMPToOne()
+    public void GetMovementPoints_WithBlownOffLeg_ShouldSetWalkingMPToOne()
     {
         // Arrange
         var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
@@ -1655,7 +1655,7 @@ public class MechTests
     [InlineData(6, 3, 2, 1, 2)] // Base 6 MP: Hip halves to 3, foot -1 = 2, heat -1 = 1, run = 2
     [InlineData(4, 2, 1, 0, 0)] // Base 4 MP: Hip halves to 2, foot -1 = 1, heat -1 = 0, run = 0
     [InlineData(8, 4, 3, 2, 3)] // Base 8 MP: Hip halves to 4, foot -1 = 3, heat -1 = 2, run = 3
-    public void MovementPoints_ScenarioTest_HipFootAndHeatDamage(int baseMp, int afterHip, int afterFoot, int expectedWalk, int expectedRun)
+    public void GetMovementPoints_ScenarioTest_HipFootAndHeatDamage(int baseMp, int afterHip, int afterFoot, int expectedWalk, int expectedRun)
     {
         // Arrange - Scenario: Destroyed Hip, Destroyed Foot, Heat Level 6 Points
         var sut = new Mech("Test", "TST-1A", 50, baseMp, CreateBasicPartsData());
@@ -1686,5 +1686,18 @@ public class MechTests
         // Final assertions
         sut.GetMovementPoints(MovementType.Walk).ShouldBe(expectedWalk, $"Final walking MP after all penalties: {expectedWalk}");
         sut.GetMovementPoints(MovementType.Run).ShouldBe(expectedRun, $"Final running MP: {expectedWalk} * 1.5 = {expectedRun}");
+    }
+    
+    [Fact]
+    public void GetMovementPoints_ForUnknownMovement_ShouldReturnZero()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+
+        // Act
+        var result = sut.GetMovementPoints((MovementType)233);
+
+        // Assert
+        result.ShouldBe(0);
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1486,4 +1486,159 @@ public class MechTests
         sensors.Hits.ShouldBe(2);
         sensors.IsDestroyed.ShouldBeTrue();
     }
+    
+    [Fact]
+    public void GetMovementPoints_WithDestroyedHipActuator_ShouldHalveWalkingMP()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        var hipActuator = sut.GetAllComponents<HipActuator>().First();
+
+        // Act
+        hipActuator.Hit(); // Destroy hip actuator
+
+        // Assert
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(3, "Hip actuator damage should halve walking MP (6/2=3)");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(5, "Running MP should be 1.5 times walking MP rounded up (3*1.5=4.5→5)");
+        hipActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetMovementPoints_WithTwoDestroyedHipActuators_ShouldReduceWalkingMPToZero()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        var hipActuators = sut.GetAllComponents<HipActuator>().ToList();
+
+        // Act
+        foreach (var actuator in hipActuators)
+        {
+            actuator.Hit(); // Destroy both hip actuators
+        }
+
+        // Assert
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(0, "Two destroyed hip actuators should reduce walking MP to 0");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(0, "Running MP should also be 0");
+        hipActuators.ShouldAllBe(actuator => actuator.IsDestroyed);
+    }
+
+    [Fact]
+    public void GetMovementPoints_WithDestroyedFootActuator_ShouldReduceWalkingMPByOne()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        var footActuator = sut.GetAllComponents<FootActuator>().First();
+
+        // Act
+        footActuator.Hit(); // Destroy foot actuator
+
+        // Assert
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(5, "Destroyed foot actuator should reduce walking MP by 1 (6-1=5)");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(8, "Running MP should be 1.5 times walking MP rounded up (5*1.5=7.5→8)");
+        footActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetMovementPoints_WithDestroyedLowerLegActuator_ShouldReduceWalkingMPByOne()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        var lowerLegActuator = sut.GetAllComponents<LowerLegActuator>().First();
+
+        // Act
+        lowerLegActuator.Hit(); // Destroy lower leg actuator
+
+        // Assert
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(5, "Destroyed lower leg actuator should reduce walking MP by 1 (6-1=5)");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(8, "Running MP should be 1.5 times walking MP rounded up (5*1.5=7.5→8)");
+        lowerLegActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetMovementPoints_WithDestroyedUpperLegActuator_ShouldReduceWalkingMPByOne()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        var upperLegActuator = sut.GetAllComponents<UpperLegActuator>().First();
+
+        // Act
+        upperLegActuator.Hit(); // Destroy upper leg actuator
+
+        // Assert
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(5, "Destroyed upper leg actuator should reduce walking MP by 1 (6-1=5)");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(8, "Running MP should be 1.5 times walking MP rounded up (5*1.5=7.5→8)");
+        upperLegActuator.IsDestroyed.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void GetMovementPoints_WithMultipleDestroyedActuators_ShouldStackPenalties()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        var footActuator = sut.GetAllComponents<FootActuator>().First();
+        var lowerLegActuator = sut.GetAllComponents<LowerLegActuator>().First();
+        var upperLegActuator = sut.GetAllComponents<UpperLegActuator>().First();
+
+        // Act
+        footActuator.Hit(); // -1 MP
+        lowerLegActuator.Hit(); // -1 MP
+        upperLegActuator.Hit(); // -1 MP
+
+        // Assert
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(3, "Three destroyed actuators should reduce walking MP by 3 (6-3=3)");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(5, "Running MP should be 1.5 times walking MP rounded up (3*1.5=4.5→5)");
+    }
+
+    [Fact]
+    public void MovementPoints_WithBlownOffLeg_ShouldSetWalkingMPToOne()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        var leftLeg = sut.Parts.First(p => p.Location == PartLocation.LeftLeg);
+
+        // Act
+        leftLeg.BlowOff();
+
+        // Assert
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(1, "Blown off leg should set walking MP to 1");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(1, "Blown off leg should prevent running (MP stays at 1)");
+        leftLeg.IsBlownOff.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(6, 3, 2, 1, 1, 2)] // Base 6 MP: Hip halves to 3, foot -1 = 2, heat -1 = 1, run = 2
+    [InlineData(4, 2, 1, 0, 0, 0)] // Base 4 MP: Hip halves to 2, foot -1 = 1, heat -1 = 0, run = 0
+    [InlineData(8, 4, 3, 2, 2, 3)] // Base 8 MP: Hip halves to 4, foot -1 = 3, heat -1 = 2, run = 3
+    public void MovementPoints_ScenarioTest_HipFootAndHeatDamage(int baseMp, int afterHip, int afterFoot, int afterHeat, int expectedWalk, int expectedRun)
+    {
+        // Arrange - Scenario: Destroyed Hip, Destroyed Foot, Heat Level 6 Points
+        var sut = new Mech("Test", "TST-1A", 50, baseMp, CreateBasicPartsData());
+
+        // Step 1: Apply Hip Actuator Critical Hit (halves walking MP, rounded up)
+        var hipActuator = sut.GetAllComponents<HipActuator>().First();
+        hipActuator.Hit();
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(afterHip, $"After hip damage: {baseMp}/2 = {afterHip}");
+
+        // Step 2: Apply Foot Actuator Critical Hit (reduce by 1)
+        var footActuator = sut.GetAllComponents<FootActuator>().First();
+        footActuator.Hit();
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(afterFoot, $"After foot damage: {afterHip}-1 = {afterFoot}");
+
+        // Step 3: Apply Heat Level Penalty (6 heat points = -1 MP)
+        var heatData = new HeatData
+        {
+            MovementHeatSources = [],
+            WeaponHeatSources = [new WeaponHeatData
+            {
+                WeaponName = "TestWeapon",
+                HeatPoints = 6
+            }],
+            DissipationData = default
+        };
+        sut.ApplyHeat(heatData);
+
+        // Final assertions
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(expectedWalk, $"Final walking MP after all penalties: {expectedWalk}");
+        sut.GetMovementPoints(MovementType.Run).ShouldBe(expectedRun, $"Final running MP: {expectedWalk} * 1.5 = {expectedRun}");
+    }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -97,7 +97,7 @@ public class UnitTests
         }
     }
     
-    public static TestUnit CreateTestUnit(Guid? id = null)
+    public static TestUnit CreateTestUnit(Guid? id = null, int walkMp = 4)
     {
         var parts = new List<UnitPart>
         {
@@ -106,7 +106,7 @@ public class UnitTests
             new TestUnitPart("Right Arm", PartLocation.RightArm, 10, 5, 10)
         };
         
-        return new TestUnit("Test", "Unit", 20, 4, parts, id);
+        return new TestUnit("Test", "Unit", 20, walkMp, parts, id);
     }
     
     private void MountWeaponOnUnit(TestUnit unit, TestWeapon weapon, PartLocation location, int[] slots)
@@ -1890,6 +1890,37 @@ public class UnitTests
 
         // Assert
         result.ShouldBeTrue();
+    }
+
+    [Theory]
+    [InlineData(MovementType.Walk)]
+    [InlineData(MovementType.Run)]
+    [InlineData(MovementType.Jump)]
+    public void GetMovementPoints_ShouldReturnWalkingPoints(MovementType movementType)
+    {
+        // Arrange
+        const int walkingPoints = 2;
+        var sut = CreateTestUnit(walkMp: walkingPoints);
+        
+        // Act
+        var result = sut.GetMovementPoints(movementType);
+        
+        // Assert
+        result.ShouldBe(walkingPoints);
+    }
+    
+    [Fact]
+    public void DamageReducedMovement_ShouldReturnWalkingPoints()
+    {
+        // Arrange
+        const int walkingPoints = 2;
+        var sut = CreateTestUnit(walkMp: walkingPoints);
+        
+        // Act
+        var result = sut.DamageReducedMovement;
+        
+        // Assert
+        result.ShouldBe(walkingPoints);
     }
 
     // Helper class for testing explodable components

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -1880,16 +1880,6 @@ public class UnitTests
     }
     
     [Fact]
-    public void CanJump_BaseUnitClass_ShouldReturnFalse()
-    {
-        // Arrange
-        var sut = CreateTestUnit();
-
-        // Act & Assert
-        sut.CanJump.ShouldBeFalse("Base Unit class should not be able to jump by default");
-    }
-    
-    [Fact]
     public void CanFireWeapons_ShouldReturnTrue()
     {
         // Arrange


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced mech movement calculations to account for leg and actuator damage, affecting walking, running, and jumping capabilities.
  * Added explicit checks for running and jumping based on mech status and damage.

* **Bug Fixes**
  * Improved logic for determining when mechs can jump or run, ensuring accuracy based on current damage and state.

* **Documentation**
  * Reorganized and clarified the critical hits tracking documentation for better readability and detail.

* **Tests**
  * Added comprehensive tests for mech movement under various damage scenarios.
  * Removed obsolete test for jumping capability in the base unit class.
  * Introduced tests verifying movement points and weapon firing for base units.

* **Chores**
  * Updated version number to 0.40.40-alpha.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->