### PR TITLE
sort available units by name and mass

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.44.7-alpha</Version>
+        <Version>0.44.8-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/AvailableUnitsTable.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/AvailableUnitsTable.axaml
@@ -41,13 +41,27 @@
                           ColumnDefinitions="2*,2*,*"
                           Background="{DynamicResource PrimaryBrush}"
                           Height="30">
-                        <TextBlock Grid.Column="0"
-                                   Text="Chassis"
-                                   Classes="label"
-                                   Foreground="White"
-                                   FontWeight="Bold"
-                                   VerticalAlignment="Center"
-                                   Margin="10,0"/>
+                        <!-- Chassis -->
+                        <Button Grid.Column="0"
+                                Command="{Binding SortByNameCommand}"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Left"
+                                Cursor="Hand">
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <TextBlock Text="Chassis"
+                                           Classes="label"
+                                           Foreground="White"
+                                           FontWeight="Bold"
+                                           VerticalAlignment="Center"/>
+                                <TextBlock Text="{Binding NameSortIndicator}"
+                                           Classes="label"
+                                           Foreground="White"
+                                           FontWeight="Bold"
+                                           VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                         <TextBlock Grid.Column="1"
                                    Text="Model"
                                    Classes="label"
@@ -55,13 +69,27 @@
                                    FontWeight="Bold"
                                    VerticalAlignment="Center"
                                    Margin="10,0"/>
-                        <TextBlock Grid.Column="2"
-                                   Text="Tonnage"
-                                   Classes="label"
-                                   Foreground="White"
-                                   FontWeight="Bold"
-                                   VerticalAlignment="Center"
-                                   Margin="10,0"/>
+                        <!-- Tonnage Column Header -->
+                        <Button Grid.Column="2"
+                                Command="{Binding SortByTonnageCommand}"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Left"
+                                Cursor="Hand">
+                            <StackPanel Orientation="Horizontal" Spacing="5">
+                                <TextBlock Text="Mass"
+                                           Classes="label"
+                                           Foreground="White"
+                                           FontWeight="Bold"
+                                           VerticalAlignment="Center"/>
+                                <TextBlock Text="{Binding TonnageSortIndicator}"
+                                           Classes="label"
+                                           Foreground="White"
+                                           FontWeight="Bold"
+                                           VerticalAlignment="Center"/>
+                            </StackPanel>
+                        </Button>
                     </Grid>
 
                     <!-- Table Content -->

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/AvailableUnitsTable.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/AvailableUnitsTable.axaml
@@ -47,8 +47,7 @@
                                 Background="Transparent"
                                 BorderThickness="0"
                                 HorizontalAlignment="Stretch"
-                                HorizontalContentAlignment="Left"
-                                Cursor="Hand">
+                                HorizontalContentAlignment="Left">
                             <StackPanel Orientation="Horizontal" Spacing="5">
                                 <TextBlock Text="Chassis"
                                            Classes="label"
@@ -75,8 +74,7 @@
                                 Background="Transparent"
                                 BorderThickness="0"
                                 HorizontalAlignment="Stretch"
-                                HorizontalContentAlignment="Left"
-                                Cursor="Hand">
+                                HorizontalContentAlignment="Left">
                             <StackPanel Orientation="Horizontal" Spacing="5">
                                 <TextBlock Text="Mass"
                                            Classes="label"

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/AvailableUnitsTableViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/AvailableUnitsTableViewModel.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.ObjectModel;
 using System.Windows.Input;
+using AsyncAwaitBestPractices.MVVM;
 using Sanet.MakaMek.Core.Data.Units;
 using Sanet.MVVM.Core.ViewModels;
 
 namespace Sanet.MakaMek.Presentation.ViewModels.Wrappers;
 
 /// <summary>
-/// ViewModel for the AvailableUnitsTable control, handling unit filtering and selection
+/// ViewModel for the AvailableUnitsTable control, handling unit filtering, sorting, and selection
 /// </summary>
 public class AvailableUnitsTableViewModel : BindableBase
 {
@@ -14,7 +15,15 @@ public class AvailableUnitsTableViewModel : BindableBase
     private UnitData? _selectedUnit;
     private WeightClass? _selectedWeightClassFilter; // Default is `all` so no filtering
     private bool _showAllClasses;
+    private SortColumn _currentSortColumn = SortColumn.Name;
+    private bool _isSortAscending = true;
     private const string FilterAllKey = "All";
+
+    private enum SortColumn
+    {
+        Name,
+        Tonnage
+    }
 
     public AvailableUnitsTableViewModel(
         IList<UnitData> availableUnits,
@@ -25,19 +34,24 @@ public class AvailableUnitsTableViewModel : BindableBase
 
         // Initialize with "All" filter selected
         _showAllClasses = true;
+
+        // Initialize sort commands
+        SortByNameCommand = new AsyncCommand(SortByName);
+        SortByTonnageCommand = new AsyncCommand(SortByTonnage);
     }
 
     /// <summary>
-    /// Gets the filtered list of available units based on the selected weight class filter
+    /// Gets the filtered and sorted list of available units based on the selected weight class filter and sort settings
     /// </summary>
     public IEnumerable<UnitData> FilteredAvailableUnits
     {
         get
         {
-            if (_showAllClasses)
-                return _availableUnits;
-            
-            return _availableUnits.Where(u => u.Mass.ToWeightClass() == _selectedWeightClassFilter);
+            var filtered = _showAllClasses
+                ? _availableUnits
+                : _availableUnits.Where(u => u.Mass.ToWeightClass() == _selectedWeightClassFilter);
+
+            return ApplySorting(filtered);
         }
     }
 
@@ -101,5 +115,90 @@ public class AvailableUnitsTableViewModel : BindableBase
     /// Command to add the selected unit
     /// </summary>
     public ICommand AddUnitCommand { get; }
+
+    /// <summary>
+    /// Command to sort by Name column
+    /// </summary>
+    public ICommand SortByNameCommand { get; }
+
+    /// <summary>
+    /// Command to sort by Tonnage column
+    /// </summary>
+    public ICommand SortByTonnageCommand { get; }
+
+    /// <summary>
+    /// Gets the sort indicator for the Name column (↓ for ascending, ↑ for descending, empty if not sorted)
+    /// </summary>
+    public string NameSortIndicator => _currentSortColumn == SortColumn.Name
+        ? (_isSortAscending ? "↓" : "↑")
+        : string.Empty;
+
+    /// <summary>
+    /// Gets the sort indicator for the Tonnage column (↓ for ascending, ↑ for descending, empty if not sorted)
+    /// </summary>
+    public string TonnageSortIndicator => _currentSortColumn == SortColumn.Tonnage
+        ? (_isSortAscending ? "↓" : "↑")
+        : string.Empty;
+
+    private Task SortByName()
+    {
+        if (_currentSortColumn == SortColumn.Name)
+        {
+            // Toggle sort order if already sorting by Name
+            _isSortAscending = !_isSortAscending;
+        }
+        else
+        {
+            // Switch to Name column with ascending order
+            _currentSortColumn = SortColumn.Name;
+            _isSortAscending = true;
+        }
+
+        RefreshSorting();
+        return Task.CompletedTask;
+    }
+
+    private Task SortByTonnage()
+    {
+        if (_currentSortColumn == SortColumn.Tonnage)
+        {
+            // Toggle sort order if already sorting by Tonnage
+            _isSortAscending = !_isSortAscending;
+        }
+        else
+        {
+            // Switch to Tonnage column with ascending order
+            _currentSortColumn = SortColumn.Tonnage;
+            _isSortAscending = true;
+        }
+
+        RefreshSorting();
+        return Task.CompletedTask;
+    }
+
+    private void RefreshSorting()
+    {
+        NotifyPropertyChanged(nameof(FilteredAvailableUnits));
+        NotifyPropertyChanged(nameof(NameSortIndicator));
+        NotifyPropertyChanged(nameof(TonnageSortIndicator));
+    }
+
+    private IEnumerable<UnitData> ApplySorting(IEnumerable<UnitData> units)
+    {
+        return _currentSortColumn switch
+        {
+            SortColumn.Name => _isSortAscending
+                ? units.OrderBy(u => u.Chassis)
+                    .ThenBy(u => u.Model)
+                : units.OrderByDescending(u => u.Chassis)
+                    .ThenByDescending(u => u.Model),
+            SortColumn.Tonnage => _isSortAscending
+                ? units.OrderBy(u => u.Mass)
+                    .ThenBy(u => u.Chassis)
+                : units.OrderByDescending(u => u.Mass)
+                    .ThenByDescending(u => u.Chassis),
+            _ => units
+        };
+    }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Available Units table now supports sorting. Click column headers for Chassis/Name and Mass to toggle ascending/descending order with visible indicators. Default view is sorted by name, and sorting persists when filters change.
- Chores
  - Version bumped to 0.44.8-alpha.
- Tests
  - Added comprehensive tests for sorting behavior, toggles, secondary sort rules, persistence across filtering, and indicator updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->