### PR TITLE
clear remaining weapon attacks if any at end phase

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.42.1-alpha</Version>
+        <Version>0.42.2-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -148,7 +148,7 @@ public class BattleMapViewModel : BaseViewModel
                 (turn, phase, player, units) => (turn, phase, player, units))
             .Subscribe(_ =>
             {
-                CleanSelection();
+                ClearSelection();
                 UpdateGamePhase();
                 NotifyStateChanged();
             });
@@ -288,6 +288,7 @@ public class BattleMapViewModel : BaseViewModel
                 break;
         
             case PhaseNames.End:
+                ClearWeaponAttacks();
                 TransitionToState(new EndState(this));
                 break;
         
@@ -295,6 +296,14 @@ public class BattleMapViewModel : BaseViewModel
                 TransitionToState(new IdleState());
                 break;
         }
+    }
+
+    private void ClearWeaponAttacks()
+    {
+        // Clear weapon attacks during phase transitions
+        if (WeaponAttacks?.Any() != true) return;
+        WeaponAttacks.Clear();
+        NotifyPropertyChanged(nameof(WeaponAttacks));
     }
 
     private void ShowUnitsToDeploy()
@@ -387,7 +396,7 @@ public class BattleMapViewModel : BaseViewModel
         CurrentState.HandleHexSelection(selectedHex);
     }
 
-    private void CleanSelection()
+    private void ClearSelection()
     {
         SelectedUnit = null;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weapon attacks now persist from Weapons Attack to Resolution and are cleared at the End phase.
  * Unit selection is reliably cleared when turns or phases change.

* **Tests**
  * Added test coverage to verify weapon attack persistence across phases and cleanup at End.

* **Chores**
  * Bumped version to 0.42.2-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->