### PR TITLE
head damage hits pilot

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.42.18-alpha</Version>
+        <Version>0.42.19-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Units/Mechs/Head.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Head.cs
@@ -22,4 +22,10 @@ public class Head : UnitPart
             Unit?.Pilot?.Kill();
         return isBlownOff;
     }
+    
+    public override int ApplyDamage(int damage, HitDirection direction, bool isExplosion = false)
+    {
+        Unit?.Pilot?.Hit();
+        return base.ApplyDamage(damage, direction, isExplosion);
+    }
 }

--- a/src/MakaMek.Core/Models/Units/Mechs/Head.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Head.cs
@@ -25,7 +25,8 @@ public class Head : UnitPart
     
     public override int ApplyDamage(int damage, HitDirection direction, bool isExplosion = false)
     {
-        Unit?.Pilot?.Hit();
+        if (damage > 0)
+            Unit?.Pilot?.Hit();
         return base.ApplyDamage(damage, direction, isExplosion);
     }
 }

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -497,7 +497,7 @@ public abstract class Unit
                     if (damagedPart == null || explosionDamage.StructureDamage <= 0) continue;
 
                     // Explosion damage bypasses armor and only affects structure
-                    damagedPart.ApplyStructureDamage(explosionDamage.StructureDamage);
+                    damagedPart.ApplyDamage(explosionDamage.StructureDamage, HitDirection.Front, true);
 
                     // Track explosion damage in total phase damage
                     TotalPhaseDamage += explosionDamage.StructureDamage;

--- a/src/MakaMek.Core/Models/Units/UnitPart.cs
+++ b/src/MakaMek.Core/Models/Units/UnitPart.cs
@@ -139,7 +139,9 @@ public abstract class UnitPart
     }
 
     /// <summary>
-    /// Applies pre-calculated armor damage to this part
+    /// Applies damage to this part.
+    /// If isExplosion is true, bypasses armor and damage transfer, applying structure damage only to this part.
+    /// Returns the overflow (unapplied) damage, if any.
     /// </summary>
     /// <param name="damage">The amount of total damage to apply</param>
     /// <param name="direction">The direction of the hit</param>

--- a/src/MakaMek.Core/Models/Units/UnitPart.cs
+++ b/src/MakaMek.Core/Models/Units/UnitPart.cs
@@ -143,8 +143,13 @@ public abstract class UnitPart
     /// </summary>
     /// <param name="damage">The amount of total damage to apply</param>
     /// <param name="direction">The direction of the hit</param>
-    public int ApplyDamage(int damage, HitDirection direction)
+    /// <param name="isExplosion">Skips armor damage if true</param>
+    public virtual int ApplyDamage(int damage, HitDirection direction, bool isExplosion = false)
     {
+        if (isExplosion)
+        {
+            return ApplyStructureDamage(damage);
+        }
         var remainingDamage = damage;
         var part = this;
 
@@ -174,7 +179,7 @@ public abstract class UnitPart
     /// Applies pre-calculated structure damage to this part
     /// </summary>
     /// <param name="structureDamage">The amount of structure damage to apply</param>
-    public int ApplyStructureDamage(int structureDamage)
+    private int ApplyStructureDamage(int structureDamage)
     {
         if (structureDamage <= 0) return structureDamage;
 

--- a/tests/MakaMek.Core.Tests/Models/Units/Components/ComponentTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Components/ComponentTests.cs
@@ -198,7 +198,7 @@ public class ComponentTests
         var component = new TestComponent("Test", []);
         var unitPart = new TestUnitPart("Test Part", PartLocation.LeftArm, 10, 5, 10);
         component.Mount([0], unitPart);
-        unitPart.ApplyStructureDamage(20);
+        unitPart.ApplyDamage(20, HitDirection.Front, true);
         component.Status.ShouldBe(ComponentStatus.Lost);
     }
 

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
@@ -55,4 +55,20 @@ public class HeadTests
         // Act & Assert
         sut.BlowOff();
     }
+    
+    [Fact]
+    public void ApplyDamage_ShouldHitPilot()
+    {
+        // Arrange
+        var sut = new Head("Head",  8, 3);
+        var mech = new Mech("Test", "TST-1A", 50, 6, [sut]);
+        var pilot = new MechWarrior("John", "Doe");
+        mech.AssignPilot(pilot);
+
+        // Act
+        sut.ApplyDamage(1, HitDirection.Front);
+
+        // Assert
+        pilot.Injuries.ShouldBe(1);
+    }
 }

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/HeadTests.cs
@@ -71,4 +71,34 @@ public class HeadTests
         // Assert
         pilot.Injuries.ShouldBe(1);
     }
+    
+    [Fact]
+    public void ApplyDamage_ShouldNoHitPilot_WhenPilotIsNotAssigned()
+    {
+        // Arrange
+        var sut = new Head("Head",  8, 3);
+        var pilot = new MechWarrior("John", "Doe");
+
+        // Act
+        sut.ApplyDamage(1, HitDirection.Front);
+
+        // Assert
+        pilot.Injuries.ShouldBe(0);
+    }
+    
+    [Fact]
+    public void ApplyDamage_ShouldNotHitPilot_WhenDamageIsZero()
+    {
+        // Arrange
+        var sut = new Head("Head",  8, 3);
+        var mech = new Mech("Test", "TST-1A", 50, 6, [sut]);
+        var pilot = new MechWarrior("John", "Doe");
+        mech.AssignPilot(pilot);
+
+        // Act
+        sut.ApplyDamage(0, HitDirection.Front);
+
+        // Assert
+        pilot.Injuries.ShouldBe(0);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Pilots now take injuries when a mech’s head is damaged.

- Bug Fixes
  - Explosion damage is processed through the standard damage system, correctly bypassing armor and applying to structure for more consistent outcomes.
  - Improved consistency of component loss when the mounting part is destroyed by explosions.

- Chores
  - Version bumped to 0.42.19-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->