### PR TITLE
weapon unavailable text

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.42.7-alpha</Version>
+        <Version>0.42.8-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
+++ b/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
@@ -249,6 +249,7 @@ public class ClassicBattletechRulesProvider : IRulesProvider
 
     public PartLocation GetHitLocation(int diceResult, FiringArc attackDirection)
     {
+        return PartLocation.LeftLeg;
         // Classic BattleTech hit location tables based on the attack direction
         // Note: Front and Rear directions use the same hit location table
         return attackDirection switch

--- a/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
+++ b/src/MakaMek.Core/Utils/TechRules/ClassicBattletechRulesProvider.cs
@@ -249,7 +249,6 @@ public class ClassicBattletechRulesProvider : IRulesProvider
 
     public PartLocation GetHitLocation(int diceResult, FiringArc attackDirection)
     {
-        return PartLocation.LeftLeg;
         // Classic BattleTech hit location tables based on the attack direction
         // Note: Front and Rear directions use the same hit location table
         return attackDirection switch

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
@@ -157,9 +157,11 @@ public class WeaponSelectionViewModel : BindableBase
             // Check if weapon is in range
             if (!IsInRange)
                 return _localizationService.GetString("Attack_OutOfRange");
-            // Check if weapon is targetting different target
+            // Check if weapon is targeting different target
             if (!IsEnabled && Target != null)
                 return string.Format(_localizationService.GetString("Attack_Targeting"), Target.Name);
+            if (!IsEnabled)
+                return Weapon.GetWeaponRestrictionReason(_localizationService);
             // Check if we have modifiers breakdown
             if (ModifiersBreakdown == null)
                 return _localizationService.GetString("Attack_NoModifiersCalculated");

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
@@ -160,14 +160,15 @@ public class WeaponSelectionViewModel : BindableBase
             // Check if weapon is targeting different target
             if (!IsEnabled && Target != null)
                 return string.Format(_localizationService.GetString("Attack_Targeting"), Target.Name);
-            if (!IsEnabled)
-                return Weapon.GetWeaponRestrictionReason(_localizationService);
             // Check if we have modifiers breakdown
             if (ModifiersBreakdown == null)
                 return _localizationService.GetString("Attack_NoModifiersCalculated");
             // Check line of sight
             if (!ModifiersBreakdown.HasLineOfSight)
                 return _localizationService.GetString("Attack_NoLineOfSight");
+            // Unavailable for some other reason
+            if (!IsEnabled)
+                return Weapon.GetWeaponRestrictionReason(_localizationService);
             // If we get here, show the modifiers breakdown
             var lines = new List<string>
             {

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
@@ -552,6 +552,8 @@ public class WeaponSelectionViewModelTests
     {
         // Arrange
         CreateSut(isEnabled: false, target: null);
+        var breakdown = CreateTestBreakdown(8, hasLineOfSight: true);
+        _sut.ModifiersBreakdown = breakdown;
         _weapon.UnMount();
         _localizationService.GetString("WeaponRestriction_NotAvailable").Returns("NotAvailable");
         

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
@@ -548,6 +548,19 @@ public class WeaponSelectionViewModelTests
     }
     
     [Fact]
+    public void AttackPossibilityDescription_HandlesWeaponUnavailability()
+    {
+        // Arrange
+        CreateSut(isEnabled: false, target: null);
+        _weapon.UnMount();
+        _localizationService.GetString("WeaponRestriction_NotAvailable").Returns("NotAvailable");
+        
+        // Act & Assert
+        _sut.AttackPossibilityDescription.ShouldBe("NotAvailable");
+        _localizationService.Received().GetString("WeaponRestriction_NotAvailable");
+    }
+    
+    [Fact]
     public void HitProbability_ReturnsZeroWhenDisabled()
     {
         // Arrange


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Weapon selection now shows a clear restriction message when a weapon is unavailable or disabled, instead of displaying a modifiers breakdown. This applies even when no target is selected, improving clarity.

* **Tests**
  * Added coverage to verify the correct localized message is shown for unavailable weapons.

* **Chores**
  * Bumped version to 0.42.8-alpha.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->