### PR TITLE
do not allow mech with destroyed gyro to stand up

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.47-alpha</Version>
+        <Version>0.40.48-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -22,7 +22,7 @@
 - [x] Gyro (Torso): Can survive only one critical hit; the second destroys it.
   - [x] First hit: Requires a PSR with a +3 modifier when applied and every time the 'Mech runs or jumps.
   - [x] Second hit: Gyro is destroyed, the 'Mech automatically falls (if standing)
-  - [ ] and becomes immobile (cannot stand, cannot move, only hexside changes possible).
+  - [x] cannot stand up, cannot move, only hexside changes possible, but not considered immobile.
 
 ### Head
 - [x] Cockpit: Destroys the slot, kills the MechWarrior, and puts the 'Mech out of commission. Small cockpits have the same effect.

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -1,5 +1,4 @@
 using Sanet.MakaMek.Core.Data.Game;
-using Sanet.MakaMek.Core.Events;
 using Sanet.MakaMek.Core.Models.Game.Dice;
 using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers;
 using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.Attack;
@@ -445,6 +444,8 @@ public class Mech : Unit
     public bool CanStandup()
     {
         if (IsShutdown) return false;
+        
+        if (!IsGyroAvailable) return false;
 
         var destroyedLegs = _parts.OfType<Leg>().Count(p=> p.IsDestroyed);
         if (destroyedLegs >= 2) return false;
@@ -455,6 +456,14 @@ public class Mech : Unit
         if (Pilot?.IsConscious == false) return false;
 
         return true;
+    }
+
+    private bool IsGyroAvailable {
+        get
+        {
+            var gyro = GetAvailableComponents<Gyro>().FirstOrDefault();
+            return gyro != null;
+        }
     }
 
     /// <summary>

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1407,16 +1407,16 @@ public class MechTests
     }
 
     [Fact]
-    public void CanStandup_WhenHasMovementPointsAndPilotConscious_ShouldReturnTrue()
+    public void CanStandup_ShouldReturnTrue_WhenHasMovementPointsAndPilotConscious()
     {
         // Arrange
         var parts = CreateBasicPartsData();
-        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
-        mech.AssignPilot(new MechWarrior("John", "Doe"));
-        mech.SetProne();
+        var sut = new Mech("Test", "TST-1A", 50, 4, parts);
+        sut.AssignPilot(new MechWarrior("John", "Doe"));
+        sut.SetProne();
 
         // Act
-        var canStandup = mech.CanStandup();
+        var canStandup = sut.CanStandup();
 
         // Assert
         canStandup.ShouldBeTrue("Mech should be able to stand up when it has movement points and pilot is conscious");
@@ -1426,41 +1426,24 @@ public class MechTests
     [InlineData(0, false)] // No movement points, unconscious pilot
     [InlineData(0, true)] // No movement points, conscious pilot 
     [InlineData(4, true)] // Has movement points, unconscious pilot
-    public void CanStandup_WhenMissingRequirements_ShouldReturnFalse(int walkMp, bool pilotUnconscious)
+    public void CanStandup_ShouldReturnFalse_WhenPilotUnconscious(int walkMp, bool pilotUnconscious)
     {
         // Arrange
         var parts = CreateBasicPartsData();
-        var mech = new Mech("Test", "TST-1A", 50, walkMp, parts);
-        mech.SetProne();
+        var sut = new Mech("Test", "TST-1A", 50, walkMp, parts);
+        sut.SetProne();
 
         // Mock pilot with specified consciousness state
         var pilot = Substitute.For<IPilot>();
         pilot.IsConscious.Returns(!pilotUnconscious);
-        typeof(Mech).GetProperty("Pilot")?.SetValue(mech, pilot);
+        typeof(Mech).GetProperty("Pilot")?.SetValue(sut, pilot);
 
         // Act
-        var canStandup = mech.CanStandup();
+        var canStandup = sut.CanStandup();
 
         // Assert
         canStandup.ShouldBe(false,
             $"Mech should not stand up with walkMP={walkMp} and pilotUnconscious={pilotUnconscious}");
-    }
-
-    [Fact]
-    public void CanStandup_WhenHasMovementPointsAndPilotConsciousAndNotShutdown_ShouldReturnTrue()
-    {
-        // Arrange
-        var parts = CreateBasicPartsData();
-        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
-        mech.AssignPilot(new MechWarrior("John", "Doe"));
-        mech.SetProne();
-
-        // Act
-        var canStandup = mech.CanStandup();
-
-        // Assert
-        canStandup.ShouldBeTrue(
-            "Mech should be able to stand up when it has movement points and pilot is conscious and not shutdown");
     }
 
     [Fact]
@@ -1496,17 +1479,17 @@ public class MechTests
     }
 
     [Fact]
-    public void CanStandup_WhenHasMovementPointsAndPilotConsciousAndShutdown_ShouldReturnFalse()
+    public void CanStandup_ShouldReturnFalse_WhenHasMovementPointsAndPilotConsciousAndShutdown()
     {
         // Arrange
         var parts = CreateBasicPartsData();
-        var mech = new Mech("Test", "TST-1A"  , 50, 4, parts);
-        mech.AssignPilot(new MechWarrior("John", "Doe"));
-        mech.SetProne();
-        mech.Shutdown();
+        var sut = new Mech("Test", "TST-1A"  , 50, 4, parts);
+        sut.AssignPilot(new MechWarrior("John", "Doe"));
+        sut.SetProne();
+        sut.Shutdown();
 
         // Act
-        var canStandup = mech.CanStandup();
+        var canStandup = sut.CanStandup();
 
         // Assert
         canStandup.ShouldBeFalse(
@@ -1514,71 +1497,91 @@ public class MechTests
     }
 
     [Fact]
-    public void CanStandup_WhenBothLegsDestroyed_ShouldReturnFalse()
+    public void CanStandup_ShouldReturnFalse_WhenBothLegsDestroyed()
     {
         // Arrange
         var parts = CreateBasicPartsData();
-        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
-        mech.SetProne();
+        var sut = new Mech("Test", "TST-1A", 50, 4, parts);
+        sut.SetProne();
 
-        var leftLeg = mech.Parts.First(p => p.Location == PartLocation.LeftLeg);
+        var leftLeg = sut.Parts.First(p => p.Location == PartLocation.LeftLeg);
         leftLeg.ApplyDamage(100);
         leftLeg.IsDestroyed.ShouldBeTrue();
-        var rightLeg = mech.Parts.First(p => p.Location == PartLocation.RightLeg);
+        var rightLeg = sut.Parts.First(p => p.Location == PartLocation.RightLeg);
         rightLeg.ApplyDamage(100);
         rightLeg.IsDestroyed.ShouldBeTrue();
 
         // Act
-        var canStandup = mech.CanStandup();
+        var canStandup = sut.CanStandup();
 
         // Assert
         canStandup.ShouldBeFalse("Mech should not be able to stand up when both legs are destroyed");
     }
 
     [Fact]
-    public void CanStandup_WhenBothLegsBlownOff_ShouldReturnFalse()
+    public void CanStandup_ShouldReturnFalse_WhenBothLegsBlownOff()
     {
         // Arrange
         var parts = CreateBasicPartsData();
-        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
-        mech.SetProne();
+        var sut = new Mech("Test", "TST-1A", 50, 4, parts);
+        sut.SetProne();
 
-        var leftLeg = mech.Parts.First(p => p.Location == PartLocation.LeftLeg);
+        var leftLeg = sut.Parts.First(p => p.Location == PartLocation.LeftLeg);
         leftLeg.BlowOff();
         leftLeg.IsBlownOff.ShouldBeTrue();
-        var rightLeg = mech.Parts.First(p => p.Location == PartLocation.RightLeg);
+        var rightLeg = sut.Parts.First(p => p.Location == PartLocation.RightLeg);
         rightLeg.BlowOff();
         rightLeg.IsBlownOff.ShouldBeTrue();
 
         // Act
-        var canStandup = mech.CanStandup();
+        var canStandup = sut.CanStandup();
 
         // Assert
         canStandup.ShouldBeFalse("Mech should not be able to stand up when both legs are blown off");
     }
 
     [Fact]
-    public void CanStandup_WhenOneLegIsBlownOffAndAnotherIsDestroyed_ShouldReturnFalse()
+    public void CanStandup_ShouldReturnFalse_WhenOneLegIsBlownOffAndAnotherIsDestroyed()
     {
         // Arrange
         var parts = CreateBasicPartsData();
-        var mech = new Mech("Test", "TST-1A", 50, 4, parts);
-        mech.SetProne();
+        var sut = new Mech("Test", "TST-1A", 50, 4, parts);
+        sut.SetProne();
 
-        var leftLeg = mech.Parts.First(p => p.Location == PartLocation.LeftLeg);
+        var leftLeg = sut.Parts.First(p => p.Location == PartLocation.LeftLeg);
         leftLeg.BlowOff();
         leftLeg.IsBlownOff.ShouldBeTrue();
-        var rightLeg = mech.Parts.First(p => p.Location == PartLocation.RightLeg);
+        var rightLeg = sut.Parts.First(p => p.Location == PartLocation.RightLeg);
         rightLeg.ApplyDamage(100);
         rightLeg.IsDestroyed.ShouldBeTrue();
 
         // Act
-        var canStandup = mech.CanStandup();
+        var canStandup = sut.CanStandup();
 
         // Assert
         canStandup.ShouldBeFalse("Mech should not be able to stand up when both legs are not available");
     }
 
+    [Fact]
+    public void CanStandup_ShouldReturnFalse_WhenGyroIsDestroyed()
+    {
+        // Arrange
+        var parts = CreateBasicPartsData();
+        var sut = new Mech("Test", "TST-1A", 50, 4, parts);
+        sut.SetProne();
+
+        var gyro = sut.GetAvailableComponents<Gyro>().First();
+        gyro.Hit();
+        gyro.Hit();
+        gyro.IsDestroyed.ShouldBeTrue();
+
+        // Act
+        var canStandup = sut.CanStandup();
+
+        // Assert
+        canStandup.ShouldBeFalse("Mech should not be able to stand up when gyro is destroyed");
+    }
+    
     [Fact]
     public void CanChangeFacingWhileProne_WhenMechIsNotProne_ShouldReturnFalse()
     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mechs now require at least one functional gyro component to stand up, ensuring more accurate behavior after gyro damage.

* **Documentation**
  * Clarified the effects of a second critical hit to the Gyro in the rules, specifying that the 'Mech cannot stand or move but is not considered immobile.

* **Tests**
  * Improved test naming for clarity and consistency.
  * Added a new test to confirm mechs cannot stand up when the gyro is destroyed.
  * Removed a redundant test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->