### PR TITLE
calculate levels when falling after jump in the water

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.56.16</Version>
+        <Version>0.56.17</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
@@ -7,6 +7,7 @@ using Sanet.MakaMek.Core.Models.Game.Rules;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
+using Sanet.MakaMek.Map.Models;
 
 namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Mechs.Falling;
 
@@ -84,8 +85,8 @@ public class FallProcessor : IFallProcessor
             .Select(f => f.ToMechFallCommand());
     }
 
-    public FallContextData ProcessMovementAttempt(Mech mech, PilotingSkillRollContext rollContext, IGame game)
-        => ProcessRollContexts([rollContext], mech, game).First();
+    public FallContextData ProcessMovementAttempt(Mech mech, PilotingSkillRollContext rollContext, IGame game, MovementType movementType)
+        => ProcessRollContexts([rollContext], mech, game, movementType).First();
 
     /// <summary>
     /// Core processing loop: evaluates each roll context in order (auto-falls first),
@@ -94,7 +95,8 @@ public class FallProcessor : IFallProcessor
     private IEnumerable<FallContextData> ProcessRollContexts(
         List<PilotingSkillRollContext> rollContexts,
         Mech mech,
-        IGame game)
+        IGame game,
+        MovementType movementType = MovementType.StandingStill)
     {
         if (rollContexts.Count == 0)
             return [];
@@ -123,16 +125,28 @@ public class FallProcessor : IFallProcessor
 
             PilotingSkillRollData? pilotDamagePsr = null;
 
+            // Determine levels fallen based on context and movement type
+            var levelsFallen = 0;
+            var wasJumping = movementType == MovementType.Jump;
+
             if (isFallingNow)
             {
-                var pilotDamageContext = new PilotDamageFromFallRollContext(LevelsFallen: 0);
+                // WaterTerrain.Height stores depth as negative integers (0 = shallow, -1 = depth 1, -2 = depth 2).
+                // EnteringDeepWaterRollContext.WaterDepth is already the positive depth value (-1 * water.Height).
+                // For water entry falls while jumping, levelsFallen = WaterDepth.
+                if (context is EnteringDeepWaterRollContext waterCtx && wasJumping)
+                {
+                    levelsFallen = waterCtx.WaterDepth;
+                }
+
+                var pilotDamageContext = new PilotDamageFromFallRollContext(levelsFallen);
                 var pilotPsrBreakdown = _pilotingSkillCalculator.GetPsrBreakdown(mech, pilotDamageContext, game);
 
                 pilotDamagePsr = _pilotingSkillCalculator.EvaluateRoll(pilotPsrBreakdown, mech, pilotDamageContext);
             }
 
             var fallingDamageData = isFallingNow
-                ? _fallingDamageCalculator.CalculateFallingDamage(mech, 0, false)
+                ? _fallingDamageCalculator.CalculateFallingDamage(mech, levelsFallen, wasJumping)
                 : null;
 
             var fallContextData = new FallContextData
@@ -143,8 +157,8 @@ public class FallProcessor : IFallProcessor
                 PilotingSkillRoll = fallPsrData,
                 PilotDamagePilotingSkillRoll = pilotDamagePsr,
                 FallingDamageData = fallingDamageData,
-                LevelsFallen = 0,
-                WasJumping = false
+                LevelsFallen = levelsFallen,
+                WasJumping = wasJumping
             };
 
             results.Add(fallContextData);

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallProcessor.cs
@@ -4,6 +4,7 @@ using Sanet.MakaMek.Core.Data.Game.Mechanics;
 using Sanet.MakaMek.Core.Data.Game.Mechanics.PilotingSkillRollContexts;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
+using Sanet.MakaMek.Map.Models;
 
 namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Mechs.Falling;
 
@@ -31,6 +32,7 @@ public interface IFallProcessor
     /// <param name="mech">The mech performing the movement attempt</param>
     /// <param name="rollContext">The PSR context for this movement attempt</param>
     /// <param name="game">The game instance</param>
+    /// <param name="movementType">The type of movement being attempted</param>
     /// <returns>FallContextData containing the result of the movement attempt</returns>
-    FallContextData ProcessMovementAttempt(Mech mech, PilotingSkillRollContext rollContext, IGame game);
+    FallContextData ProcessMovementAttempt(Mech mech, PilotingSkillRollContext rollContext, IGame game, MovementType movementType);
 }

--- a/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
@@ -66,7 +66,7 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
             foreach (var entry in waterEntries)
             {
                 var fallContextData = Game.FallProcessor.ProcessMovementAttempt(
-                    unit, new EnteringDeepWaterRollContext(entry.WaterDepth), Game);
+                    unit, new EnteringDeepWaterRollContext(entry.WaterDepth), Game, moveCommand.MovementType);
                     
                 if (fallContextData.IsFalling)
                 {
@@ -107,7 +107,7 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
                 if (destHex?.GetTerrain(MakaMekTerrains.Water) is WaterTerrain { Height: <= -1 } water)
                 {
                     var fallContextData = Game.FallProcessor.ProcessMovementAttempt(
-                        unit, new EnteringDeepWaterRollContext(-1*water.Height), Game);
+                        unit, new EnteringDeepWaterRollContext(-1*water.Height), Game, MovementType.Jump);
                     if (fallContextData.IsFalling)
                     {
                         var fallCommand = fallContextData.ToMechFallCommand();
@@ -146,7 +146,7 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
 
         // Use the FallProcessor to process the standup attempt and get context data
         var fallContextData = Game.FallProcessor.ProcessMovementAttempt(
-            unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game);
+            unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game, MovementType.StandingStill);
         
         // Create and publish the appropriate command based on the result
         if (fallContextData.IsFalling)
@@ -170,7 +170,7 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
         // Use the FallProcessor to process the jump attempt with damaged gyro
         if (unit is not Mech mech) return false;
         var fallContextData = Game.FallProcessor.ProcessMovementAttempt(
-            mech, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game);
+            mech, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game, MovementType.Jump);
         
         if (!fallContextData.IsFalling)
         {

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -946,7 +946,7 @@ public class FallProcessorTests
         SetupRollResult(true, PilotingSkillRollType.StandupAttempt);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), _game);
+        var result = _sut.ProcessMovementAttempt(_testMech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), _game, MovementType.StandingStill);
 
         // Assert
         result.ShouldNotBeNull();
@@ -987,7 +987,7 @@ public class FallProcessorTests
         SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), _game);
+        var result = _sut.ProcessMovementAttempt(_testMech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), _game, MovementType.StandingStill);
 
         // Assert
         result.ShouldNotBeNull();
@@ -1016,6 +1016,172 @@ public class FallProcessorTests
             Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
     }
 
+    [Fact]
+    public void ProcessWaterEntry_ShouldSetLevelsFallenToWaterDepth_WhenJumpingIntoDeepWaterAndFalling()
+    {
+        // Arrange - WaterDepth: 1, Jump movement
+        SetupWaterEntryPsrFor(1, 1, "Water Depth");
+        SetupPsrFor(PilotingSkillRollType.PilotDamageFromFall, 0, "Pilot taking damage from fall");
+
+        SetupRollResult(false, PilotingSkillRollType.WaterEntry);
+        SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
+
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(_testMech, 1, true)
+            .Returns(fallingDamageData);
+
+        // Act
+        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(1), _game, MovementType.Jump);
+
+        // Assert
+        result.IsFalling.ShouldBeTrue();
+        result.LevelsFallen.ShouldBe(1);
+        result.WasJumping.ShouldBeTrue();
+        result.FallingDamageData.ShouldBe(fallingDamageData);
+        result.PilotDamagePilotingSkillRoll.ShouldNotBeNull();
+        result.PilotDamagePilotingSkillRoll!.RollContext.RollType.ShouldBe(PilotingSkillRollType.PilotDamageFromFall);
+        ((PilotDamageFromFallRollContext)result.PilotDamagePilotingSkillRoll.RollContext).LevelsFallen.ShouldBe(1);
+
+        // Verify FallingDamageCalculator received correct levelsFallen and wasJumping
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 1, true);
+    }
+
+    [Fact]
+    public void ProcessWaterEntry_ShouldSetLevelsFallenToZero_WhenWalkingIntoDeepWaterAndFalling()
+    {
+        // Arrange - WaterDepth: 1, Walk movement
+        SetupWaterEntryPsrFor(1, 1, "Water Depth");
+        SetupPsrFor(PilotingSkillRollType.PilotDamageFromFall, 0, "Pilot taking damage from fall");
+
+        SetupRollResult(false, PilotingSkillRollType.WaterEntry);
+        SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
+
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(_testMech, 0, false)
+            .Returns(fallingDamageData);
+
+        // Act
+        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(1), _game, MovementType.Walk);
+
+        // Assert
+        result.IsFalling.ShouldBeTrue();
+        result.LevelsFallen.ShouldBe(0);
+        result.WasJumping.ShouldBeFalse();
+        result.FallingDamageData.ShouldBe(fallingDamageData);
+        result.PilotDamagePilotingSkillRoll.ShouldNotBeNull();
+        ((PilotDamageFromFallRollContext)result.PilotDamagePilotingSkillRoll!.RollContext).LevelsFallen.ShouldBe(0);
+
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 0, false);
+    }
+
+    [Fact]
+    public void ProcessWaterEntry_ShouldSetLevelsFallenToWaterDepth2_WhenJumpingIntoDepth2WaterAndFalling()
+    {
+        // Arrange - WaterDepth: 2, Jump movement
+        SetupWaterEntryPsrFor(2, 1, "Water Depth");
+        SetupPsrFor(PilotingSkillRollType.PilotDamageFromFall, 0, "Pilot taking damage from fall");
+
+        SetupRollResult(false, PilotingSkillRollType.WaterEntry);
+        SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
+
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(_testMech, 2, true)
+            .Returns(fallingDamageData);
+
+        // Act
+        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(2), _game, MovementType.Jump);
+
+        // Assert
+        result.IsFalling.ShouldBeTrue();
+        result.LevelsFallen.ShouldBe(2);
+        result.WasJumping.ShouldBeTrue();
+        result.FallingDamageData.ShouldBe(fallingDamageData);
+        result.PilotDamagePilotingSkillRoll.ShouldNotBeNull();
+        ((PilotDamageFromFallRollContext)result.PilotDamagePilotingSkillRoll!.RollContext).LevelsFallen.ShouldBe(2);
+
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 2, true);
+    }
+
+    [Fact]
+    public void ProcessWaterEntry_ShouldSetLevelsFallenToZero_WhenRunningIntoDeepWaterAndFalling()
+    {
+        // Arrange - WaterDepth: 1, Run movement
+        SetupWaterEntryPsrFor(1, 1, "Water Depth");
+        SetupPsrFor(PilotingSkillRollType.PilotDamageFromFall, 0, "Pilot taking damage from fall");
+
+        SetupRollResult(false, PilotingSkillRollType.WaterEntry);
+        SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
+
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(_testMech, 0, false)
+            .Returns(fallingDamageData);
+
+        // Act
+        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(1), _game, MovementType.Run);
+
+        // Assert
+        result.IsFalling.ShouldBeTrue();
+        result.LevelsFallen.ShouldBe(0);
+        result.WasJumping.ShouldBeFalse();
+
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 0, false);
+    }
+
+    [Fact]
+    public void ProcessMovementAttempt_ShouldSetLevelsFallenToZero_WhenJumpWithDamageFalls()
+    {
+        // Arrange - JumpWithDamage (non-water) should produce LevelsFallen = 0
+        SetupPsrFor(PilotingSkillRollType.JumpWithDamage, 1, "Jump with damage");
+        SetupPsrFor(PilotingSkillRollType.PilotDamageFromFall, 0, "Pilot taking damage from fall");
+
+        SetupRollResult(false, PilotingSkillRollType.JumpWithDamage);
+        SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
+
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(_testMech, 0, true)
+            .Returns(fallingDamageData);
+
+        // Act
+        var result = _sut.ProcessMovementAttempt(_testMech, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), _game, MovementType.Jump);
+
+        // Assert
+        result.IsFalling.ShouldBeTrue();
+        result.LevelsFallen.ShouldBe(0, "Non-water jump falls should have LevelsFallen = 0");
+        result.WasJumping.ShouldBeTrue();
+        result.FallingDamageData.ShouldBe(fallingDamageData);
+        result.PilotDamagePilotingSkillRoll.ShouldNotBeNull();
+        ((PilotDamageFromFallRollContext)result.PilotDamagePilotingSkillRoll!.RollContext).LevelsFallen.ShouldBe(0);
+
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 0, true);
+    }
+
+    [Fact]
+    public void ProcessMovementAttempt_ShouldSetLevelsFallenToZero_WhenStandupAttemptFails()
+    {
+        // Arrange - Standup attempt falls should produce LevelsFallen = 0
+        SetupPsrFor(PilotingSkillRollType.StandupAttempt, 2, "Standing up from prone");
+        SetupPsrFor(PilotingSkillRollType.PilotDamageFromFall, 0, "Pilot taking damage from fall");
+
+        SetupRollResult(false, PilotingSkillRollType.StandupAttempt);
+        SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
+
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(_testMech, 0, false)
+            .Returns(fallingDamageData);
+
+        // Act
+        var result = _sut.ProcessMovementAttempt(_testMech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), _game, MovementType.StandingStill);
+
+        // Assert
+        result.IsFalling.ShouldBeTrue();
+        result.LevelsFallen.ShouldBe(0, "Standup falls should have LevelsFallen = 0");
+        result.WasJumping.ShouldBeFalse();
+        result.PilotDamagePilotingSkillRoll.ShouldNotBeNull();
+        ((PilotDamageFromFallRollContext)result.PilotDamagePilotingSkillRoll!.RollContext).LevelsFallen.ShouldBe(0);
+
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(_testMech, 0, false);
+    }
+
     private void SetupWaterEntryPsrFor(int waterDepth, int modifierValue, string modifierName)
     {
         _mockPilotingSkillCalculator.GetPsrBreakdown(
@@ -1041,7 +1207,7 @@ public class FallProcessorTests
         SetupRollResult(true, PilotingSkillRollType.WaterEntry);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(waterDepth), _game);
+        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(waterDepth), _game, MovementType.Walk);
 
         // Assert
         result.ShouldNotBeNull();
@@ -1079,7 +1245,7 @@ public class FallProcessorTests
             .Returns(fallingDamageData);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(waterDepth), _game);
+        var result = _sut.ProcessMovementAttempt(_testMech, new EnteringDeepWaterRollContext(waterDepth), _game, MovementType.Walk);
 
         // Assert
         result.ShouldNotBeNull();

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -212,7 +212,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         // Set up the Mock for ProcessStandupAttempt
-        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game).Returns(successfulStandupData);
+        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game, MovementType.StandingStill).Returns(successfulStandupData);
         
         CommandPublisher.ClearReceivedCalls();
         
@@ -270,7 +270,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         // Set up the Mock for ProcessStandupAttempt
-        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game).Returns(fallContextData);
+        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game, Arg.Any<MovementType>()).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -328,7 +328,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         // Set up the Mock for ProcessStandupAttempt
-        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game).Returns(fallContextData);
+        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game, MovementType.StandingStill).Returns(fallContextData);
 
         var consciousnessCommand = new PilotConsciousnessRollCommand
         {
@@ -445,7 +445,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             }
         };
 
-        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game).Returns(successfulFallContext);
+        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game, MovementType.Jump).Returns(successfulFallContext);
 
         var moveCommand = new MoveUnitCommand
         {
@@ -501,7 +501,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game).Returns(failedFallContext);
+        MockFallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game, MovementType.Jump).Returns(failedFallContext);
 
         var moveCommand = new MoveUnitCommand
         {
@@ -557,7 +557,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game).Returns(failedFallContext);
+        MockFallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.JumpWithDamage), Game, MovementType.Jump).Returns(failedFallContext);
 
         var moveCommand = new MoveUnitCommand
         {
@@ -633,7 +633,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             WasJumping = false
         };
 
-        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game).Returns(fallContextData);
+        Game.FallProcessor.ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game, MovementType.StandingStill).Returns(fallContextData);
 
         // Setup critical hits calculator to return critical hits for fall damage
         var fallCriticalHitsCommand = new CriticalHitsResolutionCommand
@@ -728,7 +728,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         Game.FallProcessor
-            .ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game)
+            .ProcessMovementAttempt(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt), Game, MovementType.StandingStill)
             .Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
@@ -802,7 +802,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Walk).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -857,7 +857,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Jump).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -906,7 +906,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             }
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Walk).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -956,7 +956,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             }
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Jump).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed falling damage calculation for mechs jumping into water; levels fallen now correctly reflect water depth.
  * Improved falling damage accuracy by properly tracking movement type (jumping vs. standing/walking) during fall events.

* **Chores**
  * Version bumped to 0.56.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->