### PR TITLE
prevent movement change after standup

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.53-alpha</Version>
+        <Version>0.40.54-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -7,7 +7,6 @@
   - [ ] The MechWarrior automatically takes 2 points of damage and requires a Consciousness Roll.
 
 - [x] Weapons: The first critical hit to a weapon (even multi-slot ones) knocks out the weapon. Additional hits to multi-slot weapons have no further effect.
-  - [ ] Explosive components (e.g., Gauss rifles) explode similarly to ammunition explosions
 
 - [x] Jump Jet: That jump jet can no longer deliver thrust. Reduces the 'Mech's Jumping MP by 1 for each hit.
 
@@ -51,7 +50,7 @@
   - [x] Reduces Walking MP by 1 (recalculate Running MP).
 
 - [x] Leg Blown Off: Occurs on a roll of 12 on the Determining Critical Hits Table for a leg hit. The leg is blown off, and the 'Mech automatically falls (takes normal falling damage). Explosive components do not explode.
-  - [ ] Single Attempt to stand up that counts as running. Should end the turn for the unit
+  - [x] Single Attempt to stand up that counts as running. Should end the turn for the unit
   - [x] Only one MP if mech is standing up, no run
 
 ### Arms


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved movement handling after a unit stands up, ensuring that unit selection is not reset prematurely and movement must be completed before selecting another unit.

* **Documentation**
  * Updated checklist in the critical hits tracking documentation to reflect completed and removed tasks.

* **Tests**
  * Added a test to verify that unit selection is maintained after standing up, even when clicking outside reachable movement areas.

* **Chores**
  * Updated the application version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->