### PR TITLE
Fix mp calculation with spent mps 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <Version>0.56.39</Version>
+        <Version>0.56.40</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>
         <PackageLicenseExpression>GPL-3.0-only</PackageLicenseExpression>

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -54,13 +54,14 @@ public class Mech : Unit
 
     public override int GetMovementPoints(MovementType type)
     {
-        return type switch
+        var baseMp = type switch
         {
             MovementType.Walk => ModifiedMovement,
             MovementType.Run => (int)Math.Ceiling(ModifiedMovement * 1.5),
             MovementType.Jump => GetAvailableComponents<JumpJets>().Sum(j => j.JumpMp),
             _ => 0
         };
+        return Math.Max(0, baseMp - MovementPointsSpent);
     }
     
     public override IReadOnlyList<MovementType> GetAvailableMovementTypes()

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -167,8 +167,7 @@ public abstract class Unit : IUnit
     
     // Modified movement after applying effects (defaults to base movement)
     protected int ModifiedMovement => Math.Max(0, DamageReducedMovement 
-        - (MovementHeatPenalty?.Value ?? 0) 
-        - MovementPointsSpent);
+        - (MovementHeatPenalty?.Value ?? 0));
     public virtual int DamageReducedMovement => BaseMovement;
 
     // Movement heat penalty
@@ -190,7 +189,7 @@ public abstract class Unit : IUnit
     // Movement capabilities
     public virtual int GetMovementPoints(MovementType _)
     {
-        return ModifiedMovement;
+        return Math.Max(0, ModifiedMovement - MovementPointsSpent);
     }
     
     public virtual IReadOnlyList<MovementType> GetAvailableMovementTypes()

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -797,6 +797,53 @@ public class MechTests
     }
 
     [Theory]
+    [InlineData(7, 6, 1, 5)] // walk 7, run 11, spent 6 → remaining walk 1, run 5
+    [InlineData(7, 2, 5, 9)] // walk 7, run 11, spent 2 → remaining walk 5, run 9
+    [InlineData(5, 0, 5, 8)] // no movement spent
+    [InlineData(5, 5, 0, 3)] // walk 5, run 8, spent all 5 → remaining walk 0, run 3
+    public void GetMovement_ReturnsCorrectMPs_WhenSomeMPsAreSpent(int walkMp, int spentMp, int expectedWalk, int expectedRun)
+    {
+        // Arrange
+        var parts = CreateBasicPartsData(walkMp * 50);
+        var mech = new Mech("Test", "TST-1A", 50, parts);
+        mech.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        var start = mech.Position!;
+
+        // Act - spend MPs by moving
+        if (spentMp > 0)
+        {
+            mech.Move(new MovementPath([
+                new PathSegment(start, new HexPosition(new HexCoordinates(spentMp, 0), HexDirection.Top), spentMp)
+            ], MovementType.Walk), null);
+        }
+
+        // Assert
+        mech.GetMovementPoints(MovementType.Walk).ShouldBe(expectedWalk);
+        mech.GetMovementPoints(MovementType.Run).ShouldBe(expectedRun);
+    }
+
+    [Fact]
+    public void GetMovement_ReturnsCorrectRunMP_WhenSpentWhileRunning()
+    {
+        // The core bug: spent MPs were subtracted from walk base before the 1.5x run multiplier
+        // Walk 7 → Run 11. Spend 6 while running. Remaining run MP should be 5, not 2.
+        // Arrange
+        var parts = CreateBasicPartsData(350); // engine 350 / 50 tons = 7 walk MP
+        var mech = new Mech("Test", "TST-1A", 50, parts);
+        mech.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        var start = mech.Position!;
+
+        // Act - spend 6 MPs running (each hex costs 1)
+        mech.Move(new MovementPath([
+            new PathSegment(start, new HexPosition(new HexCoordinates(6, 0), HexDirection.Top), 6)
+        ], MovementType.Run), null);
+
+        // Assert - remaining should be total run MP minus spent
+        mech.GetMovementPoints(MovementType.Walk).ShouldBe(1);  // 7 - 6
+        mech.GetMovementPoints(MovementType.Run).ShouldBe(5);   // 11 - 6 (was incorrectly 2 before fix)
+    }
+
+    [Theory]
     // 2–7: 0, 8–9: 1, 10–11: 2, 12: 3 (torso), 1 (head/limb blown off)
     [InlineData(2, 0)]
     [InlineData(7, 0)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed movement point calculation to correctly display remaining movement after units spend movement points during actions. Remaining movement is now properly computed without double-counting spent points.

* **Tests**
  * Added test coverage for movement point recalculation scenarios, including verification of remaining movement after units spend points while running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anton-makarevich/MakaMek/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->