### PR TITLE
Fix/1094 water enter bridge

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.59.18</VersionPrefix>
+        <VersionPrefix>0.59.19</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Core/Models/Game/Mechanics/Movement/Interrupters/WaterEntryInterruptHandler.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Movement/Interrupters/WaterEntryInterruptHandler.cs
@@ -16,6 +16,9 @@ public class WaterEntryInterruptHandler : IMovementInterruptHandler
         var destinationHex = context.Game.BattleMap?.GetHex(new HexCoordinates(segment.To.Coordinates));
         if (destinationHex?.GetTerrain(MakaMekTerrains.Water) is not WaterTerrain { Height: <= -1 } water) return null;
 
+        var sourceHex = context.Game.BattleMap?.GetHex(new HexCoordinates(segment.From.Coordinates));
+        if (sourceHex is not null && destinationHex!.IsOnRoadOrBridge(sourceHex)) return null;
+
         if (context.Unit is not Mech mech) return null;
 
         var waterDepth = -1 * water.Height;

--- a/src/MakaMek.Map/Models/Hex.cs
+++ b/src/MakaMek.Map/Models/Hex.cs
@@ -75,7 +75,7 @@ public class Hex : IDisposable
         int cost;
         MakaMekTerrains terrainId;
 
-        if (GetRoadOrPavedTerrainId(fromHex) is { } fromRoad && GetRoadOrPavedTerrainId(this) is { } toRoad)
+        if (fromHex.GetRoadOrPavedTerrainId() is not null && this.GetRoadOrPavedTerrainId() is { } toRoad)
         {
             cost = 1;
             terrainId = toRoad;
@@ -93,14 +93,6 @@ public class Hex : IDisposable
         }
 
         return new TerrainMovementCost { TerrainId = terrainId, Value = cost, Depth = this.GetWaterDepth() };
-    }
-
-    private static MakaMekTerrains? GetRoadOrPavedTerrainId(Hex hex)
-    {
-        if (hex.HasTerrain(MakaMekTerrains.Road)) return MakaMekTerrains.Road;
-        if (hex.HasTerrain(MakaMekTerrains.Pavement)) return MakaMekTerrains.Pavement;
-        if (hex.HasTerrain(MakaMekTerrains.Bridge)) return MakaMekTerrains.Bridge;
-        return null;
     }
 
     /// <summary>

--- a/src/MakaMek.Map/Models/HexExtensions.cs
+++ b/src/MakaMek.Map/Models/HexExtensions.cs
@@ -43,5 +43,13 @@ public static class HexExtensions
                    || hex.HasTerrain(MakaMekTerrains.Pavement) 
                    || hex.HasTerrain(MakaMekTerrains.Bridge);
         }
+        
+        public MakaMekTerrains? GetRoadOrPavedTerrainId()
+        {
+            if (hex.HasTerrain(MakaMekTerrains.Road)) return MakaMekTerrains.Road;
+            if (hex.HasTerrain(MakaMekTerrains.Pavement)) return MakaMekTerrains.Pavement;
+            if (hex.HasTerrain(MakaMekTerrains.Bridge)) return MakaMekTerrains.Bridge;
+            return null;
+        }
     }
 }

--- a/src/MakaMek.Map/Models/HexExtensions.cs
+++ b/src/MakaMek.Map/Models/HexExtensions.cs
@@ -51,5 +51,13 @@ public static class HexExtensions
             if (hex.HasTerrain(MakaMekTerrains.Bridge)) return MakaMekTerrains.Bridge;
             return null;
         }
+
+        public bool IsOnRoadOrBridge(Hex fromHex)
+        {
+            return (hex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Bridge
+                || hex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Road)
+                && (fromHex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Bridge 
+                    || fromHex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Road);
+        }
     }
 }

--- a/src/MakaMek.Map/Models/HexExtensions.cs
+++ b/src/MakaMek.Map/Models/HexExtensions.cs
@@ -54,10 +54,10 @@ public static class HexExtensions
 
         public bool IsOnRoadOrBridge(Hex fromHex)
         {
-            return (hex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Bridge
-                || hex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Road)
-                && (fromHex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Bridge 
-                    || fromHex.GetRoadOrPavedTerrainId() == MakaMekTerrains.Road);
+            var toTerrain = hex.GetRoadOrPavedTerrainId();
+            var fromTerrain = fromHex.GetRoadOrPavedTerrainId();
+            return (toTerrain == MakaMekTerrains.Bridge || toTerrain == MakaMekTerrains.Road)
+                && (fromTerrain == MakaMekTerrains.Bridge || fromTerrain == MakaMekTerrains.Road);
         }
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/WaterEntryInterruptHandlerTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/WaterEntryInterruptHandlerTests.cs
@@ -210,4 +210,19 @@ public class WaterEntryInterruptHandlerTests : GamePhaseTestsBase
         result.GameActions.ShouldHaveSingleItem();
         result.GameActions[0].ShouldBeOfType<ApplyFallAction>();
     }
+
+    [Fact]
+    public void Check_WhenHexesAreConnectedByBridge_ReturnsNull()
+    {
+        var mech = Game.Players[0].Units[0] as Mech;
+        mech!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+        Game.BattleMap!.GetHex(new HexCoordinates(1, 2))!.AddTerrain(new BridgeTerrain());
+        Game.BattleMap!.GetHex(new HexCoordinates(2, 2))!.AddTerrain(new BridgeTerrain());
+        Game.BattleMap!.GetHex(new HexCoordinates(2, 2))!.AddTerrain(new WaterTerrain(-1));
+
+        var moveCommand = CreateMoveCommand(_unitId, MovementType.Walk,
+            new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), []));
+
+        _sut.Check(CreateContext(moveCommand with { PlayerId = Game.Players[0].Id }, 0)).ShouldBeNull();
+    }
 }

--- a/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
+++ b/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
@@ -140,4 +140,23 @@ public class HexExtensionsTests
         // Assert
         result.ShouldBe(expectedResult);
     }
+
+    [Theory]
+    [InlineData(MakaMekTerrains.Bridge, MakaMekTerrains.Bridge)]
+    [InlineData(MakaMekTerrains.Pavement, MakaMekTerrains.Pavement)]
+    [InlineData(MakaMekTerrains.Road, MakaMekTerrains.Road)]
+    [InlineData(MakaMekTerrains.HeavyWoods, null)]
+    public void GetRoadOrPavedTerrainId_Returns_PavedTerrain_OrNull(MakaMekTerrains terrainToAdd,
+        MakaMekTerrains? expectedTerrain)
+    {
+        // Arrange
+        var sut = new Hex(new HexCoordinates(1, 1));
+        sut.AddTerrain(Terrain.CreateTerrainOfType(terrainToAdd));
+
+        // Act
+        var terrain = sut.GetRoadOrPavedTerrainId();
+            
+        // Assert
+        terrain.ShouldBe(expectedTerrain);
+    }
 }

--- a/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
+++ b/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
@@ -159,4 +159,28 @@ public class HexExtensionsTests
         // Assert
         terrain.ShouldBe(expectedTerrain);
     }
+
+    [Theory]
+    [InlineData(MakaMekTerrains.Road, MakaMekTerrains.Road, true)]
+    [InlineData(MakaMekTerrains.Bridge, MakaMekTerrains.Road, true)]
+    [InlineData(MakaMekTerrains.Road, MakaMekTerrains.Bridge, true)]
+    [InlineData(MakaMekTerrains.Road, MakaMekTerrains.Pavement, false)]
+    [InlineData(MakaMekTerrains.Pavement, MakaMekTerrains.Road, false)]
+    [InlineData(MakaMekTerrains.Water, MakaMekTerrains.Bridge, false)]
+    [InlineData(MakaMekTerrains.LightWoods, MakaMekTerrains.Road, false)]
+    public void IsOnRoadOrBridge_Should_ReturnCorrectValue(MakaMekTerrains fromHexTerrain, MakaMekTerrains toHexTerrain,
+        bool isOnRoad)
+    {
+        // Arrange
+        var fromHex = new Hex(new HexCoordinates(1, 1));
+        fromHex.AddTerrain(Terrain.CreateTerrainOfType(fromHexTerrain));
+        var toHex = new Hex(new HexCoordinates(2, 1));
+        toHex.AddTerrain(Terrain.CreateTerrainOfType(toHexTerrain));
+        
+        // Act
+        var result = fromHex.IsOnRoadOrBridge(toHex);
+        
+        // Assert
+        result.ShouldBe(isOnRoad);
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Units no longer trigger water-entry interrupts when moving along connected roads or bridges.

* **Tests**
  * Added tests covering water-entry behavior on connected bridges/roads.
  * Added tests for road/bridge/paved detection between neighboring hexes.

* **Chores**
  * Product version updated to 0.59.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->