### PR TITLE
declare movement type before standup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.50-alpha</Version>
+        <Version>0.40.51-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Game/ClientGame.cs
+++ b/src/MakaMek.Core/Models/Game/ClientGame.cs
@@ -43,12 +43,6 @@ public sealed class ClientGame : BaseGame
     {
         if (!ShouldHandleCommand(command)) return;
         
-        // Log the command
-        _commandLog.Add(command);
-        
-        // Publish the command to subscribers
-        _commandSubject.OnNext(command);
-        
         // Handle specific command types
         switch (command)
         {
@@ -131,6 +125,12 @@ public sealed class ClientGame : BaseGame
                 }
                 break;
         }
+        
+        // Log the command
+        _commandLog.Add(command);
+        
+        // Publish the command to subscribers
+        _commandSubject.OnNext(command);
     }
 
     public bool CanActivePlayerAct => ActivePlayer != null 

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -387,6 +387,17 @@ public class Mech : Unit
 
     public override bool CanMoveBackward(MovementType type) => type == MovementType.Walk;
 
+    public override bool IsMinimumMovement
+    {
+        get
+        {
+            if (IsProne 
+                && GetMovementPoints(MovementType.Walk) == 1 
+                && StandupAttempts == 0) return true;
+            return false;
+        }
+    }
+
     public bool CanJump
     {
         get
@@ -407,7 +418,6 @@ public class Mech : Unit
     public bool CanRun {
         get
         {
-            if (IsProne) return false;
             var destroyedLegs = _parts.OfType<Leg>().Count(p=> p.IsDestroyed || p.IsBlownOff);
             if (destroyedLegs > 0) return false;
             return true;

--- a/src/MakaMek.Core/Models/Units/MovementType.cs
+++ b/src/MakaMek.Core/Models/Units/MovementType.cs
@@ -5,8 +5,6 @@ public enum MovementType
     StandingStill, // No movement
     Walk,   // Base movement
     Run,    // 1.5x walking
-    Sprint, // 2x walking
     Jump,   // Requires jump jets
-    Masc,    // Requires MASC system
     Prone
 }

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -139,6 +139,11 @@ public abstract class Unit
     /// </summary>
     public abstract bool CanMoveBackward(MovementType type);
 
+    /// <summary>
+    /// Determines if the unit is in a minimum movement situation (1 MP available)
+    /// </summary>
+    public virtual bool IsMinimumMovement => false;
+
     // Location and facing
     public virtual HexPosition? Position { get; protected set; }
 

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -149,8 +149,20 @@ public class BattleMapViewModel : BaseViewModel
                 case WeaponAttackResolutionCommand resolutionCommand:
                     ProcessWeaponAttackResolution(resolutionCommand);
                     break;
+                case MechStandUpCommand standUpCommand:
+                    ProcessMechStandUp(standUpCommand);
+                    break;
             }
         });
+    }
+
+    private void ProcessMechStandUp(MechStandUpCommand standUpCommand)
+    {
+        if (CurrentState is MovementState movementState 
+            && standUpCommand.UnitId == SelectedUnit?.Id)
+        {
+            movementState.ResumeMovementAfterStandup();
+        };
     }
 
     private void ProcessWeaponAttackDeclaration(WeaponAttackDeclarationCommand command)

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -162,7 +162,7 @@ public class BattleMapViewModel : BaseViewModel
             && standUpCommand.UnitId == SelectedUnit?.Id)
         {
             movementState.ResumeMovementAfterStandup();
-        };
+        }
     }
 
     private void ProcessWeaponAttackDeclaration(WeaponAttackDeclarationCommand command)

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1974,4 +1974,47 @@ public class MechTests
         modifier.ArmLocation.ShouldBe(PartLocation.LeftArm);
         modifier.Value.ShouldBe(4);
     }
+    
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnFalse_ByDefault()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 6, CreateBasicPartsData());
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeFalse();
+    }
+    
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnTrue_WhenProneAndOneMovementPointAndNoStandupAttempts()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 1, CreateBasicPartsData());
+        sut.SetProne();
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeTrue();
+    }
+    
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnTrue_WhenProneAndOneLegIsDestroyed()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
+        sut.SetProne();
+        var leg = sut.Parts.First(p => p.Location == PartLocation.LeftLeg);
+        leg.ApplyDamage(100);
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeTrue();
+    }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -955,14 +955,14 @@ public class MechTests
     }
 
     [Fact]
-    public void CanRun_WhenMechIsProne_ShouldReturnFalse()
+    public void CanRun_WhenMechIsProne_ShouldReturnTrue()
     {
         // Arrange
         var sut = new Mech("Test", "TST-1A", 50, 5, CreateBasicPartsData());
         sut.SetProne();
 
         // Act & Assert
-        sut.CanRun.ShouldBeFalse();
+        sut.CanRun.ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -1943,6 +1943,19 @@ public class UnitTests
         // Assert
         result.ShouldBeEmpty();
     }
+    
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnFalse_ByDefault()
+    {
+        // Arrange
+        var sut = CreateTestUnit();
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeFalse();
+    }
 
     // Helper class for testing explodable components
     private class TestExplodableComponent(string name, int explosionDamage, int size = 1) : TestComponent(name, size)

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -60,6 +60,7 @@ public class MovementStateTests
         localizationService.GetString("MovementType_Run").Returns("Run");
         localizationService.GetString("MovementType_Jump").Returns("Jump");
         localizationService.GetString("Action_AttemptStandup").Returns("Attempt Standup");
+        localizationService.GetString("Action_StandupWithMovementType").Returns("{0} ({1}%)");
         localizationService.GetString("Action_ChangeFacing").Returns("Change Facing | MP: {0}");
         
         _battleMapViewModel = new BattleMapViewModel(imageService, localizationService,Substitute.For<IDispatcherService>());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced handling for standup attempts of prone Mechs, with distinct actions for minimum and non-minimum movement scenarios.
  * Introduced new indicators for minimum movement situations in units.

* **Improvements**
  * Updated movement logic for Mechs, allowing running while prone and refining minimum movement detection.
  * Improved highlighting of reachable areas after standup actions.
  * Adjusted command processing to log and publish commands after handling.

* **Changes**
  * Removed Sprint and MASC movement types from available movement options.

* **Tests**
  * Updated tests to reflect new standup action options and verify additional available actions for prone Mechs.
  * Adjusted tests to confirm running capability while prone.
  * Added tests for minimum movement property behavior in Mechs and base units.
  * Added tests verifying movement resumption and highlighting after standup commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->