### PR TITLE
Fix resume movement after water fall

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.56.28</Version>
+        <Version>0.56.30</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.56.29</Version>
+        <Version>0.56.28</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Data/Game/Commands/Client/Builders/MoveUnitCommandBuilder.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Client/Builders/MoveUnitCommandBuilder.cs
@@ -1,4 +1,3 @@
-using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Map.Models;
 
@@ -34,7 +33,8 @@ public class MoveUnitCommandBuilder(Guid gameId, Guid playerId) : ClientCommandB
             PlayerId = PlayerId,
             UnitId = _unitId.Value,
             MovementType = _movementPath.MovementType,
-            MovementPath = _movementPath.ToData()
+            MovementPath = _movementPath.ToData(),
+            IsCompleted = true
         };
     }
 

--- a/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
@@ -19,7 +19,7 @@ public record struct MoveUnitCommand: IClientUnitCommand
         if (unit is not { Position: not null }) return string.Empty;
         var localizedTemplate = localizationService.GetString("Command_MoveUnit");
         var position = MovementPath.Count>0 ? 
-            MovementPath.Last().To
+            MovementPath[^1].To
             : unit.Position.ToData();
         var facingHex = new HexCoordinates(position.Coordinates).GetNeighbour((HexDirection)position.Facing);
         return string.Format(localizedTemplate,
@@ -34,4 +34,5 @@ public record struct MoveUnitCommand: IClientUnitCommand
     public required MovementType MovementType { get; init; }
     public required IReadOnlyList<PathSegmentData> MovementPath { get; init; }
     public Guid PlayerId { get; init; }
+    public bool IsCompleted { get; init; }
 }

--- a/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Sanet.MakaMek.Core.Models.Game;
 using Sanet.MakaMek.Localization;
 using Sanet.MakaMek.Map.Data;
@@ -22,12 +23,17 @@ public record struct MoveUnitCommand: IClientUnitCommand
             MovementPath[^1].To
             : unit.Position.ToData();
         var facingHex = new HexCoordinates(position.Coordinates).GetNeighbour((HexDirection)position.Facing);
-        return string.Format(localizedTemplate,
+        var stringBuilder = new StringBuilder();
+        stringBuilder.AppendFormat(localizedTemplate,
             player?.Name,
             unit.Model,
             new HexCoordinates(position.Coordinates),
             facingHex,
-            MovementType);
+            MovementType).AppendLine();
+        var completedKey = IsCompleted ? "Command_MoveUnit_Completed" : "Command_MoveUnit_Incomplete";
+        var completedTemplate = localizationService.GetString(completedKey);
+        stringBuilder.Append(completedTemplate);
+        return stringBuilder.ToString();
     }
 
     public required Guid UnitId { get; init; }

--- a/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
@@ -16,6 +16,8 @@ public record struct MoveUnitCommand: IClientUnitCommand
     {
         var sb = new StringBuilder();
         sb.Append(IsCompleted ? '1' : '0');
+        sb.Append('|');
+        sb.Append((int)MovementType);
         foreach (var segment in MovementPath)
         {
             sb.Append('|');

--- a/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Client/MoveUnitCommand.cs
@@ -12,6 +12,32 @@ public record struct MoveUnitCommand: IClientUnitCommand
     public DateTime Timestamp { get; set; }
     public Guid? IdempotencyKey { get; init; }
 
+    public string GetPayloadHash()
+    {
+        var sb = new StringBuilder();
+        sb.Append(IsCompleted ? '1' : '0');
+        foreach (var segment in MovementPath)
+        {
+            sb.Append('|');
+            sb.Append(segment.From.Coordinates.Q);
+            sb.Append(',');
+            sb.Append(segment.From.Coordinates.R);
+            sb.Append(',');
+            sb.Append(segment.From.Facing);
+            sb.Append(':');
+            sb.Append(segment.To.Coordinates.Q);
+            sb.Append(',');
+            sb.Append(segment.To.Coordinates.R);
+            sb.Append(',');
+            sb.Append(segment.To.Facing);
+            sb.Append(':');
+            sb.Append(segment.Cost);
+            sb.Append(':');
+            sb.Append(segment.IsReversed ? '1' : '0');
+        }
+        return sb.ToString();
+    }
+
     public string Render(ILocalizationService localizationService, IGame game)
     {
         var command = this;

--- a/src/MakaMek.Core/Data/Game/Commands/IGameCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/IGameCommand.cs
@@ -7,5 +7,6 @@ public interface IGameCommand
 {
     Guid GameOriginId { get; set; }
     DateTime Timestamp { get; set; } 
-    string Render(ILocalizationService localizationService, IGame game); 
+    string Render(ILocalizationService localizationService, IGame game);
+    string GetPayloadHash() => string.Empty;
 }

--- a/src/MakaMek.Core/Models/Game/BaseGame.cs
+++ b/src/MakaMek.Core/Models/Game/BaseGame.cs
@@ -189,7 +189,7 @@ public abstract class BaseGame : IGame
         if (unit == null) return;
         var path = new MovementPath(moveCommand.MovementPath, moveCommand.MovementType);
         var hex = BattleMap?.GetHex(path.Destination.Coordinates);
-        unit.Move(path, hex);
+        unit.Move(path, hex, moveCommand.IsCompleted);
     }
     
     internal void OnWeaponConfiguration(WeaponConfigurationCommand configCommand)

--- a/src/MakaMek.Core/Models/Game/ClientGame.cs
+++ b/src/MakaMek.Core/Models/Game/ClientGame.cs
@@ -231,7 +231,8 @@ public sealed class ClientGame : BaseGame, IDisposable, IClientGame
             Turn,
             TurnPhase.ToString(),
             unitId,
-            attempt);
+            attempt,
+            command.GetPayloadHash());
 
         // Check if this command is already pending
         if (_pendingCommands.TryGetValue(idempotencyKey, out var pendingCommand))

--- a/src/MakaMek.Core/Models/Game/Phases/MainGamePhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MainGamePhase.cs
@@ -36,7 +36,10 @@ public abstract class MainGamePhase : GamePhase
         if (playerId != Game.PhaseStepState?.ActivePlayer.Id) return;
 
         ProcessCommand(command);
-        
+
+        if (!ShouldFinalizeUnitsTurn(command))
+            return;
+
         _remainingUnits--;
         if (_remainingUnits <= 0)
         {
@@ -45,6 +48,12 @@ public abstract class MainGamePhase : GamePhase
         }
         Game.SetActivePlayer(Game.PhaseStepState?.ActivePlayer, _remainingUnits);
     }
+
+    /// <summary>
+    /// When false, the phase does not advance the per-step unit counter or republish the active player
+    /// after this command (e.g. walk into water fall with standup still pending).
+    /// </summary>
+    protected virtual bool ShouldFinalizeUnitsTurn(IGameCommand command) => true;
 
     protected abstract void ProcessCommand(IGameCommand command);
 }

--- a/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
@@ -125,8 +125,7 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
                     
                     var fallCommand = fallContextData.ToMechFallCommand();
                     ProcessFallCommand(fallCommand, unit);
-                    if (unit.CanStandup())
-                        _requestDeferStepConsumption = true;
+                    _requestDeferStepConsumption = unit.CanStandup();
                     return;
                 }
                 

--- a/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
@@ -14,17 +14,62 @@ namespace Sanet.MakaMek.Core.Models.Game.Phases;
 
 public class MovementPhase(ServerGame game) : MainGamePhase(game)
 {
+    private Guid? _deferredMovementUnitId;
+    private bool _requestDeferStepConsumption;
+
+    public override void Enter()
+    {
+        ClearMovementDeferralState();
+        base.Enter();
+    }
+
+    public override void Exit()
+    {
+        ClearMovementDeferralState();
+        base.Exit();
+    }
+
     public override void HandleCommand(IGameCommand command)
     {
+        if (_deferredMovementUnitId is { } deferredId)
+        {
+            switch (command)
+            {
+                case MoveUnitCommand m when m.UnitId != deferredId:
+                case TryStandupCommand t when t.UnitId != deferredId:
+                    return;
+            }
+        }
+
         switch (command)
         {
             case MoveUnitCommand moveCommand:
                 HandleUnitAction(command, moveCommand.PlayerId);
                 break;
             case TryStandupCommand standupCommand:
-                ProcessStandupCommand(standupCommand);  //HandleUnitAction moves to the new unit, should not happen here
+                ProcessStandupCommand(standupCommand);
                 break;
         }
+    }
+
+    protected override bool ShouldFinalizeUnitsTurn(IGameCommand command)
+    {
+        if (command is not MoveUnitCommand m)
+            return true;
+
+        if (_requestDeferStepConsumption)
+        {
+            _requestDeferStepConsumption = false;
+            _deferredMovementUnitId = m.UnitId;
+            return false;
+        }
+
+        if (_deferredMovementUnitId == m.UnitId)
+        {
+            _deferredMovementUnitId = null;
+        }
+
+        return true;
     }
 
     protected override void ProcessCommand(IGameCommand command)
@@ -80,6 +125,8 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
                     
                     var fallCommand = fallContextData.ToMechFallCommand();
                     ProcessFallCommand(fallCommand, unit);
+                    if (unit.CanStandup())
+                        _requestDeferStepConsumption = true;
                     return;
                 }
                 
@@ -208,4 +255,10 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
     }
 
     public override PhaseNames Name => PhaseNames.Movement;
+
+    private void ClearMovementDeferralState()
+    {
+        _deferredMovementUnitId = null;
+        _requestDeferStepConsumption = false;
+    }
 }

--- a/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
@@ -130,7 +130,18 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
                     var fallCommand = fallContextData.ToMechFallCommand();
                     ProcessFallCommand(fallCommand, unit);
                     var canStandup = unit.CanStandup();
-                    //TODO: if cannot stand up - complete a movement by sending another Command
+                    if (!canStandup)
+                    {
+                        var completionCommand = truncatedCommand with
+                        {
+                            IsCompleted = true,
+                            MovementPath = [truncatedCommand.MovementPath[^1]]
+                        };
+                        Game.OnMoveUnit(completionCommand);
+                        broadcastCommand = completionCommand with { GameOriginId = Game.Id };
+                        Game.CommandPublisher.PublishCommand(broadcastCommand);
+
+                    }
                     _requestDeferStepConsumption = canStandup;
                     return;
                 }

--- a/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
@@ -117,7 +117,11 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
                 {
                     var truncatedSegments = moveCommand.MovementPath.Take(entry.SegmentIndex + 1).ToList();
                     var truncatedPath = new MovementPath(truncatedSegments, moveCommand.MovementType);
-                    var truncatedCommand = moveCommand with { MovementPath = truncatedPath.ToData() };
+                    var truncatedCommand = moveCommand with
+                    {
+                        MovementPath = truncatedPath.ToData(),
+                        IsCompleted = false
+                    };
                     
                     Game.OnMoveUnit(truncatedCommand);
                     var broadcastCommand = truncatedCommand with { GameOriginId = Game.Id };
@@ -125,7 +129,9 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
                     
                     var fallCommand = fallContextData.ToMechFallCommand();
                     ProcessFallCommand(fallCommand, unit);
-                    _requestDeferStepConsumption = unit.CanStandup();
+                    var canStandup = unit.CanStandup();
+                    //TODO: if cannot stand up - complete a movement by sending another Command
+                    _requestDeferStepConsumption = canStandup;
                     return;
                 }
                 
@@ -135,7 +141,11 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
         }
 
         Game.OnMoveUnit(moveCommand);
-        var fullBroadcastCommand = moveCommand with { GameOriginId = Game.Id };
+        var fullBroadcastCommand = moveCommand with
+        {
+            GameOriginId = Game.Id,
+            IsCompleted = true
+        };
         Game.CommandPublisher.PublishCommand(fullBroadcastCommand);
         
         if (unit != null && moveCommand.MovementType == MovementType.Jump)
@@ -181,7 +191,10 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
             return;
         }
         
-        var broadcastCommand = tryStandUpCommand with { GameOriginId = Game.Id };
+        var broadcastCommand = tryStandUpCommand with
+        {
+            GameOriginId = Game.Id
+        };
         Game.CommandPublisher.PublishCommand(broadcastCommand);
 
         // Check if the unit can stand up (has sufficient MP, pilot is conscious, etc.)

--- a/src/MakaMek.Core/Models/Units/IUnit.cs
+++ b/src/MakaMek.Core/Models/Units/IUnit.cs
@@ -274,7 +274,7 @@ public interface IUnit
     /// <returns>Components of the specified type at the specified location containing the given slot</returns>
     T? GetMountedComponentAtLocation<T>(PartLocation? location, int slot) where T : Component;
 
-    void Move(MovementPath movementPath, Hex? destination, bool isCompleted = true);
+    void Move(MovementPath movementPath, Hex? destination, bool isCompleted);
 
     /// <summary>
     /// Fires a weapon based on the provided weapon data and consumes ammo if required.

--- a/src/MakaMek.Core/Models/Units/IUnit.cs
+++ b/src/MakaMek.Core/Models/Units/IUnit.cs
@@ -274,7 +274,7 @@ public interface IUnit
     /// <returns>Components of the specified type at the specified location containing the given slot</returns>
     T? GetMountedComponentAtLocation<T>(PartLocation? location, int slot) where T : Component;
 
-    void Move(MovementPath movementPath, Hex? destination);
+    void Move(MovementPath movementPath, Hex? destination, bool isCompleted = true);
 
     /// <summary>
     /// Fires a weapon based on the provided weapon data and consumes ammo if required.

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -514,6 +514,8 @@ public class Mech : Unit
     public bool CanStandup()
     {
         if (IsShutdown) return false;
+        
+        if (HasMoved) return false;
 
         // Cannot stand up in the same turn if falling during a jump
         if (MovementTaken?.MovementType == MovementType.Jump) 

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -400,7 +400,7 @@ public abstract class Unit : IUnit
     public int MovementPointsSpent { get; private set; }
     public MovementPath? MovementTaken { get; private set; }
 
-    public bool HasMoved => MovementTaken!=null;
+    public bool HasMoved { get; private set; }
 
     // Damage tracking
     public int TotalPhaseDamage { get; private set; }
@@ -429,6 +429,7 @@ public abstract class Unit : IUnit
     {
         MovementPointsSpent = 0;
         MovementTaken = null;
+        HasMoved = false;
     }
     
     /// <summary>
@@ -725,7 +726,7 @@ public abstract class Unit : IUnit
            c.MountedAtFirstLocationSlots.Contains(slot));
     }
 
-    public void Move(MovementPath movementPath, Hex? destination)
+    public void Move(MovementPath movementPath, Hex? destination, bool isCompleted = true)
     {
         if (Position == null)
         {
@@ -735,6 +736,7 @@ public abstract class Unit : IUnit
             ? Position
             : movementPath.Destination;
         MovementTaken = movementPath;
+        HasMoved = isCompleted;
         SpendMovementPoints(movementPath.TotalCost);
         Position = position;
         Hex = destination;

--- a/src/MakaMek.Core/Services/Cryptography/HashService.cs
+++ b/src/MakaMek.Core/Services/Cryptography/HashService.cs
@@ -7,7 +7,7 @@ public class HashService: IHashService
 {
     /// <summary>
     /// Computes a deterministic idempotency key for a command.
-    /// The key is based on GameId, PlayerId, UnitId (optional), Phase, Turn, and CommandType.
+    /// The key is based on GameId, PlayerId, UnitId (optional), Phase, Turn, CommandType, and PayloadHash.
     /// </summary>
     public Guid ComputeCommandIdempotencyKey(Guid gameId,
         Guid playerId,
@@ -15,10 +15,11 @@ public class HashService: IHashService
         int turn,
         string phase,
         Guid? unitId = null,
-        int attempt = 0)
+        int attempt = 0,
+        string? payloadHash = null)
     {
         // Build the input string for hashing
-        var input = $"{gameId}:{playerId}:{unitId?.ToString() ?? "null"}:{phase}:{turn}:{commandType.Name}:{attempt}";
+        var input = $"{gameId}:{playerId}:{unitId?.ToString() ?? "null"}:{phase}:{turn}:{commandType.Name}:{attempt}:{payloadHash ?? "null"}";
 
         // Compute SHA256 hash
         var hash = SHA256.HashData(Encoding.UTF8.GetBytes(input));

--- a/src/MakaMek.Core/Services/Cryptography/IHashService.cs
+++ b/src/MakaMek.Core/Services/Cryptography/IHashService.cs
@@ -9,5 +9,6 @@ public interface IHashService
         int turn,
         string phase,
         Guid? unitId = null,
-        int attempt = 0);
+        int attempt = 0,
+        string? payloadHash = null);
 }

--- a/src/MakaMek.Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Localization/FakeLocalizationService.cs
@@ -9,6 +9,8 @@ public class FakeLocalizationService: ILocalizationService
             "Command_JoinGame" => "{0} has joined game with {1} units",
             "Command_PlayerLeft" => "{0} has left the game",
             "Command_MoveUnit" => "{0} moved {1} to {2} facing {3} using {4}",
+            "Command_MoveUnit_Completed" => "Movement completed",
+            "Command_MoveUnit_Incomplete" => "Movement was interrupted",
             "Command_DeployUnit" => "{0} deployed {1} to {2} facing {3}",
             "Command_TryStandup" => "{0} attempts to stand up {1}",
             "Command_MechStandup" => "{0} Mech stood up successfully. {1}",

--- a/src/MakaMek.Presentation/UiStates/IUiState.cs
+++ b/src/MakaMek.Presentation/UiStates/IUiState.cs
@@ -14,6 +14,12 @@ public interface IUiState
     void HandleUnitSelection(IUnit? unit);
     void HandleHexSelection(Hex hex);
     void HandleFacingSelection(HexDirection direction);
+
+    /// <summary>
+    /// Whether the UI may select the given unit (e.g. list click or map). States that temporarily lock
+    /// selection to one unit can return false for others. Clearing selection (null) is not passed here.
+    /// </summary>
+    bool CanSelectUnit(IUnit? unit) => true;
     IEnumerable<StateAction> GetAvailableActions() => new List<StateAction>();
     
     /// <summary>

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -523,10 +523,26 @@ public class MovementState : IUiState
         }
     }
 
-    public void ResumeMovementAfterFall()
+    public void ResumeMovementAfterFall(Guid unitId)
     {
         lock (_stateLock)
         {
+            if (_selectedUnit == null && _viewModel.Game is { } clientGame)
+            {
+                foreach (var player in clientGame.Players)
+                {
+                    foreach (var unit in player.Units)
+                    {
+                        if (unit.Id != unitId) continue;
+                        _selectedUnit = unit;
+                        _builder.SetUnit(unit);
+                        break;
+                    }
+
+                    if (_selectedUnit != null) break;
+                }
+            }
+
             if (_selectedUnit is not Mech { IsProne: true, Position: not null } mech || _selectedPath == null)
             {
                 var exception = new InvalidOperationException("Unit is not prone after fall or no movement path");

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -401,7 +401,7 @@ public class MovementState : IUiState
             if (_selectedUnit.IsImmobile) return actions;
             
             // Walk
-            actions.Add(new(
+            actions.Add(new StateAction(
                 string.Format(_viewModel.LocalizationService.GetString("Action_MovementPoints"),
                     _viewModel.LocalizationService.GetString("MovementType_Walk"),
                     _selectedUnit.GetMovementPoints(MovementType.Walk)),
@@ -523,26 +523,10 @@ public class MovementState : IUiState
         }
     }
 
-    public void ResumeMovementAfterFall(Guid unitId)
+    public void ResumeMovementAfterFall()
     {
         lock (_stateLock)
         {
-            if (_selectedUnit == null && _viewModel.Game is { } clientGame)
-            {
-                foreach (var player in clientGame.Players)
-                {
-                    foreach (var unit in player.Units)
-                    {
-                        if (unit.Id != unitId) continue;
-                        _selectedUnit = unit;
-                        _builder.SetUnit(unit);
-                        break;
-                    }
-
-                    if (_selectedUnit != null) break;
-                }
-            }
-
             if (_selectedUnit is not Mech { IsProne: true, Position: not null } mech || _selectedPath == null)
             {
                 var exception = new InvalidOperationException("Unit is not prone after fall or no movement path");

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -27,10 +27,18 @@ public class MovementState : IUiState
     private readonly Lock _stateLock = new();
     private bool _isPostStandupMovement;
     private MovementPath? _selectedPath;
+    private Guid? _deferredMovementUnitId;
 
     private IMovementStep _step;
 
     public IClientGame? Game => _viewModel.Game;
+
+    public bool CanSelectUnit(IUnit? unit)
+    {
+        if (_deferredMovementUnitId is not { } lockedId) return true;
+        if (unit == null) return true;
+        return unit.Id == lockedId;
+    }
 
     public MovementState(BattleMapViewModel viewModel)
     {
@@ -170,6 +178,7 @@ public class MovementState : IUiState
         if (unit == null 
             || unit == _selectedUnit
             || unit.Owner?.Id != _viewModel.Game?.PhaseStepState?.ActivePlayer.Id) return false;
+        if (!CanSelectUnit(unit)) return false;
         ResetUnitSelection();
         _viewModel.SelectedUnit=unit;
         return true;
@@ -231,6 +240,7 @@ public class MovementState : IUiState
                 clientGame.MoveUnit(command.Value);
             }
 
+            _deferredMovementUnitId = null;
             _builder.Reset();
             ClearHighlighting();
             _selectedUnit = null;
@@ -523,7 +533,7 @@ public class MovementState : IUiState
         }
     }
 
-    public void ResumeMovementAfterFall()
+    public void ResumeMovementAfterFall(Guid unitId)
     {
         lock (_stateLock)
         {
@@ -534,13 +544,23 @@ public class MovementState : IUiState
                 throw exception;
             }
 
+            if (unitId != mech.Id)
+            {
+                Game?.Logger.LogWarning(
+                    "Resume movement after fall ignored: command unit {CommandUnit} does not match movement state's selected unit {StateUnit}.",
+                    unitId,
+                    mech.Id);
+                return;
+            }
+
             if (!mech.CanStandup())
             {
                 _builder.SetMovementPath(_selectedPath);
                 CompleteMovement();
                 return;
             }
-            
+
+            _deferredMovementUnitId = unitId;
             TransitionTo(new SelectingMovementTypeStep(this));
         }
     }

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -275,9 +275,7 @@ public class BattleMapViewModel : BaseViewModel
             movementState.ResumeMovementAfterFall(unitId);
             return;
         }
-
-        if (unitId == SelectedUnit?.Id)
-            return;
+        
         movementState.ResumeMovementAfterStandup();
     }
 

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -274,7 +274,7 @@ public class BattleMapViewModel : BaseViewModel
         {
             if (isFalling)
             {
-                movementState.ResumeMovementAfterFall();
+                movementState.ResumeMovementAfterFall(unitId);
             }
             else
             {

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -274,7 +274,7 @@ public class BattleMapViewModel : BaseViewModel
         {
             if (isFalling)
             {
-                movementState.ResumeMovementAfterFall();
+                movementState.ResumeMovementAfterFall(unitId);
             }
             else
             {
@@ -531,6 +531,8 @@ public class BattleMapViewModel : BaseViewModel
         set
         {
             if (value == _selectedUnit) return;
+            if (value != null && !CurrentState.CanSelectUnit(value))
+                return;
             SetProperty(ref _selectedUnit, value);
             CurrentState.HandleUnitSelection(value);
             NotifyPropertyChanged(nameof(AreUnitsToDeployVisible));

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -269,18 +269,16 @@ public class BattleMapViewModel : BaseViewModel
 
     private void ProcessMechStandUp(Guid unitId, bool isFalling)
     {
-        if (CurrentState is MovementState movementState 
-            && unitId == SelectedUnit?.Id)
+        if (CurrentState is not MovementState movementState) return;
+        if (isFalling)
         {
-            if (isFalling)
-            {
-                movementState.ResumeMovementAfterFall(unitId);
-            }
-            else
-            {
-                movementState.ResumeMovementAfterStandup();
-            }
+            movementState.ResumeMovementAfterFall(unitId);
+            return;
         }
+
+        if (unitId == SelectedUnit?.Id)
+            return;
+        movementState.ResumeMovementAfterStandup();
     }
 
     private void ProcessWeaponAttackDeclaration(WeaponAttackDeclarationCommand command)

--- a/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/BattleMapViewModel.cs
@@ -274,7 +274,7 @@ public class BattleMapViewModel : BaseViewModel
         {
             if (isFalling)
             {
-                movementState.ResumeMovementAfterFall(unitId);
+                movementState.ResumeMovementAfterFall();
             }
             else
             {

--- a/tests/MakaMek.Core.Tests/Data/Game/Commands/Client/MoveUnitCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Commands/Client/MoveUnitCommandTests.cs
@@ -43,7 +43,8 @@ public class MoveUnitCommandTests
             GameOriginId = _gameId,
             PlayerId = _player1.Id,
             UnitId = _unit.Id,
-            MovementPath = [pathSegment.ToData()]
+            MovementPath = [pathSegment.ToData()],
+            IsCompleted = true
         };
     }
 
@@ -54,12 +55,13 @@ public class MoveUnitCommandTests
         var command = CreateCommand();
         _unit.Deploy(new HexPosition(1, 1, HexDirection.Top), null);
         _localizationService.GetString("Command_MoveUnit").Returns("formatted move command");
+        _localizationService.GetString("Command_MoveUnit_Completed").Returns("completed");
 
         // Act
         var result = command.Render(_localizationService, _game);
 
         // Assert
-        result.ShouldBe("formatted move command");
+        result.ShouldBe("formatted move command" + Environment.NewLine + "completed");
         _localizationService.Received(1).GetString("Command_MoveUnit");
     }
 
@@ -87,5 +89,37 @@ public class MoveUnitCommandTests
 
         // Assert
         result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_ShouldIncludeCompletedLine_WhenMovementIsCompleted()
+    {
+        // Arrange
+        var command = CreateCommand();
+        _unit.Deploy(new HexPosition(1, 1, HexDirection.Top), null);
+        _localizationService.GetString("Command_MoveUnit").Returns("move line");
+        _localizationService.GetString("Command_MoveUnit_Completed").Returns("completed");
+
+        // Act
+        var result = command.Render(_localizationService, _game);
+
+        // Assert
+        result.ShouldBe("move line" + Environment.NewLine + "completed");
+    }
+
+    [Fact]
+    public void Render_ShouldIncludeIncompleteLine_WhenMovementIsNotCompleted()
+    {
+        // Arrange
+        var command = CreateCommand() with { IsCompleted = false };
+        _unit.Deploy(new HexPosition(1, 1, HexDirection.Top), null);
+        _localizationService.GetString("Command_MoveUnit").Returns("move line");
+        _localizationService.GetString("Command_MoveUnit_Incomplete").Returns("interrupted");
+
+        // Act
+        var result = command.Render(_localizationService, _game);
+
+        // Assert
+        result.ShouldBe("move line" + Environment.NewLine + "interrupted");
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Game/ClientGameTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/ClientGameTests.cs
@@ -58,7 +58,9 @@ public class ClientGameTests
             Arg.Any<Type>(),
             Arg.Any<int>(),
             Arg.Any<string>(),
-            Arg.Any<Guid?>())
+            Arg.Any<Guid?>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>())
             .Returns(_idempotencyKey);
         
         var battleMap = BattleMapFactory.GenerateMap(5, 5, new SingleTerrainGenerator(5,5, new ClearTerrain()));

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/EndPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/EndPhaseTests.cs
@@ -176,7 +176,7 @@ public class EndPhaseTests : GamePhaseTestsBase
         var targetPosition = new HexPosition(new HexCoordinates(1,2), HexDirection.Bottom);
         unit.Deploy(deployPosition, null);
         var movementPath = new MovementPath([new PathSegment(deployPosition, targetPosition, 1).ToData()], MovementType.Walk);
-        unit.Move(movementPath, null);
+        unit.Move(movementPath, null, true);
         
         unit.MovementTaken.ShouldBe(movementPath);
         

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/HeatPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/HeatPhaseTests.cs
@@ -634,7 +634,7 @@ public class HeatPhaseTests : GamePhaseTestsBase
         var deployPosition = new HexPosition(new HexCoordinates(1,1), HexDirection.Bottom);
         unit.Deploy(deployPosition, null);
         unit.Move(new MovementPath([new PathSegment(deployPosition, deployPosition, 1)]
-            , movementType), null);
+            , movementType), null, true);
     }
 
     private void SetupUnitWithWeaponFired(IUnit unit)
@@ -730,11 +730,11 @@ public class HeatPhaseTests : GamePhaseTestsBase
         if (engineHeatSinksCount > 0)
         {
             var engineRating = engineHeatSinksCount * 25;
-            var engineData = new Sanet.MakaMek.Core.Data.Units.Components.ComponentData
+            var engineData = new ComponentData
             {
                 Type = MakaMekComponent.Engine,
                 Assignments = [new LocationSlotAssignment(PartLocation.CenterTorso, 0, 6)],
-                SpecificData = new Sanet.MakaMek.Core.Data.Units.Components.EngineStateData(EngineType.Fusion, engineRating)
+                SpecificData = new EngineStateData(EngineType.Fusion, engineRating)
             };
             centerTorso.TryAddComponent(new Engine(engineData), [0, 1, 2, 3, 4, 5]);
         }

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -83,6 +83,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
     
         // Assert
         unit.Position?.Coordinates.ToString().ShouldBe("0301");
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.IsCompleted));
     }
 
     [Fact]
@@ -465,7 +466,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
 
         // Assert
         CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
-            cmd.UnitId == _unit1Id && cmd.MovementType == MovementType.Jump));
+            cmd.UnitId == _unit1Id && cmd.MovementType == MovementType.Jump && cmd.IsCompleted));
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd =>
             cmd.UnitId == _unit1Id && cmd.DamageData == null && cmd.FallPilotingSkillRoll!.IsSuccessful));
     }
@@ -523,7 +524,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd =>
             cmd.UnitId == _unit1Id && cmd.DamageData != null));
         CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
-            cmd.UnitId == _unit1Id && cmd.MovementType == MovementType.Jump));
+            cmd.UnitId == _unit1Id && cmd.MovementType == MovementType.Jump && cmd.IsCompleted));
     }
     
     [Fact]
@@ -812,7 +813,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
 
         // Assert
         CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => 
-            cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1 && cmd.MovementPath[0].To.Coordinates.Q == 2));
+            cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1 && cmd.MovementPath[0].To.Coordinates.Q == 2 && !cmd.IsCompleted));
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd => cmd.UnitId == _unit1Id));
     }
 
@@ -866,6 +867,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         });
 
         CommandPublisher.DidNotReceive().PublishCommand(Arg.Any<ChangeActivePlayerCommand>());
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && !cmd.IsCompleted));
     }
 
     [Fact]
@@ -939,6 +941,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         });
 
         CommandPublisher.Received().PublishCommand(Arg.Any<ChangeActivePlayerCommand>());
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && !cmd.IsCompleted));
     }
 
     [Fact]
@@ -1107,6 +1110,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         });
 
         CommandPublisher.Received(1).PublishCommand(Arg.Any<ChangeActivePlayerCommand>());
+        CommandPublisher.Received(1).PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.IsCompleted));
     }
 
     [Fact]
@@ -1159,7 +1163,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         _sut.HandleCommand(moveCommand);
 
         // Assert
-        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1));
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1 && cmd.IsCompleted));
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd => cmd.UnitId == _unit1Id));
     }
 
@@ -1208,7 +1212,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         _sut.HandleCommand(moveCommand);
 
         // Assert
-        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1));
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1 && cmd.IsCompleted));
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd => 
             cmd.UnitId == _unit1Id && cmd.DamageData == null && cmd.FallPilotingSkillRoll!.IsSuccessful));
     }
@@ -1258,7 +1262,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         _sut.HandleCommand(moveCommand);
 
         // Assert
-        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1));
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1 && cmd.IsCompleted));
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd => 
             cmd.UnitId == _unit1Id && cmd.DamageData == null && cmd.FallPilotingSkillRoll!.IsSuccessful));
     }
@@ -1331,5 +1335,6 @@ public class MovementPhaseTests : GamePhaseTestsBase
 
         unit2.Position.ShouldNotBe(unit2PositionBefore);
         unit2.Position!.Coordinates.ShouldBe(newPosition.Coordinates);
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => cmd.UnitId == unit2.Id && cmd.IsCompleted));
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -1262,4 +1262,74 @@ public class MovementPhaseTests : GamePhaseTestsBase
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd => 
             cmd.UnitId == _unit1Id && cmd.DamageData == null && cmd.FallPilotingSkillRoll!.IsSuccessful));
     }
+
+    [Fact]
+    public void Exit_ShouldClearDeferralState()
+    {
+        SetMap();
+        _sut.Enter();
+        MockConsciousnessCalculator.MakeConsciousnessRolls(Arg.Any<IPilot>()).Returns([]);
+
+        var activePlayer = Game.PhaseStepState!.Value.ActivePlayer;
+        var unit1 = activePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        var unit2 = activePlayer.Units.First(u => u.Id != _unit1Id) as Mech;
+        unit1!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+        unit2!.Deploy(new HexPosition(5, 2, HexDirection.Top), null);
+
+        var waterHex = Game.BattleMap!.GetHex(new HexCoordinates(2, 2));
+        waterHex!.AddTerrain(new Sanet.MakaMek.Map.Models.Terrains.WaterTerrain(-1));
+
+        var fallContextData = new FallContextData
+        {
+            UnitId = unit1.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new EnteringDeepWaterRollContext(1),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front)
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(unit1, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Walk)
+            .Returns(fallContextData);
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = activePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), 2).ToData()
+            ]
+        });
+
+        _sut.Exit();
+
+        var unit2PositionBefore = unit2.Position;
+        var newPosition = new HexPosition(5, 1, HexDirection.Bottom);
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = activePlayer.Id,
+            UnitId = unit2.Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(5, 2, HexDirection.Top), newPosition, 1).ToData()
+            ]
+        });
+
+        unit2.Position.ShouldNotBe(unit2PositionBefore);
+        unit2.Position!.Coordinates.ShouldBe(newPosition.Coordinates);
+    }
 }

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -11,6 +11,7 @@ using Sanet.MakaMek.Core.Models.Game.Players;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components.Internal;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
+using Sanet.MakaMek.Core.Models.Units.Pilots;
 using Sanet.MakaMek.Map.Models;
 using Shouldly;
 
@@ -813,6 +814,299 @@ public class MovementPhaseTests : GamePhaseTestsBase
         CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd => 
             cmd.UnitId == _unit1Id && cmd.MovementPath.Count == 1 && cmd.MovementPath[0].To.Coordinates.Q == 2));
         CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd => cmd.UnitId == _unit1Id));
+    }
+
+    [Fact]
+    public void HandleCommand_WhenWalkWaterFall_AndCanStandup_ShouldNotPublishChangeActivePlayer()
+    {
+        SetMap();
+        _sut.Enter();
+        MockConsciousnessCalculator.MakeConsciousnessRolls(Arg.Any<IPilot>()).Returns([]);
+
+        var unit = Game.PhaseStepState!.Value.ActivePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+
+        var hex = Game.BattleMap!.GetHex(new HexCoordinates(2, 2));
+        hex!.AddTerrain(new Sanet.MakaMek.Map.Models.Terrains.WaterTerrain(-1));
+
+        var fallContextData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new EnteringDeepWaterRollContext(1),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front)
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Walk)
+            .Returns(fallContextData);
+
+        CommandPublisher.ClearReceivedCalls();
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = Game.PhaseStepState!.Value.ActivePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), 2).ToData(),
+                new PathSegment(new HexPosition(2, 2, HexDirection.Top), new HexPosition(3, 2, HexDirection.Top), 1).ToData()
+            ]
+        });
+
+        CommandPublisher.DidNotReceive().PublishCommand(Arg.Any<ChangeActivePlayerCommand>());
+    }
+
+    [Fact]
+    public void HandleCommand_WhenWalkWaterFall_AndCannotStandup_ShouldPublishChangeActivePlayer()
+    {
+        SetMap();
+        _sut.Enter();
+
+        var unit = Game.PhaseStepState!.Value.ActivePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+
+        var hex = Game.BattleMap!.GetHex(new HexCoordinates(2, 2));
+        hex!.AddTerrain(new Sanet.MakaMek.Map.Models.Terrains.WaterTerrain(-1));
+
+        var pilotDamagePsr = new PilotingSkillRollData
+        {
+            RollContext = new PilotDamageFromFallRollContext(1),
+            DiceResults = [2, 2],
+            IsSuccessful = false,
+            PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+        };
+
+        var fallContextData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new EnteringDeepWaterRollContext(1),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            PilotDamagePilotingSkillRoll = pilotDamagePsr,
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front)
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Walk)
+            .Returns(fallContextData);
+
+        var consciousnessCommand = new PilotConsciousnessRollCommand
+        {
+            GameOriginId = Guid.Empty,
+            PilotId = unit.Pilot!.Id,
+            UnitId = unit.Id,
+            IsRecoveryAttempt = false,
+            ConsciousnessNumber = 4,
+            DiceResults = [2, 2],
+            IsSuccessful = false,
+            Timestamp = DateTime.UtcNow
+        };
+        MockConsciousnessCalculator.MakeConsciousnessRolls(Arg.Any<IPilot>()).Returns([consciousnessCommand]);
+
+        CommandPublisher.ClearReceivedCalls();
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = Game.PhaseStepState!.Value.ActivePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), 2).ToData(),
+                new PathSegment(new HexPosition(2, 2, HexDirection.Top), new HexPosition(3, 2, HexDirection.Top), 1).ToData()
+            ]
+        });
+
+        CommandPublisher.Received().PublishCommand(Arg.Any<ChangeActivePlayerCommand>());
+    }
+
+    [Fact]
+    public void HandleCommand_WhenDeferredWaterFall_ShouldIgnoreMoveForOtherUnit()
+    {
+        SetMap();
+        _sut.Enter();
+        MockConsciousnessCalculator.MakeConsciousnessRolls(Arg.Any<IPilot>()).Returns([]);
+
+        var activePlayer = Game.PhaseStepState!.Value.ActivePlayer;
+        var unit1 = activePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        var unit2 = activePlayer.Units.First(u => u.Id != _unit1Id) as Mech;
+        unit1!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+        unit2!.Deploy(new HexPosition(5, 2, HexDirection.Top), null);
+
+        var waterHex = Game.BattleMap!.GetHex(new HexCoordinates(2, 2));
+        waterHex!.AddTerrain(new Sanet.MakaMek.Map.Models.Terrains.WaterTerrain(-1));
+
+        var fallContextData = new FallContextData
+        {
+            UnitId = unit1.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new EnteringDeepWaterRollContext(1),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front)
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(unit1, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Walk)
+            .Returns(fallContextData);
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = activePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), 2).ToData()
+            ]
+        });
+
+        var unit2PositionBefore = unit2.Position;
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = activePlayer.Id,
+            UnitId = unit2.Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(5, 2, HexDirection.Top), new HexPosition(5, 1, HexDirection.Bottom), 1).ToData()
+            ]
+        });
+
+        unit2.Position.ShouldBe(unit2PositionBefore);
+    }
+
+    [Fact]
+    public void HandleCommand_WhenDeferredWaterFall_CompletionMove_ShouldConsumeStepOnce()
+    {
+        SetMap();
+        _sut.Enter();
+        MockConsciousnessCalculator.MakeConsciousnessRolls(Arg.Any<IPilot>()).Returns([]);
+
+        var activePlayer = Game.PhaseStepState!.Value.ActivePlayer;
+        var unit = activePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+
+        var waterHex = Game.BattleMap!.GetHex(new HexCoordinates(2, 2));
+        waterHex!.AddTerrain(new Sanet.MakaMek.Map.Models.Terrains.WaterTerrain(-1));
+
+        var waterFallData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new EnteringDeepWaterRollContext(1),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front)
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(
+                unit,
+                Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1),
+                Game,
+                MovementType.Walk)
+            .Returns(waterFallData);
+
+        var psrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] };
+        var successfulPsrData = new PilotingSkillRollData
+        {
+            RollContext = new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt),
+            DiceResults = [6, 6],
+            IsSuccessful = true,
+            PsrBreakdown = psrBreakdown
+        };
+        var successfulStandupData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = false,
+            PilotingSkillRoll = successfulPsrData,
+            LevelsFallen = 0,
+            WasJumping = false
+        };
+        MockFallProcessor.ProcessMovementAttempt(
+                unit,
+                Arg.Is<PilotingSkillRollContext>(c => c.RollType == PilotingSkillRollType.StandupAttempt),
+                Game,
+                MovementType.StandingStill)
+            .Returns(successfulStandupData);
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = activePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), 2).ToData()
+            ]
+        });
+
+        _sut.HandleCommand(new TryStandupCommand
+        {
+            GameOriginId = Game.Id,
+            PlayerId = activePlayer.Id,
+            UnitId = _unit1Id,
+            Timestamp = DateTime.UtcNow,
+            NewFacing = HexDirection.Top,
+            MovementTypeAfterStandup = MovementType.Walk
+        });
+
+        CommandPublisher.ClearReceivedCalls();
+
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = activePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(2, 2, HexDirection.Top), new HexPosition(3, 2, HexDirection.Top), 1).ToData()
+            ]
+        });
+
+        CommandPublisher.Received(1).PublishCommand(Arg.Any<ChangeActivePlayerCommand>());
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -1268,6 +1268,82 @@ public class MovementPhaseTests : GamePhaseTestsBase
     }
 
     [Fact]
+    public void ProcessMoveCommand_WhenWalkWaterFall_AndCannotStandup_ShouldPublishCompletionCommand()
+    {
+        // Arrange
+        SetMap();
+        _sut.Enter();
+
+        var unit = Game.PhaseStepState!.Value.ActivePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+
+        var hex = Game.BattleMap!.GetHex(new HexCoordinates(2, 2));
+        hex!.AddTerrain(new Sanet.MakaMek.Map.Models.Terrains.WaterTerrain(-1));
+
+        var fallContextData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new EnteringDeepWaterRollContext(1),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front)
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Walk)
+            .Returns(fallContextData);
+
+        // Make the unit unable to stand up (e.g., by shutting it down)
+        var shutdownData = new ShutdownData
+        {
+            Reason = ShutdownReason.Voluntary,
+            Turn = 1
+        };
+        unit.Shutdown(shutdownData);
+        unit.CanStandup().ShouldBeFalse();
+
+        CommandPublisher.ClearReceivedCalls();
+
+        var moveCommand = new MoveUnitCommand
+        {
+            MovementType = MovementType.Walk,
+            GameOriginId = Game.Id,
+            PlayerId = Game.PhaseStepState!.Value.ActivePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), 2).ToData(),
+                new PathSegment(new HexPosition(2, 2, HexDirection.Top), new HexPosition(3, 2, HexDirection.Top), 1).ToData()
+            ]
+        };
+
+        // Act
+        _sut.HandleCommand(moveCommand);
+
+        // Assert
+        // The completion command should have IsCompleted=true and contain only the last segment of the truncated path
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
+            cmd.UnitId == _unit1Id &&
+            cmd.IsCompleted &&
+            cmd.MovementPath.Count == 1 &&
+            cmd.MovementPath[0].To.Coordinates.Q == 2)); // truncated to first water-adjacent hex
+        // The truncated command (before completion) should also be published with IsCompleted=false
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
+            cmd.UnitId == _unit1Id &&
+            !cmd.IsCompleted &&
+            cmd.MovementPath.Count == 1 &&
+            cmd.MovementPath[0].To.Coordinates.Q == 2));
+    }
+
+    [Fact]
     public void Exit_ShouldClearDeferralState()
     {
         SetMap();

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -348,6 +348,23 @@ public class MechTests
         sut.Position!.Facing.ShouldBe(HexDirection.Bottom);
     }
 
+    [Fact]
+    public void CanStandup_ReturnsFalse_WhenMovementCompleted()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        var deployPosition = new HexPosition(new HexCoordinates(0, 0), HexDirection.Top);
+        sut.Deploy(deployPosition, null);
+        sut.SetProne();
+
+        // Act
+        sut.Move(MovementPath.CreateStandingStillPath(deployPosition), null, isCompleted: true);
+
+        // Assert
+        sut.HasMoved.ShouldBeTrue();
+        sut.CanStandup().ShouldBeFalse();
+    }
+
     [Theory]
     [InlineData(0, HexDirection.Top, HexDirection.TopRight, false)] // No rotation allowed
     [InlineData(1, HexDirection.Top, HexDirection.TopRight, true)] // 60 degrees allowed, within limit

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -353,10 +353,16 @@ public class MechTests
     {
         // Arrange
         var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        
+        var pilot = Substitute.For<IPilot>();
+        pilot.IsConscious.Returns(true);
+        sut.AssignPilot(pilot);
         var deployPosition = new HexPosition(new HexCoordinates(0, 0), HexDirection.Top);
         sut.Deploy(deployPosition, null);
         sut.SetProne();
 
+        sut.CanStandup().ShouldBeTrue();
+        
         // Act
         sut.Move(MovementPath.CreateStandingStillPath(deployPosition), null, isCompleted: true);
 

--- a/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
@@ -9,6 +9,8 @@ public class FakeLocalizationServiceTests
     [InlineData("Command_JoinGame", "{0} has joined game with {1} units")]
     [InlineData("Command_PlayerLeft", "{0} has left the game")]
     [InlineData("Command_MoveUnit", "{0} moved {1} to {2} facing {3} using {4}")]
+    [InlineData("Command_MoveUnit_Completed", "Movement completed")]
+    [InlineData("Command_MoveUnit_Incomplete", "Movement was interrupted")]
     [InlineData("Command_DeployUnit", "{0} deployed {1} to {2} facing {3}")]
     [InlineData("Command_TryStandup", "{0} attempts to stand up {1}")]
     [InlineData("Command_MechStandup", "{0} Mech stood up successfully. {1}")]

--- a/tests/MakaMek.Presentation.Tests/UiStates/DeploymentStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/DeploymentStateTests.cs
@@ -80,7 +80,9 @@ public class DeploymentStateTests
             Arg.Any<Type>(),
             Arg.Any<int>(),
             Arg.Any<string>(),
-            Arg.Any<Guid?>())
+            Arg.Any<Guid?>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>())
             .Returns(idempotencyKey);
         
         _game.JoinGameWithUnits(player,[],[]);

--- a/tests/MakaMek.Presentation.Tests/UiStates/DeploymentStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/DeploymentStateTests.cs
@@ -141,6 +141,13 @@ public class DeploymentStateTests
     }
 
     [Fact]
+    public void CanSelectUnit_UsesDefaultInterfaceImplementation()
+    {
+        var other = Substitute.For<IUnit>();
+        ((IUiState)_sut).CanSelectUnit(other).ShouldBeTrue();
+    }
+
+    [Fact]
     public void HandleUnitSelection_TransitionsToHexSelection_IfActivePlayerIsLocal()
     {
         // Act

--- a/tests/MakaMek.Presentation.Tests/UiStates/EndStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/EndStateTests.cs
@@ -91,7 +91,9 @@ public class EndStateTests
             Arg.Any<Type>(),
             Arg.Any<int>(),
             Arg.Any<string>(),
-            Arg.Any<Guid?>())
+            Arg.Any<Guid?>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>())
             .Returns(idempotencyKey);
         
         _game.JoinGameWithUnits(_player,[],[]);

--- a/tests/MakaMek.Presentation.Tests/UiStates/EndStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/EndStateTests.cs
@@ -624,6 +624,13 @@ public class EndStateTests
         actions.ShouldNotContain(action => action.Label.Contains("Startup"));
     }
 
+    [Fact]
+    public void CanSelectUnit_UsesDefaultInterfaceImplementation()
+    {
+        var unit = Substitute.For<IUnit>();
+        ((IUiState)_sut).CanSelectUnit(unit).ShouldBeTrue();
+    }
+
     private void SetPhase(PhaseNames phase)
     {
         _game.HandleCommand(new ChangePhaseCommand

--- a/tests/MakaMek.Presentation.Tests/UiStates/IdleStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/IdleStateTests.cs
@@ -1,5 +1,7 @@
+using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Presentation.UiStates;
 using Shouldly;
+using NSubstitute;
 
 namespace Sanet.MakaMek.Presentation.Tests.UiStates;
 
@@ -24,5 +26,12 @@ public class IdleStateTests
     {
         // Assert
         _sut.IsActionRequired.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanSelectUnit_UsesDefaultInterfaceImplementation()
+    {
+        var unit = Substitute.For<IUnit>();
+        ((IUiState)_sut).CanSelectUnit(unit).ShouldBeTrue();
     }
 }

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Reactive.Concurrency;
 using NSubstitute;
 using Sanet.MakaMek.Assets.Services;
@@ -175,6 +176,14 @@ public class MovementStateTests
     {
         _game.PhaseStepState.Returns(new PhaseStepState(PhaseNames.Movement, _player, 1));
         _game.CanActivePlayerAct.Returns(true);
+    }
+
+    // Clears MovementState's internal _selectedUnit (same field CompleteMovement() nulls) for post-command scenarios.
+    private static void ClearMovementStateInternalSelectedUnit(MovementState state)
+    {
+        var field = typeof(MovementState).GetField("_selectedUnit", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("MovementState._selectedUnit field not found");
+        field.SetValue(state, null);
     }
 
 
@@ -1775,11 +1784,13 @@ public class MovementStateTests
     {
         // Arrange
         var unit = Substitute.For<IUnit>();
+        var unitId = Guid.NewGuid();
+        unit.Id.Returns(unitId);
         unit.Position.Returns(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
         _sut.HandleUnitSelection(unit);
 
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall())
+        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall(unitId))
             .Message.ShouldBe("Unit is not prone after fall or no movement path");
     }
 
@@ -1793,8 +1804,51 @@ public class MovementStateTests
         _sut.HandleUnitSelection(mech);
 
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall())
+        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall(mech.Id))
             .Message.ShouldBe("Unit is not prone after fall or no movement path");
+    }
+
+    [Fact]
+    public void ResumeMovementAfterFall_PostCompleteMovementSelection_WhenCanStandup_TransitionsToSelectingMovementType()
+    {
+        // Water-fall: internal _selectedUnit is cleared after CompleteMovement() while MechFallCommand still arrives with unitId.
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        mech.SetProne();
+        mech.CanStandup().ShouldBeTrue();
+
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+
+        ClearMovementStateInternalSelectedUnit(_sut);
+
+        _sut.ResumeMovementAfterFall(mech.Id);
+
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
+    }
+
+    [Fact]
+    public void ResumeMovementAfterFall_PostCompleteMovementSelection_WhenCannotStandup_CompletesMovement()
+    {
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        mech.SetProne();
+        mech.Shutdown(new ShutdownData { Reason = ShutdownReason.Voluntary, Turn = 1 });
+        mech.CanStandup().ShouldBeFalse();
+
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+
+        ClearMovementStateInternalSelectedUnit(_sut);
+
+        _sut.ResumeMovementAfterFall(mech.Id);
+
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
+        _game.Received().MoveUnit(Arg.Any<MoveUnitCommand>());
     }
 
     [Fact]
@@ -1814,7 +1868,7 @@ public class MovementStateTests
         mech.CanStandup().ShouldBeFalse();
         
         // Act
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         // Assert
         _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
@@ -1839,7 +1893,7 @@ public class MovementStateTests
         _sut.HandleMovementTypeSelection(MovementType.Walk); // Sets up _selectedPath
 
         // Act
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         // Assert
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
@@ -1869,7 +1923,7 @@ public class MovementStateTests
         mech.CanStandup().ShouldBeFalse();
         
         // Act
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         // Assert - movement should complete without allowing standup
         _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
@@ -1897,7 +1951,7 @@ public class MovementStateTests
         mech.SetProne();
 
         // Game calls ResumeMovementAfterFall, transitioning back to SelectingMovementTypeStep
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
 
         // Act
@@ -1930,7 +1984,7 @@ public class MovementStateTests
         _sut.HandleUnitSelection(mech);
         _sut.HandleMovementTypeSelection(MovementType.Walk);
         mech.SetProne();
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         var actions = _sut.GetAvailableActions().ToList();
         actions.Count.ShouldBe(1);
@@ -1966,7 +2020,7 @@ public class MovementStateTests
         // Simulate fall during movement: select unit, pick Walk (sets _selectedPath), then unit already fell
         _sut.HandleUnitSelection(mech);
         _sut.HandleMovementTypeSelection(MovementType.Walk); // sets _selectedPath with Walk type
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
 
         // Act

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Reactive.Concurrency;
 using NSubstitute;
 using Sanet.MakaMek.Assets.Services;
@@ -176,14 +175,6 @@ public class MovementStateTests
     {
         _game.PhaseStepState.Returns(new PhaseStepState(PhaseNames.Movement, _player, 1));
         _game.CanActivePlayerAct.Returns(true);
-    }
-
-    // Clears MovementState's internal _selectedUnit (same field CompleteMovement() nulls) for post-command scenarios.
-    private static void ClearMovementStateInternalSelectedUnit(MovementState state)
-    {
-        var field = typeof(MovementState).GetField("_selectedUnit", BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("MovementState._selectedUnit field not found");
-        field.SetValue(state, null);
     }
 
 
@@ -1784,13 +1775,11 @@ public class MovementStateTests
     {
         // Arrange
         var unit = Substitute.For<IUnit>();
-        var unitId = Guid.NewGuid();
-        unit.Id.Returns(unitId);
         unit.Position.Returns(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
         _sut.HandleUnitSelection(unit);
 
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall(unitId))
+        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall())
             .Message.ShouldBe("Unit is not prone after fall or no movement path");
     }
 
@@ -1804,51 +1793,8 @@ public class MovementStateTests
         _sut.HandleUnitSelection(mech);
 
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall(mech.Id))
+        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall())
             .Message.ShouldBe("Unit is not prone after fall or no movement path");
-    }
-
-    [Fact]
-    public void ResumeMovementAfterFall_PostCompleteMovementSelection_WhenCanStandup_TransitionsToSelectingMovementType()
-    {
-        // Water-fall: internal _selectedUnit is cleared after CompleteMovement() while MechFallCommand still arrives with unitId.
-        SetPhase(PhaseNames.Movement);
-        SetActivePlayer();
-        var mech = _unit1 as Mech;
-        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
-        mech.SetProne();
-        mech.CanStandup().ShouldBeTrue();
-
-        _sut.HandleUnitSelection(mech);
-        _sut.HandleMovementTypeSelection(MovementType.Walk);
-
-        ClearMovementStateInternalSelectedUnit(_sut);
-
-        _sut.ResumeMovementAfterFall(mech.Id);
-
-        _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
-    }
-
-    [Fact]
-    public void ResumeMovementAfterFall_PostCompleteMovementSelection_WhenCannotStandup_CompletesMovement()
-    {
-        SetPhase(PhaseNames.Movement);
-        SetActivePlayer();
-        var mech = _unit1 as Mech;
-        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
-        mech.SetProne();
-        mech.Shutdown(new ShutdownData { Reason = ShutdownReason.Voluntary, Turn = 1 });
-        mech.CanStandup().ShouldBeFalse();
-
-        _sut.HandleUnitSelection(mech);
-        _sut.HandleMovementTypeSelection(MovementType.Walk);
-
-        ClearMovementStateInternalSelectedUnit(_sut);
-
-        _sut.ResumeMovementAfterFall(mech.Id);
-
-        _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
-        _game.Received().MoveUnit(Arg.Any<MoveUnitCommand>());
     }
 
     [Fact]
@@ -1868,7 +1814,7 @@ public class MovementStateTests
         mech.CanStandup().ShouldBeFalse();
         
         // Act
-        _sut.ResumeMovementAfterFall(mech.Id);
+        _sut.ResumeMovementAfterFall();
 
         // Assert
         _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
@@ -1893,7 +1839,7 @@ public class MovementStateTests
         _sut.HandleMovementTypeSelection(MovementType.Walk); // Sets up _selectedPath
 
         // Act
-        _sut.ResumeMovementAfterFall(mech.Id);
+        _sut.ResumeMovementAfterFall();
 
         // Assert
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
@@ -1923,7 +1869,7 @@ public class MovementStateTests
         mech.CanStandup().ShouldBeFalse();
         
         // Act
-        _sut.ResumeMovementAfterFall(mech.Id);
+        _sut.ResumeMovementAfterFall();
 
         // Assert - movement should complete without allowing standup
         _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
@@ -1951,7 +1897,7 @@ public class MovementStateTests
         mech.SetProne();
 
         // Game calls ResumeMovementAfterFall, transitioning back to SelectingMovementTypeStep
-        _sut.ResumeMovementAfterFall(mech.Id);
+        _sut.ResumeMovementAfterFall();
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
 
         // Act
@@ -1984,7 +1930,7 @@ public class MovementStateTests
         _sut.HandleUnitSelection(mech);
         _sut.HandleMovementTypeSelection(MovementType.Walk);
         mech.SetProne();
-        _sut.ResumeMovementAfterFall(mech.Id);
+        _sut.ResumeMovementAfterFall();
 
         var actions = _sut.GetAvailableActions().ToList();
         actions.Count.ShouldBe(1);
@@ -2020,7 +1966,7 @@ public class MovementStateTests
         // Simulate fall during movement: select unit, pick Walk (sets _selectedPath), then unit already fell
         _sut.HandleUnitSelection(mech);
         _sut.HandleMovementTypeSelection(MovementType.Walk); // sets _selectedPath with Walk type
-        _sut.ResumeMovementAfterFall(mech.Id);
+        _sut.ResumeMovementAfterFall();
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
 
         // Act

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -52,6 +52,12 @@ public class MovementStateTests
     private readonly IImageService _imageService = Substitute.For<IImageService>();
     private readonly ITerrainAssetService _terrainAssetsService = Substitute.For<ITerrainAssetService>();
 
+    private static void BindViewModelCurrentStateTo(MovementState state, BattleMapViewModel viewModel)
+    {
+        typeof(BattleMapViewModel).GetProperty(nameof(BattleMapViewModel.CurrentState))!
+            .GetSetMethod(true)!.Invoke(viewModel, [state]);
+    }
+
     public MovementStateTests()
     {
         // Mock localization service responses
@@ -1779,7 +1785,7 @@ public class MovementStateTests
         _sut.HandleUnitSelection(unit);
 
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall())
+        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall(unit.Id))
             .Message.ShouldBe("Unit is not prone after fall or no movement path");
     }
 
@@ -1793,7 +1799,7 @@ public class MovementStateTests
         _sut.HandleUnitSelection(mech);
 
         // Act & Assert
-        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall())
+        Should.Throw<InvalidOperationException>(() => _sut.ResumeMovementAfterFall(mech.Id))
             .Message.ShouldBe("Unit is not prone after fall or no movement path");
     }
 
@@ -1814,7 +1820,7 @@ public class MovementStateTests
         mech.CanStandup().ShouldBeFalse();
         
         // Act
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         // Assert
         _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
@@ -1839,7 +1845,7 @@ public class MovementStateTests
         _sut.HandleMovementTypeSelection(MovementType.Walk); // Sets up _selectedPath
 
         // Act
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         // Assert
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
@@ -1869,7 +1875,7 @@ public class MovementStateTests
         mech.CanStandup().ShouldBeFalse();
         
         // Act
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         // Assert - movement should complete without allowing standup
         _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
@@ -1897,7 +1903,7 @@ public class MovementStateTests
         mech.SetProne();
 
         // Game calls ResumeMovementAfterFall, transitioning back to SelectingMovementTypeStep
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
 
         // Act
@@ -1930,7 +1936,7 @@ public class MovementStateTests
         _sut.HandleUnitSelection(mech);
         _sut.HandleMovementTypeSelection(MovementType.Walk);
         mech.SetProne();
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
 
         var actions = _sut.GetAvailableActions().ToList();
         actions.Count.ShouldBe(1);
@@ -1966,7 +1972,7 @@ public class MovementStateTests
         // Simulate fall during movement: select unit, pick Walk (sets _selectedPath), then unit already fell
         _sut.HandleUnitSelection(mech);
         _sut.HandleMovementTypeSelection(MovementType.Walk); // sets _selectedPath with Walk type
-        _sut.ResumeMovementAfterFall();
+        _sut.ResumeMovementAfterFall(mech.Id);
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
 
         // Act
@@ -1977,6 +1983,141 @@ public class MovementStateTests
         actions[0].Label.ShouldStartWith("Attempt Standup");
         actions[0].Label.ShouldContain("%"); // probability appended
         actions[0].Label.ShouldNotContain("Walk | MP:");
+    }
+
+    [Fact]
+    public void ResumeMovementAfterFall_Ignores_WhenUnitIdDoesNotMatchSelectedUnit()
+    {
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        var stepBefore = _sut.CurrentMovementStep;
+        mech.SetProne();
+
+        _sut.ResumeMovementAfterFall(Guid.NewGuid());
+
+        _sut.CurrentMovementStep.ShouldBe(stepBefore);
+        ((IUiState)_sut).CanSelectUnit(_unit2).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CanSelectUnit_BlocksOtherFriendly_WhenDeferredAfterFall()
+    {
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech1 = _unit1 as Mech;
+        mech1!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        var mechFactory = new MechFactory(_rulesProvider, _componentProvider, _localizationService);
+        var allyData = MechFactoryTests.CreateDummyMechData();
+        allyData.Id = Guid.NewGuid();
+        var ally = mechFactory.Create(allyData);
+        ally.AssignPilot(_pilot);
+        _player.AddUnit(ally);
+        ally.Deploy(new HexPosition(new HexCoordinates(2, 1), HexDirection.Top), null);
+
+        _pilotingSkillCalculator.GetPsrBreakdown(mech1, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        _sut.HandleUnitSelection(mech1);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech1.SetProne();
+        _sut.ResumeMovementAfterFall(mech1.Id);
+
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingMovementType);
+
+        ((IUiState)_sut).CanSelectUnit(ally).ShouldBeFalse();
+        ((IUiState)_sut).CanSelectUnit(mech1).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void HandleHexSelection_DoesNotChangeSelectedUnit_WhenDeferredBlocksOtherFriendly()
+    {
+        BindViewModelCurrentStateTo(_sut, _battleMapViewModel);
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech1 = _unit1 as Mech;
+        mech1!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        var mechFactory = new MechFactory(_rulesProvider, _componentProvider, _localizationService);
+        var allyData = MechFactoryTests.CreateDummyMechData();
+        allyData.Id = Guid.NewGuid();
+        var ally = mechFactory.Create(allyData);
+        ally.AssignPilot(_pilot);
+        _player.AddUnit(ally);
+        ally.Deploy(new HexPosition(new HexCoordinates(2, 1), HexDirection.Top), null);
+
+        _pilotingSkillCalculator.GetPsrBreakdown(mech1, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        _battleMapViewModel.SelectedUnit = mech1;
+        _sut.HandleUnitSelection(mech1);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech1.SetProne();
+        _sut.ResumeMovementAfterFall(mech1.Id);
+
+        var allyHex = _game.BattleMap!.GetHex(ally.Position!.Coordinates)!;
+        _sut.HandleHexSelection(allyHex);
+
+        _battleMapViewModel.SelectedUnit.ShouldBe(mech1);
+    }
+
+    [Fact]
+    public void SelectedUnitSetter_DoesNotChangeSelection_WhenCanSelectUnitFalse()
+    {
+        BindViewModelCurrentStateTo(_sut, _battleMapViewModel);
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech1 = _unit1 as Mech;
+        mech1!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        var mechFactory = new MechFactory(_rulesProvider, _componentProvider, _localizationService);
+        var allyData = MechFactoryTests.CreateDummyMechData();
+        allyData.Id = Guid.NewGuid();
+        var ally = mechFactory.Create(allyData);
+        ally.AssignPilot(_pilot);
+        _player.AddUnit(ally);
+        ally.Deploy(new HexPosition(new HexCoordinates(2, 1), HexDirection.Top), null);
+
+        _pilotingSkillCalculator.GetPsrBreakdown(mech1, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        _battleMapViewModel.SelectedUnit = mech1;
+        _sut.HandleUnitSelection(mech1);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech1.SetProne();
+        _sut.ResumeMovementAfterFall(mech1.Id);
+
+        _battleMapViewModel.SelectedUnit = ally;
+
+        _battleMapViewModel.SelectedUnit.ShouldBe(mech1);
+    }
+
+    [Fact]
+    public void HandleUnitSelection_AllowsDeferredUnit_WhenHasMoved()
+    {
+        BindViewModelCurrentStateTo(_sut, _battleMapViewModel);
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech1 = _unit1 as Mech;
+        mech1!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+
+        _pilotingSkillCalculator.GetPsrBreakdown(mech1, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        _battleMapViewModel.SelectedUnit = mech1;
+        _sut.HandleUnitSelection(mech1);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech1.SetProne();
+        _sut.ResumeMovementAfterFall(mech1.Id);
+
+        mech1.Move(MovementPath.CreateStandingStillPath(mech1.Position!), null, isCompleted: true);
+        mech1.HasMoved.ShouldBeTrue();
+
+        _battleMapViewModel.SelectedUnit = null;
+        _battleMapViewModel.SelectedUnit = mech1;
+
+        _battleMapViewModel.SelectedUnit.ShouldBe(mech1);
     }
 }
 

--- a/tests/MakaMek.Presentation.Tests/UiStates/WeaponsAttackStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/WeaponsAttackStateTests.cs
@@ -2306,4 +2306,11 @@ public class WeaponsAttackStateTests
             cmd.WeaponTargets[0].TargetId == target.Id
         ));
     }
+
+    [Fact]
+    public void CanSelectUnit_UsesDefaultInterfaceImplementation()
+    {
+        var unit = Substitute.For<IUnit>();
+        ((IUiState)_sut).CanSelectUnit(unit).ShouldBeTrue();
+    }
 }

--- a/tests/MakaMek.Presentation.Tests/UiStates/WeaponsAttackStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/WeaponsAttackStateTests.cs
@@ -97,7 +97,9 @@ public class WeaponsAttackStateTests
             Arg.Any<Type>(),
             Arg.Any<int>(),
             Arg.Any<string>(),
-            Arg.Any<Guid?>())
+            Arg.Any<Guid?>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>())
             .Returns(idempotencyKey);
         
         var battleMap = BattleMapFactory.GenerateMap(

--- a/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
@@ -2141,6 +2141,93 @@ public class BattleMapViewModelTests
     }
 
     [Fact]
+    public void ProcessMechFall_ShouldResumeMovement_WhenSelectedUnitIsNull_ButMovementStateTracksUnit()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var player = new Player(playerId, "Player1", PlayerControlType.Human);
+        var mechData = MechFactoryTests.CreateDummyMechData();
+        mechData.Id = Guid.NewGuid();
+        var game = CreateClientGame();
+        game.JoinGameWithUnits(player, [mechData], []);
+        game.SetBattleMap(BattleMapFactory.GenerateMap(2, 2,
+            new SingleTerrainGenerator(2, 2, new ClearTerrain())));
+        _sut.Game = game;
+
+        game.HandleCommand(new JoinGameCommand
+        {
+            PlayerId = player.Id,
+            Units = [mechData],
+            PlayerName = player.Name,
+            GameOriginId = Guid.NewGuid(),
+            Tint = "#FF0000",
+            PilotAssignments = [],
+            IdempotencyKey = _idempotencyKey
+        });
+
+        game.HandleCommand(new ChangePhaseCommand
+        {
+            Phase = PhaseNames.Movement,
+            GameOriginId = Guid.NewGuid()
+        });
+
+        game.HandleCommand(new ChangeActivePlayerCommand
+        {
+            PlayerId = player.Id,
+            GameOriginId = Guid.NewGuid(),
+            UnitsToPlay = 1
+        });
+
+        var position = new HexPosition(new HexCoordinates(1, 1), HexDirection.Bottom);
+        var unit = _sut.Units.First() as Mech;
+        var pilot = Substitute.For<IPilot>();
+        pilot.IsConscious.Returns(true);
+        unit!.AssignPilot(pilot);
+        unit.Deploy(position, null);
+
+        _sut.HandleHexSelection(game.BattleMap!.GetHexes().First(h => h.Coordinates == position.Coordinates));
+
+        var movementState = _sut.CurrentState as MovementState;
+        movementState.ShouldNotBeNull();
+
+        game.PilotingSkillCalculator.GetPsrBreakdown(unit, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown
+            {
+                BasePilotingSkill = 4,
+                Modifiers = []
+            });
+
+        var action = movementState.GetAvailableActions()
+            .First(a => a.Label.StartsWith("Walk"));
+        action.OnExecute();
+
+        _sut.SelectedUnit = null;
+
+        var fallCommand = new MechFallCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            UnitId = unit.Id,
+            LevelsFallen = 0,
+            WasJumping = false,
+            DamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 0),
+                new DiceResult(1),
+                HitDirection.Front
+            )
+        };
+
+        // Act
+        game.HandleCommand(fallCommand);
+
+        // Assert
+        _localizationService.GetString("Action_StayProne").Returns("StayProne");
+        var actions = movementState.GetAvailableActions().ToList();
+        actions.Count.ShouldBe(1);
+        actions.ShouldContain(a => a.Label.Contains("Walk"));
+    }
+
+    [Fact]
     public void ProcessMechFall_ShouldNotCallProcessMechStandUp_WhenDamageDataIsNull()
     {
         // Arrange

--- a/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
@@ -64,7 +64,9 @@ public class BattleMapViewModelTests
             Arg.Any<Type>(),
             Arg.Any<int>(),
             Arg.Any<string>(),
-            Arg.Any<Guid?>())
+            Arg.Any<Guid?>(),
+            Arg.Any<int>(),
+            Arg.Any<string?>())
             .Returns(_idempotencyKey);
         var imageService = Substitute.For<IImageService>();
         var dispatcherService = Substitute.For<IDispatcherService>();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deferred movement flow: after a fall, movement can be resumed for the specific unit and other unit selection is temporarily blocked until resolved.
  * Move notifications now indicate whether a movement was completed or interrupted.

* **Bug Fixes**
  * Units that have already completed movement can no longer stand up.
  * Deep-water fall handling improved to publish correct truncated vs final move updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anton-makarevich/MakaMek/pull/931)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->