### PR TITLE
remote players fixes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.45.3-alpha</Version>
+        <Version>0.45.4-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Game/Players/Player.cs
+++ b/src/MakaMek.Core/Models/Game/Players/Player.cs
@@ -5,13 +5,13 @@ namespace Sanet.MakaMek.Core.Models.Game.Players;
 
 public class Player(Guid id, string name, string tint = "#ffffff") : IPlayer
 {
-    public Player(PlayerData data) : this(data.Id, data.Name, data.Tint)
+    public Player(PlayerData data, Guid? idOverride = null) : this(idOverride ?? data.Id, data.Name, data.Tint)
     {
     }
     
     private readonly List<Unit> _units = [];
     
-    public Guid Id { get; set; } = id;
+    public Guid Id { get; } = id;
     public string Name { get; set; } = name;
     public string Tint { get; } = tint;
     public IReadOnlyList<Unit> Units => _units;

--- a/src/MakaMek.Core/Models/Game/Players/Player.cs
+++ b/src/MakaMek.Core/Models/Game/Players/Player.cs
@@ -11,7 +11,7 @@ public class Player(Guid id, string name, string tint = "#ffffff") : IPlayer
     
     private readonly List<Unit> _units = [];
     
-    public Guid Id { get; } = id;
+    public Guid Id { get; set; } = id;
     public string Name { get; set; } = name;
     public string Tint { get; } = tint;
     public IReadOnlyList<Unit> Units => _units;

--- a/src/MakaMek.Presentation/ViewModels/JoinGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/JoinGameViewModel.cs
@@ -71,7 +71,7 @@ public class JoinGameViewModel : NewGameViewModel
                 var existingPlayerVm = _players.FirstOrDefault(p => p.Player.Id == joinCmd.PlayerId);
                 if (existingPlayerVm == null) // Add if it's a new remote player
                 {
-                     var newRemotePlayer = new Player(joinCmd.PlayerId, joinCmd.PlayerName, joinCmd.PlayerId.ToString()); // Use PlayerId as tilt for now
+                     var newRemotePlayer = new Player(joinCmd.PlayerId, joinCmd.PlayerName, joinCmd.Tint); 
                      var remotePlayerViewModel = new PlayerViewModel(
                         newRemotePlayer,
                         isLocalPlayer: false,

--- a/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
@@ -87,9 +87,6 @@ public abstract class NewGameViewModel : BaseViewModel
     protected void PublishJoinCommand(PlayerViewModel playerVm)
     {
         if (!playerVm.IsLocalPlayer || !CanPublishCommands || _localGame == null) return;
-
-        // ensure every player that joins has a unique id for the game
-        playerVm.Player.Id = Guid.NewGuid();
         
         // Create pilot assignments for each unit
         var pilotAssignments = playerVm.Units.Select(unit => new PilotAssignmentData
@@ -182,7 +179,7 @@ public abstract class NewGameViewModel : BaseViewModel
         playerData ??= PlayerData.CreateDefault() with { Tint = GetNextTint() };
 
         // Create Local Player Object
-        var newPlayer = new Player(playerData.Value);
+        var newPlayer = new Player(playerData.Value, Guid.NewGuid());
 
         // Create Local ViewModel Wrapper with customizable callbacks
         var playerViewModel = CreatePlayerViewModel(newPlayer, isDefaultPlayer);

--- a/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
@@ -88,6 +88,9 @@ public abstract class NewGameViewModel : BaseViewModel
     {
         if (!playerVm.IsLocalPlayer || !CanPublishCommands || _localGame == null) return;
 
+        // ensure every player that joins has a unique id for the game
+        playerVm.Player.Id = Guid.NewGuid();
+        
         // Create pilot assignments for each unit
         var pilotAssignments = playerVm.Units.Select(unit => new PilotAssignmentData
         {

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/PlayerViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/PlayerViewModel.cs
@@ -30,7 +30,7 @@ public class PlayerViewModel : BindableBase
     /// <summary>
     /// Indicates whether this player can be removed from the game setup
     /// </summary>
-    public bool IsRemovable => !_isDefaultPlayer && Status == PlayerStatus.NotJoined;
+    public bool IsRemovable => !_isDefaultPlayer && IsLocalPlayer && Status == PlayerStatus.NotJoined;
 
     public PlayerStatus Status => Player.Status;
 

--- a/tests/MakaMek.Core.Tests/Models/Game/Players/PlayerTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Players/PlayerTests.cs
@@ -95,6 +95,25 @@ public class PlayerTests
         player.Units.ShouldBeEmpty();
         player.CanAct.ShouldBeFalse();
     }
+    
+    [Fact]
+    public void Constructor_WithPlayerDataAndIdOverride_ShouldUseOverrideForId()
+    {
+        // Arrange
+        var playerData = new PlayerData
+        {
+            Id = Guid.NewGuid(),
+            Name = "Test Player From Data",
+            Tint = "#00FF00"
+        };
+        var idOverride = Guid.NewGuid();
+        
+        // Act
+        var player = new Player(playerData, idOverride);
+        
+        // Assert
+        player.Id.ShouldBe(idOverride);
+    }
 
     [Fact]
     public void AddUnit_ShouldAddUnitToCollection()

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PlayerViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PlayerViewModelTests.cs
@@ -796,6 +796,19 @@ public class PlayerViewModelTests
         // Assert
         isRemovable.ShouldBe(expected);
     }
+    
+    [Fact]
+    public void IsRemovable_ShouldBeFalse_WhenIsRemotePlayer()
+    {
+        // Arrange
+        var sut = new PlayerViewModel(new Player(Guid.NewGuid(), "Player1"), false);
+
+        // Act
+        var isRemovable = sut.IsRemovable;
+
+        // Assert
+        isRemovable.ShouldBeFalse();
+    }
 
     [Fact]
     public void RefreshStatus_ShouldNotifyCanRemoveUnitPropertyChanged()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote players now use the correct tint when joining.
  * Remote players can no longer be removed; only local, non-default, not-joined players are removable.
  * Each player now receives a unique ID on creation to improve multiplayer reliability.

* **Tests**
  * Added test to confirm remote players are not removable.

* **Chores**
  * Bumped app version to 0.45.4-alpha.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->