### PR TITLE
fix: set map size correctly when creatigg from data

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.47.13</Version>
+        <Version>0.47.14</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Map/Factory/BattleMapFactory.cs
+++ b/src/MakaMek.Core/Models/Map/Factory/BattleMapFactory.cs
@@ -35,8 +35,8 @@ public class BattleMapFactory : IBattleMapFactory
     public BattleMap CreateFromData(IList<HexData> hexData)
     {
         var map = new BattleMap(
-            hexData.Max(h => h.Coordinates.Q) + 1,
-            hexData.Max(h => h.Coordinates.R) + 1);
+            hexData.Max(h => h.Coordinates.Q),
+            hexData.Max(h => h.Coordinates.R));
         
         foreach (var hex in hexData)
         {

--- a/tests/MakaMek.Core.Tests/Models/Map/BattleMapExtensionsTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Map/BattleMapExtensionsTests.cs
@@ -35,6 +35,7 @@ public class BattleMapExtensionsTests
     [InlineData(3, 3, false)]  // Center (not edge)
     [InlineData(2, 2, false)]  // Interior (not edge)
     [InlineData(4, 4, false)]  // Interior (not edge)
+    [InlineData(6, 3, false)]  // Out of bounds (not edge)
     public void GetEdgeHexCoordinates_ShouldIncludeOnlyEdgeHexes(int q, int r, bool shouldBeIncluded)
     {
         // Arrange


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected hexagonal map initialization to accurately calculate boundaries using exact coordinate values, eliminating previously applied padding offsets that could cause incorrect map sizing.

* **Tests**
  * Enhanced test coverage for boundary validation, ensuring out-of-bounds coordinates are correctly identified and excluded from edge hex detection.

* **Chores**
  * Version updated to 0.47.14.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->