### PR TITLE
pilot dead on head blownoff

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.46-alpha</Version>
+        <Version>0.40.47-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Units/Mechs/Head.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Head.cs
@@ -14,4 +14,12 @@ public class Head : UnitPart
     }
 
     internal override bool CanBeBlownOff => true;
+
+    public override bool BlowOff()
+    {
+        var isBlownOff = base.BlowOff();
+        if (isBlownOff)
+            Unit?.Pilot?.Kill();
+        return isBlownOff;
+    }
 }

--- a/src/MakaMek.Core/Models/Units/UnitPart.cs
+++ b/src/MakaMek.Core/Models/Units/UnitPart.cs
@@ -195,7 +195,7 @@ public abstract class UnitPart
     /// Blows off this part as a result of a critical hit
     /// </summary>
     /// <returns>True if the part was successfully blown off, false otherwise</returns>
-    public bool BlowOff()
+    public virtual bool BlowOff()
     {
         if (!CanBeBlownOff)
             return false;

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
@@ -51,7 +51,6 @@ public class HeadTests
     {
         // Arrange
         var sut = new Head("Head",  8, 3);
-        var mech = new Mech("Test", "TST-1A", 50, 6, [sut]);
 
         // Act & Assert
         sut.BlowOff();

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
@@ -2,6 +2,7 @@ using Shouldly;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
+using Sanet.MakaMek.Core.Models.Units.Pilots;
 
 namespace Sanet.MakaMek.Core.Tests.Models.Units.Mechs;
 
@@ -11,21 +12,37 @@ public class HeadTests
     public void Head_ShouldBeInitializedCorrectly()
     {
         // Arrange & Act
-        var head = new Head("Head",  8, 3);
+        var sut = new Head("Head",  8, 3);
 
         // Assert
-        head.Name.ShouldBe("Head");
-        head.Location.ShouldBe(PartLocation.Head);
-        head.MaxArmor.ShouldBe(8);
-        head.CurrentArmor.ShouldBe(8);
-        head.MaxStructure.ShouldBe(3);
-        head.CurrentStructure.ShouldBe(3);
-        head.TotalSlots.ShouldBe(6);
-        head.CanBeBlownOff.ShouldBeTrue();
+        sut.Name.ShouldBe("Head");
+        sut.Location.ShouldBe(PartLocation.Head);
+        sut.MaxArmor.ShouldBe(8);
+        sut.CurrentArmor.ShouldBe(8);
+        sut.MaxStructure.ShouldBe(3);
+        sut.CurrentStructure.ShouldBe(3);
+        sut.TotalSlots.ShouldBe(6);
+        sut.CanBeBlownOff.ShouldBeTrue();
 
         // Verify default components
-        head.GetComponent<LifeSupport>().ShouldNotBeNull();
-        head.GetComponent<Sensors>().ShouldNotBeNull();
-        head.GetComponent<Cockpit>().ShouldNotBeNull();
+        sut.GetComponent<LifeSupport>().ShouldNotBeNull();
+        sut.GetComponent<Sensors>().ShouldNotBeNull();
+        sut.GetComponent<Cockpit>().ShouldNotBeNull();
+    }
+    
+    [Fact]
+    public void BlowOff_ShouldKillPilot()
+    {
+        // Arrange
+        var sut = new Head("Head",  8, 3);
+        var mech = new Mech("Test", "TST-1A", 50, 6, [sut]);
+        var pilot = new MechWarrior("John", "Doe");
+        mech.AssignPilot(pilot);
+
+        // Act
+        sut.BlowOff();
+
+        // Assert
+        pilot.IsDead.ShouldBeTrue();
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
@@ -45,4 +45,15 @@ public class HeadTests
         // Assert
         pilot.IsDead.ShouldBeTrue();
     }
+    
+    [Fact]
+    public void BlowOff_ShouldNotThrow_WhenPilotIsNotAssigned()
+    {
+        // Arrange
+        var sut = new Head("Head",  8, 3);
+        var mech = new Mech("Test", "TST-1A", 50, 6, [sut]);
+
+        // Act & Assert
+        sut.BlowOff();
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blowing off a mech's head now results in the pilot's death, adding a new consequence to this action.

* **Tests**
  * Added tests to confirm that blowing off the head causes the pilot to die and that no errors occur if no pilot is assigned.
  * Minor variable renaming in existing tests for clarity.

* **Chores**
  * Updated version number.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->