### PR TITLE
disable agressivenes slider

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.56.24</Version>
+        <Version>0.56.25</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/PlayersFragment.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/PlayersFragment.axaml
@@ -103,6 +103,7 @@
                                             Maximum="1"
                                             Value="{Binding AggressivenessIndex}"
                                             Width="100"
+                                            IsEnabled="{Binding CanEditAggressiveness}"
                                             VerticalAlignment="Center"/>
                                 </StackPanel>
                             </Grid>

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/PlayerViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/PlayerViewModel.cs
@@ -70,6 +70,7 @@ public class PlayerViewModel : BindableBase
         NotifyPropertyChanged(nameof(CanSelectUnit));
         NotifyPropertyChanged(nameof(CanEditName));
         NotifyPropertyChanged(nameof(IsRemovable));
+        NotifyPropertyChanged(nameof(CanEditAggressiveness));
     }
 
     public ICommand ShowAvailableUnitsCommand { get; }
@@ -121,6 +122,8 @@ public class PlayerViewModel : BindableBase
     public bool CanSelectUnit => IsLocalPlayer && Status == PlayerStatus.NotJoined;
 
     public bool CanEditName => IsLocalPlayer && Status == PlayerStatus.NotJoined && !IsEditingName;
+
+    public bool CanEditAggressiveness => IsBot && Status == PlayerStatus.NotJoined;
 
     private Task ExecuteJoinGame()
     {

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PlayerViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PlayerViewModelTests.cs
@@ -983,4 +983,50 @@ public class PlayerViewModelTests
         // Assert
         botSettings.AggressivenessIndex.ShouldBe(0.6f);
     }
+
+    [Theory]
+    [InlineData(true, PlayerStatus.NotJoined, true)]
+    [InlineData(true, PlayerStatus.Joined, false)]
+    [InlineData(true, PlayerStatus.Ready, false)]
+    [InlineData(false, PlayerStatus.NotJoined, false)]
+    public void CanEditAggressiveness_ShouldReturnCorrectValue_ForDifferentStates(
+        bool isBot,
+        PlayerStatus status,
+        bool expected)
+    {
+        // Arrange
+        var controlType = isBot ? PlayerControlType.Bot : PlayerControlType.Human;
+        var player = new Player(Guid.NewGuid(), "Player1", controlType)
+        {
+            Status = status
+        };
+        var sut = new PlayerViewModel(player, true);
+
+        // Act
+        var canEdit = sut.CanEditAggressiveness;
+
+        // Assert
+        canEdit.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void RefreshStatus_ShouldNotifyCanEditAggressivenessPropertyChanged()
+    {
+        // Arrange
+        var sut = new PlayerViewModel(
+            new Player(Guid.NewGuid(), "BotPlayer", PlayerControlType.Bot),
+            isLocalPlayer: true);
+
+        var propertyChanged = false;
+        sut.PropertyChanged += (_, args) => {
+            if (args.PropertyName == nameof(PlayerViewModel.CanEditAggressiveness))
+                propertyChanged = true;
+        };
+
+        // Act
+        sut.RefreshStatus();
+
+        // Assert
+        propertyChanged.ShouldBeTrue();
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bot player aggressiveness slider is now conditionally enabled, allowing edits only before the player joins the game.

* **Tests**
  * Added test coverage for aggressiveness slider edit availability across different player states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anton-makarevich/MakaMek/pull/923)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->