### PR TITLE
return correct action label for standup direction

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.42.4-alpha</Version>
+        <Version>0.42.5-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -352,6 +352,7 @@ public class MovementState : IUiState
         MovementStep.SelectingTargetHex => _viewModel.LocalizationService.GetString("Action_SelectTargetHex"),
         MovementStep.SelectingDirection => _viewModel.LocalizationService.GetString("Action_SelectFacingDirection"),
         MovementStep.ConfirmMovement => _viewModel.LocalizationService.GetString("Action_MoveUnit"),
+        MovementStep.SelectingStandingUpDirection => _viewModel.LocalizationService.GetString("Action_SelectFacingDirection"),
         _ => string.Empty
     };
 

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -1067,6 +1067,31 @@ public class MovementStateTests
     }
     
     [Fact]
+    public void ActionLabel_ShouldBeSelectDirection_WhenInSelectingStandingUpDirectionStep()
+    {
+        // Arrange
+        var position = new HexPosition(new HexCoordinates(1, 1), HexDirection.Bottom);
+        var unit = _battleMapViewModel.Units.First() as Mech;
+        unit!.Deploy(position);
+        unit.AssignPilot(_pilot);
+        unit.SetProne();
+        _pilotingSkillCalculator.GetPsrBreakdown(unit, PilotingSkillRollType.StandupAttempt)
+            .Returns(new PsrBreakdown
+            {
+                BasePilotingSkill = 4,
+                Modifiers = []
+            });
+        _sut.HandleUnitSelection(unit);
+        _sut.GetAvailableActions().First(a => a.Label.Contains("Walk")).OnExecute();
+        
+        // Act
+        var result = _sut.ActionLabel;
+        
+        // Assert
+        result.ShouldBe("Select facing direction");
+    }
+    
+    [Fact]
     public void HandleStandupAttempt_ShowsDirectionSelector()
     {
         // Arrange


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the action label shown during the standing-up direction step to display “Select facing direction” for improved clarity and consistency.
* **Tests**
  * Added a unit test to verify the correct label is shown during the standing-up direction selection step.
* **Chores**
  * Bumped app version to 0.42.5-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->