### PR TITLE
sign windows app

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -61,7 +61,7 @@ jobs:
             --icon $GITHUB_WORKSPACE/src/MakaMek.Avalonia/MakaMek.Avalonia/Assets/avalonia-logo.ico \
             --mainExe MakaMek.exe \
             --signParallel 12 \
-            --signTemplate "jsign --certfile $GITHUB_WORKSPACE/certs/sign.crt --keyfile $GITHUB_WORKSPACE/certs/sign.key --tsaurl https://timestamp.digicert.com --name MakaMek --url https://makamek.nl {{file}}"
+            --signTemplate "jsign --certfile $GITHUB_WORKSPACE/certs/sign.crt --keyfile $GITHUB_WORKSPACE/certs/sign.key --tsaurl http://timestamp.digicert.com --name MakaMek --url https://makamek.nl {{file}}"
 
       # For tagged releases only
       - name: Create Release


### PR DESCRIPTION
with self-signed cert for now

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI build moved to a Linux-based runner to improve Windows packaging.
  * Version extraction switched to a bash-based step.
  * Automated signing of Windows executables and libraries added, with certificate setup and cleanup.
  * Installer creation integrated into the workflow; installer artifact uploaded with 90-day retention.
  * Packaging identifier updated to nl.sanetby.makamek and output paths adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->