### PR TITLE
fix commands order

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.44.8-alpha</Version>
+        <Version>0.44.9-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
@@ -393,9 +393,9 @@ public class WeaponAttackResolutionPhase(ServerGame game) : GamePhase(game)
         Game.CommandPublisher.PublishCommand(command);
 
         // Calculate and send critical hits if any location received structure damage
-        if (resolution.HitLocationsData?.HitLocations is not null 
-            && resolution.HitLocationsData.HitLocations
-                .Any(h => h.Damage.Any(d => d.StructureDamage > 0)))
+        if (resolution.HitLocationsData?.HitLocations == null 
+            || resolution.HitLocationsData.HitLocations
+                .Any(h => !h.Damage.Any(d => d.StructureDamage > 0)))
         {
             ProcessConsciousnessRollsForUnit(target);
             return;

--- a/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
@@ -1,7 +1,6 @@
 using Sanet.MakaMek.Core.Data.Game;
 using Sanet.MakaMek.Core.Data.Game.Commands;
 using Sanet.MakaMek.Core.Data.Game.Commands.Server;
-using Sanet.MakaMek.Core.Data.Units.Components;
 using Sanet.MakaMek.Core.Models.Game.Players;
 using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
@@ -394,14 +393,16 @@ public class WeaponAttackResolutionPhase(ServerGame game) : GamePhase(game)
         Game.CommandPublisher.PublishCommand(command);
 
         // Calculate and send critical hits if any location received structure damage
-        if (resolution is not { IsHit: true, HitLocationsData.HitLocations.Count: > 0 })
+        if (resolution.HitLocationsData?.HitLocations is not null 
+            && resolution.HitLocationsData.HitLocations
+                .Any(h => h.Damage.Any(d => d.StructureDamage > 0)))
         {
             ProcessConsciousnessRollsForUnit(target);
             return;
         }
 
         var criticalHitsCommand = Game.CriticalHitsCalculator
-            .CalculateAndApplyCriticalHits(target, resolution.HitLocationsData.HitLocations
+            .CalculateAndApplyCriticalHits(target, (resolution.HitLocationsData?.HitLocations!) //nullability is checked above
                 .SelectMany(h => h.Damage).ToList());
         IEnumerable<ComponentHitData> allComponentHits = [];
         List<PartLocation> blownOffParts = [];

--- a/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/WeaponAttackResolutionPhase.cs
@@ -394,8 +394,8 @@ public class WeaponAttackResolutionPhase(ServerGame game) : GamePhase(game)
 
         // Calculate and send critical hits if any location received structure damage
         if (resolution.HitLocationsData?.HitLocations == null 
-            || resolution.HitLocationsData.HitLocations
-                .Any(h => !h.Damage.Any(d => d.StructureDamage > 0)))
+            || !resolution.HitLocationsData.HitLocations
+                .Any(h => h.Damage.Any(d => d.StructureDamage > 0)))
         {
             ProcessConsciousnessRollsForUnit(target);
             return;

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
@@ -1253,42 +1253,6 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
             "Test Cluster Weapon", damage, 3,
             0, 3, 6, 9,
             type, 10, clusters, clusterSize, 1, 1, MakaMekComponent.LRM10, ammoType));
-    
-    [Fact]
-    public void Enter_ShouldCallCriticalHitsCalculatorButNotPublishCommand_WhenOnlyArmorDamage()
-    {
-        // Arrange
-        SetMap();
-        SetupPlayer1WeaponTargets();
-        SetupDiceRolls(8, 9, 4); // Set up dice rolls to ensure hits
-
-        // Setup structure damage calculator to return only armor damage (no structure damage)
-        MockDamageTransferCalculator.CalculateStructureDamage(
-                Arg.Any<Unit>(),
-                Arg.Any<PartLocation>(),
-                Arg.Any<int>(),
-                Arg.Any<HitDirection>())
-            .Returns([new LocationDamageData(PartLocation.CenterTorso, 5, 0, false)]);
-
-        // Setup critical hits calculator to return null (no critical hits for armor-only damage)
-        MockCriticalHitsCalculator.CalculateAndApplyCriticalHits(
-                Arg.Any<Unit>(),
-                Arg.Any<List<LocationDamageData>>())
-            .Returns((CriticalHitsResolutionCommand?)null);
-
-        // Act
-        _sut.Enter();
-
-        // Assert
-        // Critical hits calculator should be called even for armor-only damage (the filter is inside)
-        MockCriticalHitsCalculator.Received().CalculateAndApplyCriticalHits(
-            Arg.Any<Unit>(),
-            Arg.Any<List<LocationDamageData>>());
-
-        // No critical hits command should be published when the calculator returns null
-        CommandPublisher.DidNotReceive().PublishCommand(
-            Arg.Any<CriticalHitsResolutionCommand>());
-    }
 
     [Fact]
     public void Enter_ShouldCallCriticalHitsCalculatorAndPublishCommand_WhenStructureDamageOccurs()
@@ -1511,6 +1475,103 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
             Arg.Is<CriticalHitsResolutionCommand>(cmd =>
                 cmd.TargetId == _player1Unit1.Id &&
                 cmd.GameOriginId == Game.Id ));
+    }
+
+    [Fact]
+    public void Enter_ShouldNotPublishCriticalHitsCommand_WhenNoStructureDamage()
+    {
+        // Arrange
+        SetMap();
+
+        // Setup a single weapon attack from player1 to player2
+        var weapon1 = new TestWeapon();
+        var part1 = _player1Unit1.Parts[0];
+        part1.TryAddComponent(weapon1).ShouldBeTrue();
+
+        var weaponTargets1 = new List<WeaponTargetData>
+        {
+            new()
+            {
+                Weapon = new ComponentData
+                {
+                    Name = weapon1.Name,
+                    Type = weapon1.ComponentType,
+                    Assignments = [
+                        new LocationSlotAssignment(part1.Location,
+                            weapon1.MountedAtFirstLocationSlots.First(),
+                            weapon1.MountedAtFirstLocationSlots.Length)
+                    ]
+                },
+                TargetId = _player2Unit1.Id,
+                IsPrimaryTarget = true
+            }
+        };
+        _player1Unit1.DeclareWeaponAttack(weaponTargets1);
+
+        // Setup ToHitCalculator
+        Game.ToHitCalculator.GetToHitNumber(
+                Arg.Any<Unit>(),
+                Arg.Any<Unit>(),
+                Arg.Any<Weapon>(),
+                Arg.Any<BattleMap>(),
+                Arg.Any<bool>(),
+                Arg.Any<PartLocation?>())
+            .Returns(7);
+
+        // Setup dice rolls: attack hits (8), hits head (12), but no structure damage
+        SetupDiceRolls(8, 12);
+
+        // Setup damage calculator to return only armor damage (no structure damage)
+        MockDamageTransferCalculator.CalculateStructureDamage(
+                Arg.Any<Unit>(),
+                Arg.Any<PartLocation>(),
+                Arg.Any<int>(),
+                Arg.Any<HitDirection>())
+            .Returns(callInfo => [new LocationDamageData(callInfo.Arg<PartLocation>(), callInfo.Arg<int>(), 0, false)]);
+        
+        // Setup consciousness calculator to return a consciousness roll command
+        var consciousnessCommand = new PilotConsciousnessRollCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            PilotId = _player2Unit1.Pilot!.Id,
+            UnitId = _player2Unit1.Id,
+            IsRecoveryAttempt = false,
+            ConsciousnessNumber = 3,
+            DiceResults = [5, 4],
+            IsSuccessful = true
+        };
+        MockConsciousnessCalculator.MakeConsciousnessRolls(_player2Unit1.Pilot!)
+            .Returns([consciousnessCommand]);
+        
+        // Capture all published commands in order
+        var publishedCommands = new List<IGameCommand>();
+        CommandPublisher.PublishCommand(Arg.Do<IGameCommand>(cmd => publishedCommands.Add(cmd)));
+        
+        // Act
+        _sut.Enter();
+
+        // Assert
+        publishedCommands.Count.ShouldBeGreaterThanOrEqualTo(2);
+
+        // Find the indices of the relevant commands
+        var weaponAttackIndex = publishedCommands.FindIndex(cmd =>
+            cmd is WeaponAttackResolutionCommand warc && warc.AttackerId == _player1Unit1.Id);
+        var consciousnessIndex = publishedCommands.FindIndex(cmd =>
+            cmd is PilotConsciousnessRollCommand pcrc && pcrc.UnitId == _player2Unit1.Id);
+
+        // Verify all commands were published
+        weaponAttackIndex.ShouldBeGreaterThanOrEqualTo(0, "WeaponAttackResolutionCommand should be published");
+        consciousnessIndex.ShouldBeGreaterThanOrEqualTo(0, "PilotConsciousnessRollCommand should be published");
+
+        // Verify the correct order: WeaponAttackResolution -> CriticalHitsResolution
+        weaponAttackIndex.ShouldBeLessThan(consciousnessIndex,
+            "WeaponAttackResolutionCommand should be published before PilotConsciousnessRollCommand");
+
+        // Verify that no critical hits command was published
+        CommandPublisher.DidNotReceive().PublishCommand(
+            Arg.Is<CriticalHitsResolutionCommand>(cmd => 
+                cmd.TargetId == _player2Unit1.Id &&
+                cmd.GameOriginId == Game.Id));
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
@@ -1543,14 +1543,15 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
         MockConsciousnessCalculator.MakeConsciousnessRolls(_player2Unit1.Pilot!)
             .Returns([consciousnessCommand]);
         
-        // Capture all published commands in order
-        var publishedCommands = new List<IGameCommand>();
-        CommandPublisher.PublishCommand(Arg.Do<IGameCommand>(cmd => publishedCommands.Add(cmd)));
-        
         // Act
         _sut.Enter();
 
         // Assert
+        var publishedCommands = CommandPublisher.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == "PublishCommand")
+            .Select(call => (IGameCommand)call.GetArguments()[0]!)
+            .ToList();
+        
         publishedCommands.Count.ShouldBeGreaterThanOrEqualTo(2);
 
         // Find the indices of the relevant commands
@@ -1664,14 +1665,15 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
         MockConsciousnessCalculator.MakeConsciousnessRolls(_player2Unit1.Pilot!)
             .Returns([consciousnessCommand]);
 
-        // Capture all published commands in order
-        var publishedCommands = new List<IGameCommand>();
-        CommandPublisher.PublishCommand(Arg.Do<IGameCommand>(cmd => publishedCommands.Add(cmd)));
-
         // Act
         _sut.Enter();
 
         // Assert
+        var publishedCommands = CommandPublisher.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == "PublishCommand")
+            .Select(call => (IGameCommand)call.GetArguments()[0]!)
+            .ToList();
+        
         // Verify we have at least 3 commands published
         publishedCommands.Count.ShouldBeGreaterThanOrEqualTo(3);
 

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/WeaponAttackResolutionPhaseTests.cs
@@ -1564,7 +1564,7 @@ public class WeaponAttackResolutionPhaseTests : GamePhaseTestsBase
         weaponAttackIndex.ShouldBeGreaterThanOrEqualTo(0, "WeaponAttackResolutionCommand should be published");
         consciousnessIndex.ShouldBeGreaterThanOrEqualTo(0, "PilotConsciousnessRollCommand should be published");
 
-        // Verify the correct order: WeaponAttackResolution -> CriticalHitsResolution
+        // Verify the correct order: WeaponAttackResolution -> PilotConsciousnessRoll (no CriticalHitsResolution when no structure damage)
         weaponAttackIndex.ShouldBeLessThan(consciousnessIndex,
             "WeaponAttackResolutionCommand should be published before PilotConsciousnessRollCommand");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Pilot consciousness checks now occur only when structure damage exists and are applied after critical hits and component blows, improving accuracy and event ordering.
  - Critical-hit handling skipped for armor-only damage.
  - Fall resolution refined: applies prone state, triggers PSR when limbs are blown off, and ensures correct sequencing.
  - More robust handling of missing hit-location data.

- Tests
  - Expanded coverage for command ordering, structure vs. armor damage, falls, cluster interactions, and consciousness roll counts.

- Chores
  - Version bumped to 0.44.9-alpha.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->