### PR TITLE
prevent map selector view from horizontal scrolling

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.54.0</Version>
+        <Version>0.54.1</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/StartNewGameViewNarrow.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/StartNewGameViewNarrow.axaml
@@ -21,7 +21,8 @@
                 <fragments1:PlayersFragment/>
             </TabItem>
             <TabItem Header="Map">
-                <ScrollViewer Classes="gameScrollViewer">
+                <ScrollViewer Classes="gameScrollViewer"
+                              HorizontalScrollBarVisibility="Disabled">
                     <fragments1:MapConfigFragment DataContext="{Binding MapConfig}"/>
                 </ScrollViewer>
             </TabItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted horizontal scrollbar display in the Map tab of the Start New Game screen.

**Version:** 0.54.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->