### PR TITLE
set movement type in the command builder for standup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.51-alpha</Version>
+        <Version>0.40.52-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -500,6 +500,8 @@ public class MovementState : IUiState
 
         // Set the selected movement type for later use
         _selectedMovementType = movementType;
+        // Ensure the builder has the unit and movement type set
+        _builder.SetMovementType(_selectedMovementType.Value);
 
         CurrentMovementStep = MovementStep.SelectingStandingUpDirection;
         _viewModel.ShowDirectionSelector(_selectedUnit.Position.Coordinates, Enum.GetValues<HexDirection>());

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -500,7 +500,7 @@ public class MovementState : IUiState
 
         // Set the selected movement type for later use
         _selectedMovementType = movementType;
-        // Ensure the builder has the unit and movement type set
+        // Ensure the builder has the movement type set
         _builder.SetMovementType(_selectedMovementType.Value);
 
         CurrentMovementStep = MovementStep.SelectingStandingUpDirection;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of movement type selection during standup attempts to ensure the correct movement type is set.

* **Chores**
  * Updated the application version to 0.40.52-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->