### PR TITLE
correctly calculate movement order when one team has 3x and more…

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.41.8-alpha</Version>
+        <Version>0.41.9-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Game/TurnOrder.cs
+++ b/src/MakaMek.Core/Models/Game/TurnOrder.cs
@@ -44,8 +44,10 @@ public class TurnOrder
                 if (!remainingUnits.ContainsKey(player) || remainingUnits[player] <= 0)
                     continue;
 
-                // Calculate how many units this player should move
-                var unitsToMove = remainingUnits[player] >= minUnits * 2 ? 2 : 1;
+                // Calculate how many units this player should move based on ratio
+                // If a team has N times as many units as the minimum, they move N units
+                var ratio = remainingUnits[player] / minUnits;
+                var unitsToMove = Math.Max(1, ratio); // At least 1 unit
                 unitsToMove = Math.Min(unitsToMove, remainingUnits[player]); // Don't move more units than remaining
 
                 _steps.Add(new TurnStep(player, unitsToMove));

--- a/tests/MakaMek.Core.Tests/Models/Game/TurnOrderTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/TurnOrderTests.cs
@@ -3,6 +3,7 @@ using NSubstitute;
 using Sanet.MakaMek.Core.Data.Units;
 using Sanet.MakaMek.Core.Models.Game;
 using Sanet.MakaMek.Core.Models.Game.Players;
+using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Services.Localization;
 using Sanet.MakaMek.Core.Tests.Data.Community;
 using Sanet.MakaMek.Core.Utils;
@@ -123,5 +124,209 @@ public class TurnOrderTests
         _sut.CurrentStep.ShouldBeNull();
         var nextStep = _sut.GetNextStep();
         nextStep.ShouldBe(_sut.Steps[0]);
+    }
+
+    [Fact]
+    public void CalculateOrder_With3To9UnitRatio_ShouldHandleTripleMovements()
+    {
+        // Arrange - Player 1 has 3 units, Player 2 has 9 units, Player 1 wins initiative
+        var player1Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+        var player2Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+
+        _player1.AliveUnits.Returns(player1Units);
+        _player2.AliveUnits.Returns(player2Units);
+
+        // Player 1 wins initiative (first in list)
+        var initiativeOrder = new List<IPlayer> { _player1, _player2 };
+
+        // Act
+        _sut.CalculateOrder(initiativeOrder);
+
+        // Assert - Expected movement sequence based on BattleTech rules
+        var steps = _sut.Steps;
+        steps.Count.ShouldBe(6);
+
+        // Turn 1: Player 2 has 9 units, Player 1 has 3 units (Player 2 has 3x as many units)
+        // Player 2 moves three units (Units 1, 2, 3). Remaining: Player 2 (6), Player 1 (3)
+        steps[0].ShouldBe(new TurnStep(_player2, 3));
+
+        // Player 1 moves one unit (Unit 1). Remaining: Player 2 (6), Player 1 (2)
+        steps[1].ShouldBe(new TurnStep(_player1, 1));
+
+        // Player 2 moves three units (Units 4, 5, 6). Remaining: Player 2 (3), Player 1 (2)
+        steps[2].ShouldBe(new TurnStep(_player2, 3));
+
+        // Player 1 moves one unit (Unit 2). Remaining: Player 2 (3), Player 1 (1)
+        steps[3].ShouldBe(new TurnStep(_player1, 1));
+
+        // Player 2 moves three units (Units 7, 8, 9). Remaining: Player 2 (0), Player 1 (1)
+        steps[4].ShouldBe(new TurnStep(_player2, 3));
+
+        // Player 1 moves one unit (Unit 3). Remaining: Player 1 (0)
+        steps[5].ShouldBe(new TurnStep(_player1, 1));
+    }
+
+    [Fact]
+    public void CalculateOrder_With1To4UnitRatio_ShouldHandleQuadrupleMovements()
+    {
+        // Arrange - Player 1 has 1 unit, Player 2 has 4 units, Player 1 wins initiative
+        var player1Units = new List<Unit> { _mechFactory.Create(_unitData) };
+        var player2Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+
+        _player1.AliveUnits.Returns(player1Units);
+        _player2.AliveUnits.Returns(player2Units);
+
+        // Player 1 wins initiative (first in list)
+        var initiativeOrder = new List<IPlayer> { _player1, _player2 };
+
+        // Act
+        _sut.CalculateOrder(initiativeOrder);
+
+        // Assert - Expected movement sequence based on BattleTech rules
+        var steps = _sut.Steps;
+        steps.Count.ShouldBe(2);
+
+        // Player 2 has 4x as many units as Player 1, so moves 4 units
+        steps[0].ShouldBe(new TurnStep(_player2, 4));
+
+        // Player 1 moves 1 unit
+        steps[1].ShouldBe(new TurnStep(_player1, 1));
+    }
+
+    [Fact]
+    public void CalculateOrder_With2To5UnitRatio_ShouldHandlePartialRatios()
+    {
+        // Arrange - Player 1 has 2 units, Player 2 has 5 units, Player 1 wins initiative
+        var player1Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+        var player2Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+
+        _player1.AliveUnits.Returns(player1Units);
+        _player2.AliveUnits.Returns(player2Units);
+
+        // Player 1 wins initiative (first in list)
+        var initiativeOrder = new List<IPlayer> { _player1, _player2 };
+
+        // Act
+        _sut.CalculateOrder(initiativeOrder);
+
+        // Assert - Expected movement sequence based on BattleTech rules
+        var steps = _sut.Steps;
+        steps.Count.ShouldBe(4);
+
+        // Initial: Player1=2, Player2=5. Min=2. Player2 moves 5/2=2 units, Player1 moves 2/2=1 unit
+        steps[0].ShouldBe(new TurnStep(_player2, 2)); // Player2: 5/2=2 units
+        steps[1].ShouldBe(new TurnStep(_player1, 1)); // Player1: 2/2=1 unit
+
+        // After round 1: Player1=1, Player2=3. Min=1. Player2 moves 3/1=3 units, Player1 moves 1/1=1 unit
+        steps[2].ShouldBe(new TurnStep(_player2, 3)); // Player2: 3/1=3 units
+        steps[3].ShouldBe(new TurnStep(_player1, 1)); // Player1: 1/1=1 unit
+
+        // After round 2: Player1=0, Player2=0. Done.
+    }
+
+    [Fact]
+    public void CalculateOrder_WithThreePlayersUnequalUnits_ShouldHandleMultipleRatios()
+    {
+        // Arrange - Player 1 has 1 unit, Player 2 has 2 units, Player 3 has 6 units
+        var player1Units = new List<Unit> { _mechFactory.Create(_unitData) };
+        var player2Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+        var player3Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+
+        _player1.AliveUnits.Returns(player1Units);
+        _player2.AliveUnits.Returns(player2Units);
+        _player3.AliveUnits.Returns(player3Units);
+
+        // Player 1 wins initiative, Player 2 second, Player 3 last
+        var initiativeOrder = new List<IPlayer> { _player1, _player2, _player3 };
+
+        // Act
+        _sut.CalculateOrder(initiativeOrder);
+
+        // Assert - Expected movement sequence based on BattleTech rules
+        var steps = _sut.Steps;
+        steps.Count.ShouldBe(3);
+
+        // Initial: Player1=1, Player2=2, Player3=6. Min=1
+        // Player 3 moves 6/1=6 units, Player 2 moves 2/1=2 units, Player 1 moves 1/1=1 unit
+        steps[0].ShouldBe(new TurnStep(_player3, 6)); // Player 3 moves all 6 units
+        steps[1].ShouldBe(new TurnStep(_player2, 2)); // Player 2 moves all 2 units
+        steps[2].ShouldBe(new TurnStep(_player1, 1)); // Player 1 moves 1 unit
+
+        // All players have moved all their units in one round
+    }
+
+    [Fact]
+    public void CalculateOrder_WithZeroUnitsPlayer_ShouldSkipPlayer()
+    {
+        // Arrange - Player 1 has 0 units, Player 2 has 3 units
+        var player1Units = new List<Unit>();
+        var player2Units = new List<Unit>
+        {
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData),
+            _mechFactory.Create(_unitData)
+        };
+
+        _player1.AliveUnits.Returns(player1Units);
+        _player2.AliveUnits.Returns(player2Units);
+
+        var initiativeOrder = new List<IPlayer> { _player1, _player2 };
+
+        // Act
+        _sut.CalculateOrder(initiativeOrder);
+
+        // Assert - Player 1 should be skipped entirely, Player 2 moves one unit at a time
+        var steps = _sut.Steps;
+        steps.Count.ShouldBe(3);
+
+        // Player 2 moves 1 unit at a time since there's no other player to compare against
+        steps[0].ShouldBe(new TurnStep(_player2, 1));
+        steps[1].ShouldBe(new TurnStep(_player2, 1));
+        steps[2].ShouldBe(new TurnStep(_player2, 1));
     }
 }


### PR DESCRIPTION
… units

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced turn order logic to proportionally determine the number of units each player moves per turn, based on their remaining units relative to others.

* **Tests**
  * Added comprehensive tests to verify the updated turn order calculation across various player unit distributions and scenarios.

* **Chores**
  * Updated version number to 0.41.9-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->