### PR TITLE
feat: make cloud openai a default llm provider

### DIFF
--- a/src/MakaMek.Tools/BotAgent/appsettings.json
+++ b/src/MakaMek.Tools/BotAgent/appsettings.json
@@ -8,8 +8,8 @@
   },
   "AllowedHosts": "*",
   "LlmProvider": {
-    "Type": "LocalOpenAI",
-    "Model": "qwen/qwen3-vl-8b",
+    "Type": "OpenAI",
+    "Model": "gpt-5-mini",
     "Timeout": 30000,
     "ApiKey": "",
     "Endpoint": "http://localhost:1234/v1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the AI model provider configuration to use OpenAI's cloud-based service with the gpt-5-mini model instead of the previously configured locally hosted model. Endpoint and timeout settings remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->