### PR TITLE
add stay prone and change facing actions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.56.32</Version>
+        <Version>0.56.33</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Presentation/UiStates/MovementState.cs
+++ b/src/MakaMek.Presentation/UiStates/MovementState.cs
@@ -288,7 +288,19 @@ public class MovementState : IUiState
                 if (_selectedPath != null)
                 {
                     var lockedType = _selectedPath.MovementType;
-                    var lockedProneActions = new List<StateAction>();
+                    var lockedProneActions = new List<StateAction>
+                    {
+                        // Stay Prone - always available in post-fall state
+                        new(
+                            _viewModel.LocalizationService.GetString("Action_StayProne"),
+                            true,
+                            () =>
+                            {
+                                _builder.SetUnit(_selectedUnit);
+                                _builder.SetMovementPath(_selectedPath);
+                                CompleteMovement();
+                            })
+                    };
 
                     if (!mech.CanStandup()) return lockedProneActions;
 
@@ -317,6 +329,16 @@ public class MovementState : IUiState
                             lockedActionText,
                             true,
                             () => AttemptStandup(lockedType)));
+                    }
+
+                    // Change Facing action - if mech can change facing while prone
+                    if (mech.CanChangeFacingWhileProne())
+                    {
+                        var availableMp = mech.GetMovementPoints(MovementType.Walk);
+                        lockedProneActions.Add(new StateAction(
+                            string.Format(_viewModel.LocalizationService.GetString("Action_ChangeFacing"), availableMp),
+                            true,
+                            () => HandleProneFacingChange(mech)));
                     }
 
                     return lockedProneActions;

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/WeaponSelectionViewModel.cs
@@ -191,7 +191,9 @@ public class WeaponSelectionViewModel : BindableBase
 
     // Additional properties for UI display
     public string Name => Weapon.Name;
-    public string RangeInfo => $"{Weapon.Range.LongRange}";
+    public string RangeInfo =>Weapon.Range!=null 
+        ? $"{Weapon.Range.LongRange}"
+        : "-";
 
     public string Damage => $"{Weapon.Damage}";
     public string Heat => $"{Weapon.Heat}";

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -1951,14 +1951,16 @@ public class MovementStateTests
         // Act
         var actions = _sut.GetAvailableActions().ToList();
 
-        // Assert — exactly one action locked to the originally declared movement type
-        actions.Count.ShouldBe(1, "Post-fall should only offer the single locked standup option");
+        // Assert — Stay Prone is first, then standup locked to the originally declared movement type, then Change Facing
+        actions.Count.ShouldBe(3, "Post-fall should offer Stay Prone, locked standup, and Change Facing");
+
+        actions[0].Label.ShouldBe("Stay Prone");
 
         var expectedTypeLabel = selectedBeforeFall == MovementType.Run ? "Run" : "Walk";
-        actions[0].Label.ShouldContain(expectedTypeLabel);
+        actions[1].Label.ShouldContain(expectedTypeLabel);
 
-        actions.ShouldNotContain(a => a.Label.Contains("Stay Prone"));
-        actions.ShouldNotContain(a => a.Label.Contains("Change Facing"));
+        var changeFacingAction = actions[2];
+        changeFacingAction.Label.ShouldBe("Change Facing | MP: 8");
 
         var otherTypeLabel = selectedBeforeFall == MovementType.Run ? "Walk" : "Run";
         actions.ShouldNotContain(a => a.Label.Contains(otherTypeLabel));
@@ -1981,10 +1983,11 @@ public class MovementStateTests
         _sut.ResumeMovementAfterFall(mech.Id);
 
         var actions = _sut.GetAvailableActions().ToList();
-        actions.Count.ShouldBe(1);
+        actions.Count.ShouldBe(3);
+        actions[0].Label.ShouldBe("Stay Prone");
 
-        // Act — execute the locked standup action
-        actions[0].OnExecute();
+        // Act — execute the locked standup action (at index 1, after Stay Prone)
+        actions[1].OnExecute();
 
         // Assert — should transition to direction selection for standup
         _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingStandingUpDirection);
@@ -2020,11 +2023,101 @@ public class MovementStateTests
         // Act
         var actions = _sut.GetAvailableActions().ToList();
 
-        // Assert — exactly one action using the "Attempt Standup" label (not the "Walk | MP: X" form)
-        actions.Count.ShouldBe(1);
-        actions[0].Label.ShouldStartWith("Attempt Standup");
-        actions[0].Label.ShouldContain("%"); // probability appended
-        actions[0].Label.ShouldNotContain("Walk | MP:");
+        // Assert — Stay Prone first, then Attempt Standup, then Change Facing
+        actions.Count.ShouldBe(3);
+        actions[0].Label.ShouldBe("Stay Prone");
+        actions[1].Label.ShouldStartWith("Attempt Standup");
+        actions[1].Label.ShouldContain("%"); // probability appended
+        actions[1].Label.ShouldNotContain("Walk | MP:");
+    }
+
+    [Fact]
+    public void GetAvailableActions_PostFallProneMech_StayProneAction_CompletesMovement()
+    {
+        // Arrange
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        _pilotingSkillCalculator.GetPsrBreakdown(mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech.SetProne();
+        _sut.ResumeMovementAfterFall(mech.Id);
+
+        var actions = _sut.GetAvailableActions().ToList();
+        var stayProneAction = actions[0];
+        stayProneAction.Label.ShouldBe("Stay Prone");
+
+        // Act
+        stayProneAction.OnExecute();
+
+        // Assert
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.Completed);
+        _game.Received().MoveUnit(Arg.Any<MoveUnitCommand>());
+    }
+
+    [Fact]
+    public void GetAvailableActions_PostFallProneMech_DoesNotShowChangeFacingAction_WhenNoMP()
+    {
+        // Arrange
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        _pilotingSkillCalculator.GetPsrBreakdown(mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        // Destroy both legs so mech has 0 walk MP
+        var leftLeg = mech.Parts[PartLocation.LeftLeg];
+        leftLeg.ApplyDamage(20, HitDirection.Front);
+        var rightLeg = mech.Parts[PartLocation.RightLeg];
+        rightLeg.ApplyDamage(20, HitDirection.Front);
+
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech.SetProne();
+
+        _sut.ResumeMovementAfterFall(mech.Id);
+
+        // Act
+        var actions = _sut.GetAvailableActions().ToList();
+
+        // Assert
+        actions.ShouldNotContain(a => a.Label.Contains("Change Facing"));
+    }
+
+    [Fact]
+    public void GetAvailableActions_PostFallProneMech_ChangeFacingAction_TransitionsToSelectingDirectionStep()
+    {
+        // Arrange
+        SetPhase(PhaseNames.Movement);
+        SetActivePlayer();
+        var mech = _unit1 as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        _pilotingSkillCalculator.GetPsrBreakdown(mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
+            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
+
+        _sut.HandleUnitSelection(mech);
+        _sut.HandleMovementTypeSelection(MovementType.Walk);
+        mech.SetProne();
+        _sut.ResumeMovementAfterFall(mech.Id);
+
+        var actions = _sut.GetAvailableActions().ToList();
+        var changeFacingAction = actions.FirstOrDefault(a => a.Label.Contains("Change Facing"));
+        changeFacingAction.ShouldNotBeNull();
+
+        // Act
+        changeFacingAction.OnExecute();
+
+        // Assert
+        _sut.CurrentMovementStep.ShouldBe(MovementStep.SelectingDirection);
+        _battleMapViewModel.IsDirectionSelectorVisible.ShouldBeTrue();
+        _battleMapViewModel.DirectionSelectorPosition.ShouldBe(mech.Position!.Coordinates);
+        _battleMapViewModel.AvailableDirections.ShouldNotBeNull();
+        _battleMapViewModel.AvailableDirections.ShouldNotBeEmpty();
     }
 
     [Fact]

--- a/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
+++ b/tests/MakaMek.Presentation.Tests/UiStates/MovementStateTests.cs
@@ -2060,32 +2060,28 @@ public class MovementStateTests
     }
 
     [Fact]
-    public void GetAvailableActions_PostFallProneMech_DoesNotShowChangeFacingAction_WhenNoMP()
+    public void GetAvailableActions_ProneMech_DoesNotShowChangeFacingAction_WhenNoMP()
     {
         // Arrange
         SetPhase(PhaseNames.Movement);
         SetActivePlayer();
         var mech = _unit1 as Mech;
         mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
-        _pilotingSkillCalculator.GetPsrBreakdown(mech, new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt))
-            .Returns(new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] });
 
-        // Destroy both legs so mech has 0 walk MP
+        // Destroy both legs so mech has 0 walk MP (but not both arms, so IsImmobile is false)
         var leftLeg = mech.Parts[PartLocation.LeftLeg];
         leftLeg.ApplyDamage(20, HitDirection.Front);
         var rightLeg = mech.Parts[PartLocation.RightLeg];
         rightLeg.ApplyDamage(20, HitDirection.Front);
 
         _sut.HandleUnitSelection(mech);
-        _sut.HandleMovementTypeSelection(MovementType.Walk);
         mech.SetProne();
-
-        _sut.ResumeMovementAfterFall(mech.Id);
 
         // Act
         var actions = _sut.GetAvailableActions().ToList();
 
         // Assert
+        actions.ShouldNotBeEmpty("Prone mech should have at least 'Stay Prone' available");
         actions.ShouldNotContain(a => a.Label.Contains("Change Facing"));
     }
 

--- a/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/BattleMapViewModelTests.cs
@@ -2136,7 +2136,7 @@ public class BattleMapViewModelTests
 
         // Verify that there is only one option to continue movement
         var actions = movementState.GetAvailableActions().ToList();
-        actions.Count.ShouldBe(1);
+        actions.Count.ShouldBe(3);
         actions.ShouldContain(a => a.Label.Contains("Walk"));
     }
 
@@ -2223,7 +2223,7 @@ public class BattleMapViewModelTests
         // Assert
         _localizationService.GetString("Action_StayProne").Returns("StayProne");
         var actions = movementState.GetAvailableActions().ToList();
-        actions.Count.ShouldBe(1);
+        actions.Count.ShouldBe(3);
         actions.ShouldContain(a => a.Label.Contains("Walk"));
     }
 

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
@@ -453,11 +453,10 @@ public class WeaponSelectionViewModelTests
          CreateSut(isEnabled: true);
          var wasActionCalled = false;
          var expectedValue = true;
-         var value = expectedValue;
          _selectionChangedAction = (weapon, selected) =>
          {
              weapon.ShouldBe(_weapon);
-             selected.ShouldBe(value);
+             selected.ShouldBe(expectedValue);
              wasActionCalled = true;
          };
          _sut.ModifiersBreakdown = CreateTestBreakdown(5);
@@ -471,6 +470,7 @@ public class WeaponSelectionViewModelTests
     
          // Test deselection
          wasActionCalled = false;
+         expectedValue = false;
          _sut.IsSelected = false;
     
          _sut.IsSelected.ShouldBeFalse();

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/WeaponSelectionViewModelTests.cs
@@ -12,6 +12,7 @@ using Sanet.MakaMek.Core.Tests.Utils;
 using Sanet.MakaMek.Core.Utils;
 using Sanet.MakaMek.Localization;
 using Sanet.MakaMek.Map.Models;
+using Sanet.MakaMek.Map.Models.Terrains;
 using Sanet.MakaMek.Presentation.ViewModels;
 using Sanet.MakaMek.Presentation.ViewModels.Wrappers;
 using Shouldly;
@@ -102,6 +103,53 @@ public class WeaponSelectionViewModelTests
 
         // Act & Assert
         _sut.RangeInfo.ShouldBe("9");
+    }
+
+    [Fact]
+    public void RangeInfo_ReturnsDash_WhenWeaponHasNoRange()
+    {
+        // Arrange
+        var structureValueProvider = Substitute.For<IRulesProvider>();
+        structureValueProvider.GetStructureValues(20).Returns(new Dictionary<PartLocation, int>
+        {
+            { PartLocation.Head, 8 },
+            { PartLocation.CenterTorso, 10 },
+            { PartLocation.LeftTorso, 8 },
+            { PartLocation.RightTorso, 8 },
+            { PartLocation.LeftArm, 4 },
+            { PartLocation.RightArm, 4 },
+            { PartLocation.LeftLeg, 8 },
+            { PartLocation.RightLeg, 8 }
+        });
+        var mechFactory = new MechFactory(
+            structureValueProvider,
+            new ClassicBattletechComponentProvider(),
+            Substitute.For<ILocalizationService>());
+        var mechData = MechFactoryTests.CreateDummyMechData();
+        var attacker = mechFactory.Create(mechData);
+
+        var weapon = new TestBallisticWeapon();
+        var part = attacker.Parts[PartLocation.LeftArm];
+        part.TryAddComponent(weapon);
+
+        var hex = new Hex(new HexCoordinates(1, 1));
+        hex.AddTerrain(new WaterTerrain(-2));
+        attacker.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), hex);
+
+        _sut = new WeaponSelectionViewModel(
+            weapon,
+            true,
+            false,
+            true,
+            null,
+            (_, _) => { },
+            _onShowAimedShotLocationSelector,
+            _onHideAimedShotLocationSelector,
+            _localizationService,
+            _toHitCalculator);
+
+        // Act & Assert
+        _sut.RangeInfo.ShouldBe("-");
     }
 
     [Fact]
@@ -405,10 +453,11 @@ public class WeaponSelectionViewModelTests
          CreateSut(isEnabled: true);
          var wasActionCalled = false;
          var expectedValue = true;
+         var value = expectedValue;
          _selectionChangedAction = (weapon, selected) =>
          {
              weapon.ShouldBe(_weapon);
-             selected.ShouldBe(expectedValue);
+             selected.ShouldBe(value);
              wasActionCalled = true;
          };
          _sut.ModifiersBreakdown = CreateTestBreakdown(5);
@@ -421,7 +470,6 @@ public class WeaponSelectionViewModelTests
          wasActionCalled.ShouldBeTrue();
     
          // Test deselection
-         expectedValue = false;
          wasActionCalled = false;
          _sut.IsSelected = false;
     


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced post-fall movement handling for prone mechs with "Stay Prone" action (re-applies declared movement path) and conditional "Change Facing" option when supported.

* **Bug Fixes**
  * Fixed weapon range display to safely handle null values—displays "-" instead of crashing when range data unavailable.

* **Chores**
  * Updated version to 0.56.33.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anton-makarevich/MakaMek/pull/949)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->