### PR TITLE
hit pilot on explosion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.40.54-alpha</Version>
+        <Version>0.40.55-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -3,7 +3,6 @@
 
 ### General
 - [x] Ammunition: If a critical hit destroys a slot with explosive ammunition, the ammo explodes. The 'Mech takes internal structure damage based on the total Damage Value of the ammo in the slot, multiplied by shots remaining.
-  - [ ] If the location has CASE, excess damage dissipates.
   - [x] The MechWarrior automatically takes 2 points of damage.
 
 - [x] Weapons: The first critical hit to a weapon (even multi-slot ones) knocks out the weapon. Additional hits to multi-slot weapons have no further effect.

--- a/docs/Critical-Hits-Tracking.md
+++ b/docs/Critical-Hits-Tracking.md
@@ -4,7 +4,7 @@
 ### General
 - [x] Ammunition: If a critical hit destroys a slot with explosive ammunition, the ammo explodes. The 'Mech takes internal structure damage based on the total Damage Value of the ammo in the slot, multiplied by shots remaining.
   - [ ] If the location has CASE, excess damage dissipates.
-  - [ ] The MechWarrior automatically takes 2 points of damage and requires a Consciousness Roll.
+  - [x] The MechWarrior automatically takes 2 points of damage.
 
 - [x] Weapons: The first critical hit to a weapon (even multi-slot ones) knocks out the weapon. Additional hits to multi-slot weapons have no further effect.
 

--- a/docs/MakaMek-MVP-PRD.md
+++ b/docs/MakaMek-MVP-PRD.md
@@ -5,7 +5,7 @@
 MakaMek is a cross-platform implementation of the classic BattleTech tabletop game. The MVP is targeting simplified 3025-era combat mechanics and focuses on core turn-based tactical combat featuring BattleMechs on hex-based maps with essential game mechanics including movement, combat, heat management, and critical damage systems.
 
 **Primary Objectives:**
-- Deliver a playable BattleTech experience with simplified rules
+- Deliver a playable BattleTech experience with simplified rules (Level 1)
 - Support cross-platform deployment (Desktop, Web, Mobile)
 - Provide multiplayer capabilities (local and LAN)
 - Maintain compatibility with standard BattleTech community data formats (MTF)

--- a/src/MakaMek.Core/Models/Units/Components/Component.cs
+++ b/src/MakaMek.Core/Models/Units/Components/Component.cs
@@ -67,6 +67,11 @@ public abstract class Component : IManufacturedItem
     public virtual void Hit()
     {
         Hits++;
+        if (CanExplode && !HasExploded)
+        {
+            HasExploded = true;
+            MountedOn?.Unit?.Pilot?.ExplosionHit();
+        }
     }
 
     public int HealthPoints { get; }

--- a/src/MakaMek.Core/Models/Units/Components/Weapons/Ammo.cs
+++ b/src/MakaMek.Core/Models/Units/Components/Weapons/Ammo.cs
@@ -36,7 +36,6 @@ public class Ammo : Component
     public override void Hit()
     {
         base.Hit();
-        HasExploded = true;
         _remainingShots = 0;
     }
 

--- a/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
@@ -55,4 +55,5 @@ public interface IPilot
     void Kill();
 
     PilotData ToData();
+    void ExplosionHit();
 }

--- a/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/IPilot.cs
@@ -55,5 +55,10 @@ public interface IPilot
     void Kill();
 
     PilotData ToData();
+        
+    /// <summary>
+    /// Applies explosion damage to the pilot, typically from exploding components
+    /// Requires a sepaeate method as should be implemented differently for different pilot types
+    /// </summary>
     void ExplosionHit();
 }

--- a/src/MakaMek.Core/Models/Units/Pilots/MechWarrior.cs
+++ b/src/MakaMek.Core/Models/Units/Pilots/MechWarrior.cs
@@ -8,6 +8,7 @@ namespace Sanet.MakaMek.Core.Models.Units.Pilots;
 /// </summary>
 public class MechWarrior : IPilot
 {
+    private const int MechWarriorExplosionDamage = 2;
     /// <summary>
     /// Default gunnery skill for Inner Sphere MechWarriors
     /// </summary>
@@ -106,6 +107,11 @@ public class MechWarrior : IPilot
             Injuries = Injuries,
             IsConscious = IsConscious
         };
+    }
+
+    public void ExplosionHit()
+    {
+        Hit(MechWarriorExplosionDamage);
     }
 
     public bool IsDead => Injuries >= Health;

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -1245,10 +1245,12 @@ public class UnitTests
     }
 
     [Fact]
-    public void ApplyDamage_WithExplodableComponent_ShouldAddExplosionDamage()
+    public void ApplyDamage_WithExplodableComponent_ShouldAddExplosionDamage_AndHitPilot()
     {
         // Arrange
         var unit = CreateTestUnit();
+        var pilot = new MechWarrior("John", "Doe");
+        unit.AssignPilot(pilot);
         var targetPart = unit.Parts.First(p => p.Location == PartLocation.LeftArm);
         
         // Create an explodable component
@@ -1273,6 +1275,7 @@ public class UnitTests
         explodableComponent.HasExploded.ShouldBeTrue();
         // Verify that the total damage applied was the initial damage (5) plus the explosion damage (5)
         targetPart.CurrentArmor.ShouldBe(0); // 10 - (5 + 5) = 0
+        pilot.Injuries.ShouldBe(2);
     }
     
     [Fact]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pilots now automatically receive 2 damage when an explosive component detonates.
* **Bug Fixes**
  * Updated logic to ensure explosion damage is correctly applied to pilots.
* **Documentation**
  * Clarified and completed the checklist regarding MechWarrior damage from explosive ammunition critical hits.
  * Updated product requirements phrasing to specify simplified rules at Level 1.
* **Tests**
  * Enhanced tests to verify that explosion damage is applied to both components and pilots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->