### PR TITLE
lock movement type after fall

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.56.12</Version>
+        <Version>0.56.13</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -272,6 +272,47 @@ public class MovementState : IUiState
             if (_selectedUnit is Mech { IsProne: true } mech
                 && _viewModel.Game is not null)
             {
+                // Post-fall: _selectedPath being non-null means the unit was already moving when it fell.
+                // Lock the standup to the originally declared movement type — no Stay Prone,
+                // no alternate type, no facing change.
+                if (_selectedPath != null)
+                {
+                    var lockedType = _selectedPath.MovementType;
+                    var lockedProneActions = new List<StateAction>();
+
+                    if (!mech.CanStandup()) return lockedProneActions;
+
+                    var lockedPsrBreakdown = _viewModel.Game.PilotingSkillCalculator.GetPsrBreakdown(
+                        mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt));
+                    var lockedSuccessProbability =
+                        Core.Utils.DiceUtils.Calculate2d6Probability(lockedPsrBreakdown.ModifiedPilotingSkill);
+                    var lockedProbabilityText = $" ({lockedSuccessProbability:0}%)";
+
+                    if (mech.IsMinimumMovement)
+                    {
+                        lockedProneActions.Add(new StateAction(
+                            _viewModel.LocalizationService.GetString("Action_AttemptStandup") + lockedProbabilityText,
+                            true,
+                            () => AttemptStandup(lockedType)));
+                    }
+                    else
+                    {
+                        var lockedTypeKey = lockedType == MovementType.Run ? "MovementType_Run" : "MovementType_Walk";
+                        var lockedActionText = string.Format(
+                            _viewModel.LocalizationService.GetString("Action_MovementPoints"),
+                            _viewModel.LocalizationService.GetString(lockedTypeKey),
+                            _selectedUnit.GetMovementPoints(lockedType)) + lockedProbabilityText;
+
+                        lockedProneActions.Add(new StateAction(
+                            lockedActionText,
+                            true,
+                            () => AttemptStandup(lockedType)));
+                    }
+
+                    return lockedProneActions;
+                }
+
+                // Start-of-phase prone: full choice available.
                 var proneActions = new List<StateAction>
                 {
                     // Add stay prone action (equivalent to standing still for prone mechs)

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -1844,4 +1844,71 @@ public class MovementStateTests
         // Assert
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
     }
+
+    [Theory]
+    [InlineData(MovementType.Walk)]
+    [InlineData(MovementType.Run)]
+    public void GetAvailableActions_PostFallProneMech_OnlyShowsLockedMovementTypeStandupOption(MovementType selectedBeforeFall)
+    {
+        // Arrange
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top));
+        _pilotingSkillCalculator.GetPsrBreakdown(mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        // Simulate: player selected a movement type before the fall — _selectedPath gets set
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(selectedBeforeFall);
+
+        // Unit falls during movement resolution
+        mech.SetProne();
+
+        // Game calls ResumeMovementAfterFall, transitioning back to SelectingMovementTypeStep
+        _sut.ResumeMovementAfterFall();
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
+
+        // Act
+        var actions = _sut.GetAvailableActions().ToList();
+
+        // Assert — exactly one action locked to the originally declared movement type
+        actions.Count.ShouldBe(1, "Post-fall should only offer the single locked standup option");
+
+        var expectedTypeLabel = selectedBeforeFall == MovementType.Run ? "Run" : "Walk";
+        actions[0].Label.ShouldContain(expectedTypeLabel);
+
+        actions.ShouldNotContain(a => a.Label.Contains("Stay Prone"));
+        actions.ShouldNotContain(a => a.Label.Contains("Change Facing"));
+
+        var otherTypeLabel = selectedBeforeFall == MovementType.Run ? "Walk" : "Run";
+        actions.ShouldNotContain(a => a.Label.Contains(otherTypeLabel));
+    }
+
+    [Fact]
+    public void GetAvailableActions_PostFallProneMech_LockedStandupAction_TransitionsToStandingUpDirectionStep()
+    {
+        // Arrange
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top));
+        _pilotingSkillCalculator.GetPsrBreakdown(mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech.SetProne();
+        _sut.ResumeMovementAfterFall();
+
+        var actions = _sut.GetAvailableActions().ToList();
+        actions.Count.ShouldBe(1);
+
+        // Act — execute the locked standup action
+        actions[0].OnExecute();
+
+        // Assert — should transition to direction selection for standup
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingStandingUpDirection);
+        _battleMapViewModel.IsDirectionSelectorVisible.ShouldBeTrue();
+    }
 }

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -1911,4 +1911,41 @@ public class MovementStateTests
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingStandingUpDirection);
         _battleMapViewModel.IsDirectionSelectorVisible.ShouldBeTrue();
     }
+
+    [Fact]
+    public void GetAvailableActions_PostFallProneMech_MinimumMovement_ShowsAttemptStandupLabel()
+    {
+        // Arrange — mech with a destroyed leg has IsMinimumMovement = true (1 MP walk, prone, no standup attempts yet)
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top));
+
+        // Destroy one leg to reduce walk MPs to 1
+        var leg = mech.Parts[PartLocation.LeftLeg];
+        leg.ApplyDamage(20, HitDirection.Front);
+
+        // SetProne before checking IsMinimumMovement — the property requires IsProne == true
+        mech.SetProne();
+        mech.IsMinimumMovement.ShouldBeTrue();
+
+        _pilotingSkillCalculator.GetPsrBreakdown(mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        // Simulate fall during movement: select unit, pick Walk (sets _selectedPath), then unit already fell
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk); // sets _selectedPath with Walk type
+        _sut.ResumeMovementAfterFall();
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
+
+        // Act
+        var actions = _sut.GetAvailableActions().ToList();
+
+        // Assert — exactly one action using the "Attempt Standup" label (not the "Walk | MP: X" form)
+        actions.Count.ShouldBe(1);
+        actions[0].Label.ShouldStartWith("Attempt Standup");
+        actions[0].Label.ShouldContain("%"); // probability appended
+        actions[0].Label.ShouldNotContain("Walk | MP:");
+    }
 }
+

--- a/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
@@ -2132,9 +2132,10 @@ public class BattleMapViewModelTests
         // Assert
         _localizationService.GetString("Action_StayProne").Returns("StayProne");
 
-        // Verify that we have the "StayProne" action, which signifies we are handling a prone unit in SelectingMovementTypeStep
-        var actions = movementState.GetAvailableActions();
-        actions.ShouldContain(a => a.Label.Contains("StayProne"));
+        // Verify that there is only one option to continue movement
+        var actions = movementState.GetAvailableActions().ToList();
+        actions.Count.ShouldBe(1);
+        actions.ShouldContain(a => a.Label.Contains("Walk"));
     }
 
     [Fact]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When a prone mech attempts to stand after falling, the UI now displays the standup success probability and restricts movement options to the type originally selected before the fall.

* **Tests**
  * Expanded test coverage for post-fall prone state behavior, including standup action constraints and UI state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->