### PR TITLE
skidding psr modifier

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.59.25</VersionPrefix>
+        <VersionPrefix>0.59.26</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollContexts/SkidCheckRollContext.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/PilotingSkillRollContexts/SkidCheckRollContext.cs
@@ -2,7 +2,7 @@ using Sanet.MakaMek.Localization;
 
 namespace Sanet.MakaMek.Core.Data.Game.Mechanics.PilotingSkillRollContexts;
 
-public record SkidCheckRollContext(int SkidDistance) : PilotingSkillRollContext(PilotingSkillRollType.SkidCheck)
+public record SkidCheckRollContext(int SkidDistance, int HexesMoved) : PilotingSkillRollContext(PilotingSkillRollType.SkidCheck)
 {
     public override string Render(ILocalizationService localizationService)
         => string.Format(localizationService.GetString("PilotingSkillRollType_SkidCheck_WithHexes"),

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculator.cs
@@ -241,6 +241,14 @@ public class PilotingSkillCalculator : IPilotingSkillCalculator
                 WaterDepth = waterCtx.WaterDepth
             });
         }
+        else if (context is SkidCheckRollContext skidCtx)
+        {
+            modifiers.Add(new SkiddingModifier
+            {
+                Value = _rules.GetSkidModifier(skidCtx.HexesMoved),
+                HexesMoved = skidCtx.HexesMoved
+            });
+        }
         return modifiers;
     }
 

--- a/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/SkiddingModifier.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Modifiers/PilotingSkill/SkiddingModifier.cs
@@ -1,0 +1,13 @@
+using Sanet.MakaMek.Localization;
+
+namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+public record SkiddingModifier : RollModifier
+{
+    public required int HexesMoved { get; init; }
+
+    public override string Render(ILocalizationService localizationService)
+    {
+        return string.Format(localizationService.GetString("Modifier_SkidDistance"), HexesMoved, Value.ToString("+0;-0"));
+    }
+}

--- a/src/MakaMek.Core/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandler.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandler.cs
@@ -35,7 +35,7 @@ public class SkidInterruptHandler : IMovementInterruptHandler
         var skidFacing = (HexDirection)segment.From.Facing;
 
         var skidPathSegments = GenerateSkidPathSegments(context.Game, turnHexCoords, skidFacing, maxSkidDistance);
-        var skidContext = new SkidCheckRollContext(skidPathSegments.Count);
+        var skidContext = new SkidCheckRollContext(skidPathSegments.Count, hexesMoved);
         var skidFallContext = context.Game.FallProcessor.ProcessMovementAttempt(
             mech, skidContext, context.Game, context.MoveCommand.MovementType);
 

--- a/src/MakaMek.Core/Models/Game/Rules/IRulesProvider.cs
+++ b/src/MakaMek.Core/Models/Game/Rules/IRulesProvider.cs
@@ -181,4 +181,11 @@ public interface IRulesProvider
     /// - Depth 3+: +1
     /// </returns>
     int GetWaterDepthModifier(int waterDepth);
+
+    /// <summary>
+    /// Gets the piloting skill roll modifier based on the number of hexes moved before skidding.
+    /// </summary>
+    /// <param name="hexesMoved">The number of hexes moved before the skid turn</param>
+    /// <returns>The modifier value for the skid PSR based on hexes moved</returns>
+    int GetSkidModifier(int hexesMoved);
 }

--- a/src/MakaMek.Core/Models/Game/Rules/TotalWarfareRulesProvider.cs
+++ b/src/MakaMek.Core/Models/Game/Rules/TotalWarfareRulesProvider.cs
@@ -560,4 +560,18 @@ public class TotalWarfareRulesProvider : IRulesProvider
             _ => 1    // Depth 3+: +1 modifier
         };
     }
+
+    public int GetSkidModifier(int hexesMoved)
+    {
+        return hexesMoved switch
+        {
+            <= 2 => -1,   // 0-2 hexes
+            <= 4 => 0,    // 3-4 hexes
+            <= 7 => 1,    // 5-7 hexes
+            <= 10 => 2,   // 8-10 hexes
+            <= 17 => 4,   // 11-17 hexes
+            <= 24 => 5,   // 18-24 hexes
+            _ => 6        // 25+ hexes
+        };
+    }
 }

--- a/src/MakaMek.Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Localization/FakeLocalizationService.cs
@@ -149,6 +149,7 @@ public class FakeLocalizationService : ILocalizationService
         ["Modifier_ProneFiring"] = "Prone Firing: +{0}",
         ["Modifier_PartialCover"] = "Partial Cover: +{0}",
         ["Modifier_WaterDepth"] = "Water Depth ({0}): {1}",
+        ["Modifier_SkidDistance"] = "Skid ({0} hexes moved): {1}",
         ["WeaponRestriction_NotAvailable"] = "Weapon not available",
         ["WeaponRestriction_PartialCoverLegs"] = "Cannot fire leg weapons while in partial cover",
         ["WeaponRestriction_ProneLegs"] = "Cannot fire leg weapons while prone",

--- a/tests/MakaMek.Core.Tests/Data/Game/Mechanics/PilotingSkillRollContexts/SkidCheckRollContextTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Mechanics/PilotingSkillRollContexts/SkidCheckRollContextTests.cs
@@ -14,15 +14,24 @@ public class SkidCheckRollContextTests
     public void Constructor_WhenCalled_SetsSkidDistance()
     {
         const int skidDistance = 5;
-        var sut = new SkidCheckRollContext(skidDistance);
+        var sut = new SkidCheckRollContext(skidDistance, 3);
 
         sut.SkidDistance.ShouldBe(skidDistance);
     }
 
     [Fact]
+    public void Constructor_WhenCalled_SetsHexesMoved()
+    {
+        const int hexesMoved = 7;
+        var sut = new SkidCheckRollContext(5, hexesMoved);
+
+        sut.HexesMoved.ShouldBe(hexesMoved);
+    }
+
+    [Fact]
     public void Constructor_WhenCalled_SetsRollTypeToSkidCheck()
     {
-        var sut = new SkidCheckRollContext(3);
+        var sut = new SkidCheckRollContext(3, 5);
 
         sut.RollType.ShouldBe(PilotingSkillRollType.SkidCheck);
     }
@@ -30,7 +39,7 @@ public class SkidCheckRollContextTests
     [Fact]
     public void Render_WhenCalled_ReturnsLocalizedStringWithHexes()
     {
-        var sut = new SkidCheckRollContext(5);
+        var sut = new SkidCheckRollContext(5, 3);
 
         var result = sut.Render(_localizationService);
 
@@ -44,7 +53,7 @@ public class SkidCheckRollContextTests
     [InlineData(10, "Skid Check (10 hexes)")]
     public void Render_WithDifferentSkidDistances_ReturnsCorrectLocalizedString(int skidDistance, string expected)
     {
-        var sut = new SkidCheckRollContext(skidDistance);
+        var sut = new SkidCheckRollContext(skidDistance, 3);
 
         var result = sut.Render(_localizationService);
 

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -1471,7 +1471,7 @@ public class FallProcessorTests
             .Returns(skidDamageData);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3), _game, MovementType.Run);
+        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 3), _game, MovementType.Run);
 
         // Assert
         result.IsFalling.ShouldBeTrue();
@@ -1492,7 +1492,7 @@ public class FallProcessorTests
         SetupRollResult(true, PilotingSkillRollType.SkidCheck);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3), _game, MovementType.Run);
+        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 3), _game, MovementType.Run);
 
         // Assert
         result.IsFalling.ShouldBeFalse();
@@ -1517,7 +1517,7 @@ public class FallProcessorTests
             .Returns(skidDamageData);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3), _game, MovementType.Run);
+        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 3), _game, MovementType.Run);
 
         // Assert
         result.IsFalling.ShouldBeTrue();

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -1471,7 +1471,7 @@ public class FallProcessorTests
             .Returns(skidDamageData);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 3), _game, MovementType.Run);
+        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 7), _game, MovementType.Run);
 
         // Assert
         result.IsFalling.ShouldBeTrue();
@@ -1492,7 +1492,7 @@ public class FallProcessorTests
         SetupRollResult(true, PilotingSkillRollType.SkidCheck);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 3), _game, MovementType.Run);
+        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 7), _game, MovementType.Run);
 
         // Assert
         result.IsFalling.ShouldBeFalse();
@@ -1517,7 +1517,7 @@ public class FallProcessorTests
             .Returns(skidDamageData);
 
         // Act
-        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 3), _game, MovementType.Run);
+        var result = _sut.ProcessMovementAttempt(_testMech, new SkidCheckRollContext(3, 7), _game, MovementType.Run);
 
         // Assert
         result.IsFalling.ShouldBeTrue();

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/PilotingSkillCalculatorTests.cs
@@ -853,5 +853,51 @@ namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Mechs.Falling
             var enterWaterModifier = result.Modifiers[0] as WaterDepthModifier;
             enterWaterModifier!.Value.ShouldBe(0);
         }
+
+        [Theory]
+        [InlineData(2, -1)]
+        [InlineData(5, 1)]
+        [InlineData(10, 2)]
+        [InlineData(18, 5)]
+        public void GetPsrBreakdown_SkidCheck_AddsSkidDistanceModifier(int hexesMoved, int expectedModifierValue)
+        {
+            // Arrange
+            var torso = new CenterTorso("Test Torso", 10, 3, 5);
+            var mech = new Mech("Test", "TST-1A", 50, [torso]);
+            mech.AssignPilot(new MechWarrior("John", "Doe"));
+            _mockRulesProvider.GetSkidModifier(hexesMoved).Returns(expectedModifierValue);
+
+            // Act
+            var result = _sut.GetPsrBreakdown(mech, new SkidCheckRollContext(3, hexesMoved));
+
+            // Assert
+            result.BasePilotingSkill.ShouldBe(mech.Pilot!.Piloting);
+            result.Modifiers.ShouldContain(m => m is SkiddingModifier);
+            var skidModifier = result.Modifiers.OfType<SkiddingModifier>().Single();
+            skidModifier.Value.ShouldBe(expectedModifierValue);
+            skidModifier.HexesMoved.ShouldBe(hexesMoved);
+            result.ModifiedPilotingSkill.ShouldBe(mech.Pilot.Piloting + expectedModifierValue);
+        }
+
+        [Fact]
+        public void GetPsrBreakdown_SkidCheck_WithDamagedGyro_IncludesBothModifiers()
+        {
+            // Arrange
+            var torso = new CenterTorso("Test Torso", 10, 3, 5);
+            var gyro = torso.GetComponent<Gyro>()!;
+            gyro.Hit();
+            var mech = new Mech("Test", "TST-1A", 50, [torso]);
+            mech.AssignPilot(new MechWarrior("John", "Doe"));
+            _mockRulesProvider.GetPilotingSkillRollModifier(PilotingSkillRollType.GyroHit).Returns(3);
+            _mockRulesProvider.GetSkidModifier(5).Returns(1);
+
+            // Act
+            var result = _sut.GetPsrBreakdown(mech, new SkidCheckRollContext(3, 5));
+
+            // Assert
+            result.Modifiers.ShouldContain(m => m is DamagedGyroModifier);
+            result.Modifiers.ShouldContain(m => m is SkiddingModifier);
+            result.ModifiedPilotingSkill.ShouldBe(mech.Pilot!.Piloting + 3 + 1);
+        }
     }
 }

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/SkiddingModifierTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Modifiers/PilotingSkill/SkiddingModifierTests.cs
@@ -1,0 +1,93 @@
+using NSubstitute;
+using Sanet.MakaMek.Core.Models.Game.Mechanics.Modifiers.PilotingSkill;
+using Sanet.MakaMek.Localization;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Modifiers.PilotingSkill;
+
+public class SkiddingModifierTests
+{
+    private readonly ILocalizationService _localizationService = Substitute.For<ILocalizationService>();
+
+    [Fact]
+    public void Render_ShouldFormatCorrectly()
+    {
+        var sut = new SkiddingModifier
+        {
+            Value = 2,
+            HexesMoved = 5
+        };
+        _localizationService.GetString("Modifier_SkidDistance").Returns("Skid ({0} hexes moved): {1}");
+
+        var result = sut.Render(_localizationService);
+
+        result.ShouldBe("Skid (5 hexes moved): +2");
+        _localizationService.Received(1).GetString("Modifier_SkidDistance");
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(5, 5)]
+    [InlineData(10, 10)]
+    [InlineData(25, 25)]
+    public void HexesMoved_ShouldBeSetCorrectly(int hexesMoved, int expectedHexesMoved)
+    {
+        var sut = new SkiddingModifier
+        {
+            Value = 1,
+            HexesMoved = hexesMoved
+        };
+
+        sut.HexesMoved.ShouldBe(expectedHexesMoved);
+    }
+
+    [Theory]
+    [InlineData(-1, -1)]
+    [InlineData(0, 0)]
+    [InlineData(1, 1)]
+    [InlineData(6, 6)]
+    public void Value_ShouldBeSetCorrectly(int value, int expectedValue)
+    {
+        var sut = new SkiddingModifier
+        {
+            Value = value,
+            HexesMoved = 5
+        };
+
+        sut.Value.ShouldBe(expectedValue);
+    }
+
+    [Theory]
+    [InlineData(3, 0)]
+    [InlineData(5, 1)]
+    [InlineData(8, 2)]
+    [InlineData(11, 4)]
+    public void Render_WithDifferentHexesMovedAndValues_ShouldFormatCorrectly(int hexesMoved, int value)
+    {
+        var sut = new SkiddingModifier
+        {
+            Value = value,
+            HexesMoved = hexesMoved
+        };
+        _localizationService.GetString("Modifier_SkidDistance").Returns("Skid ({0} hexes moved): {1}");
+
+        var result = sut.Render(_localizationService);
+
+        result.ShouldBe($"Skid ({hexesMoved} hexes moved): +{value}");
+    }
+
+    [Fact]
+    public void Render_WithNegativeValue_ShouldFormatCorrectly()
+    {
+        var sut = new SkiddingModifier
+        {
+            Value = -1,
+            HexesMoved = 1
+        };
+        _localizationService.GetString("Modifier_SkidDistance").Returns("Skid ({0} hexes moved): {1}");
+
+        var result = sut.Render(_localizationService);
+
+        result.ShouldBe("Skid (1 hexes moved): -1");
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandlerTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandlerTests.cs
@@ -79,7 +79,7 @@ public class SkidInterruptHandlerTests : GamePhaseTestsBase
             IsFalling = false,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(1),
+                RollContext = new SkidCheckRollContext(1, 3),
                 DiceResults = [10, 10],
                 IsSuccessful = true,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -116,7 +116,7 @@ public class SkidInterruptHandlerTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(1),
+                RollContext = new SkidCheckRollContext(1, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandlerTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandlerTests.cs
@@ -85,7 +85,11 @@ public class SkidInterruptHandlerTests : GamePhaseTestsBase
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
             }
         };
-        MockFallProcessor.ProcessMovementAttempt(mech, Arg.Any<SkidCheckRollContext>(), Game, MovementType.Run)
+        MockFallProcessor.ProcessMovementAttempt(
+            mech,
+            Arg.Is<SkidCheckRollContext>(ctx => ctx.SkidDistance == 1 && ctx.HexesMoved == 2),
+            Game,
+            MovementType.Run)
             .Returns(successContext);
 
         var moveCommand = CreateMoveCommand(_unitId, MovementType.Run,
@@ -127,7 +131,11 @@ public class SkidInterruptHandlerTests : GamePhaseTestsBase
                 new DiceResult(3),
                 HitDirection.Front)
         };
-        MockFallProcessor.ProcessMovementAttempt(mech, Arg.Any<SkidCheckRollContext>(), Game, MovementType.Run)
+        MockFallProcessor.ProcessMovementAttempt(
+            mech,
+            Arg.Is<SkidCheckRollContext>(ctx => ctx.SkidDistance == 1 && ctx.HexesMoved == 2),
+            Game,
+            MovementType.Run)
             .Returns(fallContext);
 
         var moveCommand = CreateMoveCommand(_unitId, MovementType.Run,

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -1602,7 +1602,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 1), Game, MovementType.Run).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -1654,7 +1654,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             }
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run).Returns(successContext);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 1), Game, MovementType.Run).Returns(successContext);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -1775,7 +1775,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 1), Game, MovementType.Run).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -1830,7 +1830,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             )
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 1), Game, MovementType.Run).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -1996,7 +1996,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1), Game, MovementType.Run).Returns(waterSuccessData);
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run).Returns(skidFallData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 2), Game, MovementType.Run).Returns(skidFallData);
 
         CommandPublisher.ClearReceivedCalls();
 
@@ -2058,7 +2058,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         MockFallProcessor.ProcessMovementAttempt(unit,
-            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 3), Game, MovementType.Run)
+            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 3 && c.HexesMoved == 7), Game, MovementType.Run)
             .Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
@@ -2121,7 +2121,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         MockFallProcessor.ProcessMovementAttempt(unit,
-            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run)
+            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 5), Game, MovementType.Run)
             .Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
@@ -2184,7 +2184,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         MockFallProcessor.ProcessMovementAttempt(unit,
-            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 2), Game, MovementType.Run)
+            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 2 && c.HexesMoved == 5), Game, MovementType.Run)
             .Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
@@ -2251,7 +2251,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         MockFallProcessor.ProcessMovementAttempt(unit,
-            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 3), Game, MovementType.Run)
+            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 3 && c.HexesMoved == 5), Game, MovementType.Run)
             .Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
@@ -2311,7 +2311,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         MockFallProcessor.ProcessMovementAttempt(unit,
-            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 0), Game, MovementType.Run)
+            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 0 && c.HexesMoved == 5), Game, MovementType.Run)
             .Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
@@ -2417,10 +2417,10 @@ public class MovementPhaseTests : GamePhaseTestsBase
         };
 
         MockFallProcessor.ProcessMovementAttempt(unit1,
-            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 3), Game, MovementType.Run)
+            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 3 && c.HexesMoved == 7), Game, MovementType.Run)
             .Returns(waterFallContextData);
         MockFallProcessor.ProcessMovementAttempt(unit2,
-            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run)
+            Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 5), Game, MovementType.Run)
             .Returns(deepWaterFallContextData);
 
         CommandPublisher.ClearReceivedCalls();
@@ -2538,7 +2538,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
                 new DiceResult(3), HitDirection.Front)
         };
 
-        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1), Game, MovementType.Run).Returns(fallContextData);
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 1), Game, MovementType.Run).Returns(fallContextData);
 
         CommandPublisher.ClearReceivedCalls();
 

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -1590,7 +1590,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(1),
+                RollContext = new SkidCheckRollContext(1, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -1647,7 +1647,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = false,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(1),
+                RollContext = new SkidCheckRollContext(1, 3),
                 DiceResults = [6, 6],
                 IsSuccessful = true,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -1763,7 +1763,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(1),
+                RollContext = new SkidCheckRollContext(1, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -1818,7 +1818,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(1),
+                RollContext = new SkidCheckRollContext(1, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -1983,7 +1983,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(2),
+                RollContext = new SkidCheckRollContext(2, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2048,7 +2048,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(7),
+                RollContext = new SkidCheckRollContext(7, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2111,7 +2111,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(5),
+                RollContext = new SkidCheckRollContext(5, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2174,7 +2174,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(5),
+                RollContext = new SkidCheckRollContext(5, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2241,7 +2241,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(5),
+                RollContext = new SkidCheckRollContext(5, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2301,7 +2301,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(5),
+                RollContext = new SkidCheckRollContext(5, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2391,7 +2391,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(7),
+                RollContext = new SkidCheckRollContext(7, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2407,7 +2407,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(5),
+                RollContext = new SkidCheckRollContext(5, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
@@ -2527,7 +2527,7 @@ public class MovementPhaseTests : GamePhaseTestsBase
             IsFalling = true,
             PilotingSkillRoll = new PilotingSkillRollData
             {
-                RollContext = new SkidCheckRollContext(1),
+                RollContext = new SkidCheckRollContext(1, 3),
                 DiceResults = [2, 2],
                 IsSuccessful = false,
                 PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }

--- a/tests/MakaMek.Core.Tests/Models/Game/Rules/TotalWarfareRulesProviderTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Rules/TotalWarfareRulesProviderTests.cs
@@ -1099,4 +1099,32 @@ public class TotalWarfareRulesProviderTests
         Should.Throw<ArgumentOutOfRangeException>(() => 
             _sut.GetWaterDepthModifier(waterDepth));
     }
+
+    [Theory]
+    [InlineData(0, -1)]   // 0-2 hexes: -1
+    [InlineData(1, -1)]
+    [InlineData(2, -1)]
+    [InlineData(3, 0)]    // 3-4 hexes: 0
+    [InlineData(4, 0)]
+    [InlineData(5, 1)]    // 5-7 hexes: +1
+    [InlineData(6, 1)]
+    [InlineData(7, 1)]
+    [InlineData(8, 2)]    // 8-10 hexes: +2
+    [InlineData(9, 2)]
+    [InlineData(10, 2)]
+    [InlineData(11, 4)]   // 11-17 hexes: +4
+    [InlineData(14, 4)]
+    [InlineData(17, 4)]
+    [InlineData(18, 5)]   // 18-24 hexes: +5
+    [InlineData(20, 5)]
+    [InlineData(24, 5)]
+    [InlineData(25, 6)]   // 25+ hexes: +6
+    [InlineData(30, 6)]
+    [InlineData(50, 6)]
+    public void GetSkidModifier_ShouldReturnExpectedValues(int hexesMoved, int expectedModifier)
+    {
+        var result = _sut.GetSkidModifier(hexesMoved);
+
+        result.ShouldBe(expectedModifier);
+    }
 }

--- a/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
@@ -211,6 +211,7 @@ public class FakeLocalizationServiceTests
     [InlineData("Modifier_ProneFiring", "Prone Firing: +{0}")]
     [InlineData("Modifier_PartialCover", "Partial Cover: +{0}")]
     [InlineData("Modifier_WaterDepth", "Water Depth ({0}): {1}")]
+    [InlineData("Modifier_SkidDistance", "Skid ({0} hexes moved): {1}")]
     [InlineData("WeaponRestriction_NotAvailable", "Weapon not available")]
     [InlineData("WeaponRestriction_PartialCoverLegs", "Cannot fire leg weapons while in partial cover")]
     [InlineData("WeaponRestriction_ProneLegs", "Cannot fire leg weapons while prone")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Skid checks now factor in distance moved before the skid, adjusting piloting roll modifiers dynamically for more contextual difficulty and tactical depth.
* **Localization**
  * Added localized formatting for skid modifiers so messages show hexes moved (e.g., "Skid (X hexes moved): ...").
* **Tests**
  * Expanded tests to cover the new skid-distance logic and modifier rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->