### PR TITLE
clean up heat modifiers ui

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.44.4-alpha</Version>
+        <Version>0.44.5-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitMovementInfoPanel.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitMovementInfoPanel.axaml
@@ -6,17 +6,17 @@
              xmlns:converters="clr-namespace:Sanet.MakaMek.Avalonia.Converters;assembly=Sanet.MakaMek.Avalonia"
              x:DataType="units:Unit"
              x:Class="Sanet.MakaMek.Avalonia.Controls.UnitMovementInfoPanel"
-             mc:Ignorable="d">
+             mc:Ignorable="d"
+             IsVisible="{Binding HasMoved}">
     <UserControl.Resources>
         <converters:CollectionToVisibilityConverter x:Key="CollectionToVisibilityConverter"/>
         <converters:ModifierToTextConverter x:Key="ModifierToTextConverter"/>
     </UserControl.Resources>
-    <StackPanel Spacing="2" Orientation="Vertical">
+    <StackPanel Spacing="5" Orientation="Vertical">
         <Border Background="#20000000"
             CornerRadius="4"
-            Padding="10"
-            IsVisible="{Binding HasMoved}">
-       
+            Padding="5"
+            >
             <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto">
                 <TextBlock Grid.Row="0" Grid.Column="0"
                          Text="Type"
@@ -41,11 +41,10 @@
         </Border>
          <!-- Movement Penalties Section -->
         <ItemsControl ItemsSource="{Binding MovementModifiers}"
-                       IsVisible="{Binding MovementModifiers, Converter={StaticResource CollectionToVisibilityConverter}}"
-                       Margin="0,10,0,0">
+                       IsVisible="{Binding MovementModifiers, Converter={StaticResource CollectionToVisibilityConverter}}">
           <ItemsControl.ItemsPanel>
              <ItemsPanelTemplate>
-                 <WrapPanel ItemSpacing="2" LineSpacing="2" Orientation="Horizontal"/>
+                 <WrapPanel Margin="0,10" ItemSpacing="2" LineSpacing="2" Orientation="Horizontal"/>
              </ItemsPanelTemplate>
           </ItemsControl.ItemsPanel>
           <ItemsControl.ItemTemplate>

--- a/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Core/Services/Localization/FakeLocalizationService.cs
@@ -110,7 +110,7 @@ public class FakeLocalizationService: ILocalizationService
             "Modifier_AttackerMovement" => "Attacker Movement ({0}): +{1}",
             "Modifier_TargetMovement" => "Target Movement ({0} hexes): +{1}",
             "Modifier_Range" => "{0} at {1} hexes ({2} range): +{3}",
-            "Modifier_Heat" => "Heat Level ({0}): +{1}",
+            "Modifier_Heat" => "Heat ({0}) Attack Modifier: +{1}",
             "Modifier_Terrain" => "{0} at {1}: +{2}",
             "Modifier_DamagedGyro" => "Damaged Gyro ({0} {1}): +{2}",
             "Modifier_HeavyDamage" => "Heavy Damage ({0} points): +{1}",
@@ -240,7 +240,7 @@ public class FakeLocalizationService: ILocalizationService
             
             // Penalty messages
             "Penalty_FootActuatorMovement" => "{0} destroyed foot actuator(s) | -{1} MP",
-            "Penalty_HeatMovement" => "Heat level {0} | -{1} MP",
+            "Penalty_HeatMovement" => "Heat ({0}) MP Penalty | -{1} MP",
             "Penalty_EngineHeat"   => "Engine Heat Penalty ({0} hits): +{1} heat/turn",
             "Penalty_LowerLegActuatorMovement" => "{0} destroyed lower leg actuator(s) | -{1} MP",
             "Penalty_UpperLegActuatorMovement" => "{0} destroyed upper leg actuator(s) | -{1} MP",

--- a/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Localization/FakeLocalizationServiceTests.cs
@@ -152,7 +152,7 @@ public class FakeLocalizationServiceTests
     [InlineData("Modifier_AttackerMovement", "Attacker Movement ({0}): +{1}")]
     [InlineData("Modifier_TargetMovement", "Target Movement ({0} hexes): +{1}")]
     [InlineData("Modifier_Range", "{0} at {1} hexes ({2} range): +{3}")]
-    [InlineData("Modifier_Heat", "Heat Level ({0}): +{1}")]
+    [InlineData("Modifier_Heat", "Heat ({0}) Attack Modifier: +{1}")]
     [InlineData("Modifier_Terrain", "{0} at {1}: +{2}")]
     [InlineData("Modifier_DamagedGyro", "Damaged Gyro ({0} {1}): +{2}")]
     [InlineData("Modifier_HeavyDamage", "Heavy Damage ({0} points): +{1}")]
@@ -180,7 +180,7 @@ public class FakeLocalizationServiceTests
     [InlineData("Attack_OutOfRange", "Target out of range")]
     // Penalty messages
     [InlineData("Penalty_FootActuatorMovement", "{0} destroyed foot actuator(s) | -{1} MP")]
-    [InlineData("Penalty_HeatMovement", "Heat level {0} | -{1} MP")]
+    [InlineData("Penalty_HeatMovement", "Heat ({0}) MP Penalty | -{1} MP")]
     [InlineData("Penalty_EngineHeat", "Engine Heat Penalty ({0} hits): +{1} heat/turn")]
     [InlineData("Penalty_LowerLegActuatorMovement", "{0} destroyed lower leg actuator(s) | -{1} MP")]
     [InlineData("Penalty_UpperLegActuatorMovement", "{0} destroyed upper leg actuator(s) | -{1} MP")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unit Movement panel now auto-hides when the unit hasn’t moved, reducing on-screen clutter.
  - Improved layout spacing and padding in the Movement panel for clearer readability.

- Style
  - Updated heat-related localization strings for clearer wording (attack modifier and MP penalty).

- Tests
  - Adjusted test expectations to match updated localization strings.

- Chores
  - Bumped app version to 0.44.5-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->