### PR TITLE
add panel with available movement points

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.45.10-alpha</Version>
+        <Version>0.45.11-alpha</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitMovementInfoPanel.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitMovementInfoPanel.axaml
@@ -7,34 +7,74 @@
              x:DataType="units:Unit"
              x:Class="Sanet.MakaMek.Avalonia.Controls.UnitMovementInfoPanel"
              mc:Ignorable="d"
-             IsVisible="{Binding HasMoved}">
+             >
     <UserControl.Resources>
         <converters:CollectionToVisibilityConverter x:Key="CollectionToVisibilityConverter"/>
         <converters:ModifierToTextConverter x:Key="ModifierToTextConverter"/>
     </UserControl.Resources>
-    <StackPanel Spacing="5" Orientation="Vertical">
-        <Border Background="{StaticResource OverlayTransparentBrush}"
-            CornerRadius="4"
-            Padding="5"
-            >
-            <Grid ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto">
+    <StackPanel  Spacing="5" Orientation="Vertical">
+        <Border
+            IsVisible="{Binding !HasMoved}"
+            Classes="card"
+        >
+            <Grid
+                ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto,Auto">
                 <TextBlock Grid.Row="0" Grid.Column="0"
+                           Classes="labelLarge"
+                           Text="Walk MP"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Grid.Row="0" Grid.Column="1"
+                           Classes="labelLarge"
+                           Text="Run MP"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Grid.Row="0" Grid.Column="2"
+                           Classes="labelLarge"
+                           Text="Jump MP"
+                           HorizontalAlignment="Center"/>
+
+                <TextBlock Grid.Row="1" Grid.Column="0"
+                           Text="{Binding AvailableWalkingPoints}"
+                           Classes="label"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Grid.Row="1" Grid.Column="1"
+                           Classes="label"
+                           Text="{Binding AvailableRunningPoints}"
+                           HorizontalAlignment="Center"/>
+                <TextBlock Grid.Row="1" Grid.Column="2"
+                           Classes="label"
+                           Text="{Binding AvailableJumpingPoints}"
+                           HorizontalAlignment="Center"/>
+            </Grid>
+        </Border>
+        <Border
+            IsVisible="{Binding HasMoved}"
+            Classes="card"
+        >
+            <Grid
+                ColumnDefinitions="*,*,*" RowDefinitions="Auto,Auto">
+                <TextBlock Grid.Row="0" Grid.Column="0"
+                           Classes="labelLarge"
                          Text="Type"
                          HorizontalAlignment="Center"/>
                 <TextBlock Grid.Row="0" Grid.Column="1"
+                           Classes="labelLarge"
                          Text="Points"
                          HorizontalAlignment="Center"/>
                 <TextBlock Grid.Row="0" Grid.Column="2"
+                           Classes="labelLarge"
                          Text="Distance"
                          HorizontalAlignment="Center"/>
 
                 <TextBlock Grid.Row="1" Grid.Column="0"
+                         Classes="label"
                          Text="{Binding MovementTypeUsed}"
                          HorizontalAlignment="Center"/>
                 <TextBlock Grid.Row="1" Grid.Column="1"
+                         Classes="label"
                          Text="{Binding MovementPointsSpent}"
                          HorizontalAlignment="Center"/>
                 <TextBlock Grid.Row="1" Grid.Column="2"
+                         Classes="label"
                          Text="{Binding DistanceCovered}"
                          HorizontalAlignment="Center"/>
             </Grid>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/WeaponSelectionPanel.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/WeaponSelectionPanel.axaml
@@ -61,7 +61,7 @@
                                     IsEnabled="{Binding IsEnabled}"
                                     Margin="0,0,10,0"/>
                                 
-                                <TextBlock Grid.Column="2" Text="{Binding Name}"
+                                <TextBlock Grid.Row="0" Grid.Column="2" Text="{Binding Name}"
                                           FontWeight="Bold"/>
                                 <StackPanel
                                     Grid.Column="2"

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/BattleMapView.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/BattleMapView.axaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:controls="clr-namespace:Sanet.MakaMek.Avalonia.Controls"
              xmlns:templatedControls="clr-namespace:Sanet.MakaMek.Avalonia.Views.TemplatedControls"
-             xmlns:converters="clr-namespace:Sanet.MakaMek.Avalonia.Converters"
              xmlns:behaviors="clr-namespace:Sanet.MakaMek.Avalonia.Behaviors"
              xmlns:viewModels1="clr-namespace:Sanet.MakaMek.Presentation.ViewModels;assembly=Sanet.MakaMek.Presentation"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -12,8 +11,6 @@
              x:CompileBindings="True"
              x:DataType="viewModels1:BattleMapViewModel">
     <UserControl.Resources>
-        <converters:HitProbabilityColorConverter x:Key="HitProbabilityColorConverter"/>
-        <converters:StringNotEmptyToBoolConverter x:Key="StringNotEmptyToBoolConverter"/>
     </UserControl.Resources>
     <Grid>
         <Canvas x:Name="MapCanvas" 

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -142,6 +142,11 @@ public abstract class Unit
     {
         return ModifiedMovement;
     }
+    
+    // Could be moved to ViewModel as those are presentation only
+    public int AvailableWalkingPoints => GetMovementPoints(MovementType.Walk);
+    public int AvailableRunningPoints => GetMovementPoints(MovementType.Run);
+    public int AvailableJumpingPoints => GetMovementPoints(MovementType.Jump);
 
     /// <summary>
     /// Determines if the unit can move backward with the given movement type

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -630,6 +630,10 @@ public class MechTests
         walkingMp.ShouldBe(walkMp, "walking MP should match the base movement");
         runningMp.ShouldBe(runMp, "running MP should be 1.5x walking");
         jumpingMp.ShouldBe(jumpMp, "jumping MP should match the number of jump jets");
+        
+        mech.AvailableWalkingPoints.ShouldBe(walkingMp);
+        mech.AvailableRunningPoints.ShouldBe(runningMp);
+        mech.AvailableJumpingPoints.ShouldBe(jumpingMp);
     }
 
     [Theory]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Movement panel now shows distinct views for units that haven’t moved (available walk/run/jump points) vs. units that have moved (type, points spent, distance). Includes a Movement Modifiers section.
  - Exposed read-only movement point values for walking, running, and jumping.

- Style
  - Adjusted weapon selection layout for correct header placement.

- Refactor
  - Removed unused converters/resources from the battle map view.

- Tests
  - Added assertions for newly exposed movement point values.

- Chores
  - Bumped app version to 0.45.11-alpha.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->