### PR TITLE
add generic description to PSR command

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.42.21-alpha</Version>
+        <Version>0.42.22-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Data/Game/Commands/Server/MechFallCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Server/MechFallCommand.cs
@@ -60,16 +60,21 @@ public record struct MechFallCommand : IGameCommand
             .SelectMany(p => p.Units)
             .FirstOrDefault(u => u.Id == command.UnitId);
             
-        if (unit == null)
+        if (unit == null || (FallPilotingSkillRoll == null && DamageData == null))
         {
             return string.Empty;
         }
-        
+
         var stringBuilder = new StringBuilder();
+
+        // Intro line: subject + action/situation summary before any PSR details
+        stringBuilder.AppendLine(string.Format(
+                        localizationService.GetString("Command_MechFalling_PsrIntro"),
+                        unit.Model));
         
-        // Render the fall PSR details if it exists, regardless of outcome.
         if (FallPilotingSkillRoll != null)
         {
+            // Render the fall PSR details
             stringBuilder.AppendLine(FallPilotingSkillRoll.Render(localizationService));
         }
         

--- a/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
@@ -70,6 +70,7 @@ public class FakeLocalizationService: ILocalizationService
             "Direction_Backward" => "backward",
             
             // MechFallingCommand strings
+            "Command_MechFalling_PsrIntro" => "{0} may fall",
             "Command_MechFalling_Base" => "{0} fell",
             "Command_MechFalling_Levels" => " {0} level(s)",
             "Command_MechFalling_Jumping" => " while jumping",

--- a/tests/MakaMek.Core.Tests/Data/Game/Commands/Server/MechFallCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Commands/Server/MechFallCommandTests.cs
@@ -338,7 +338,8 @@ public class MechFallCommandTests
         var result = sut.Render(_localizationService, _game);
 
         // Assert
-        result.ShouldBe($"{psrDetailsRenderedText}");
+        result.ShouldContain("LCT-1V may fall");
+        result.ShouldContain(psrDetailsRenderedText);
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
@@ -118,6 +118,7 @@ public class FakeLocalizationServiceTests
     [InlineData("Direction_Forward", "forward")]
     [InlineData("Direction_Backward", "backward")]
     // MechFallingCommand strings
+    [InlineData("Command_MechFalling_PsrIntro", "{0} may fall")]
     [InlineData("Command_MechFalling_Base", "{0} fell")]
     [InlineData("Command_MechFalling_Levels", " {0} level(s)")]
     [InlineData("Command_MechFalling_Jumping", " while jumping")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Mech fall messages now include a clear preface indicating the unit may fall before piloting roll details.
- Tests
  - Updated assertions to validate the new composite fall message.
  - Added coverage for the new localized fall preface text.
- Chores
  - Bumped app version to 0.42.22-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->