### PR TITLE
fix: detect bridge for source hex

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.59.29</VersionPrefix>
+        <VersionPrefix>0.59.30</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Map/Models/HexExtensions.cs
+++ b/src/MakaMek.Map/Models/HexExtensions.cs
@@ -60,8 +60,13 @@ public static class HexExtensions
         public int GetBridgeElevationChange(Hex fromHex, int unitHeight)
         {
             var bridgeHeight = hex.GetBridgeHeight();
+            var fromBridgeHeight = fromHex.GetBridgeHeight();
             if (bridgeHeight == null)
+            {
+                if (fromBridgeHeight != null)
+                    return hex.GetBottomLevel() - (fromHex.Level + fromBridgeHeight.Value);
                 return hex.GetElevationChange(fromHex);
+            }
 
             if (hex.IsOnRoadOrBridge(fromHex))
                 return hex.GetStandingLevel(fromHex) - fromHex.GetStandingLevel(hex);

--- a/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
+++ b/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
@@ -353,6 +353,54 @@ public class HexExtensionsTests
     }
 
     [Fact]
+    public void GetBridgeElevationChange_BridgeOverWaterToClear_UsesBridgeSurface()
+    {
+        var fromHex = new Hex(new HexCoordinates(1, 1)) { Level = 0 };
+        fromHex.AddTerrain(new WaterTerrain(-1));
+        fromHex.AddTerrain(new BridgeTerrain(0, 0));
+        var toHex = new Hex(new HexCoordinates(2, 1)) { Level = 0 };
+        toHex.AddTerrain(new ClearTerrain());
+
+        var result = toHex.GetBridgeElevationChange(fromHex, 2);
+
+        // unit is on bridge surface = 0 + 0 = 0, target bottom = 0
+        // elevation change = 0 - 0 = 0
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetBridgeElevationChange_BridgeOverWaterToRoad_UsesBridgeSurface()
+    {
+        var fromHex = new Hex(new HexCoordinates(1, 1)) { Level = 0 };
+        fromHex.AddTerrain(new WaterTerrain(-1));
+        fromHex.AddTerrain(new BridgeTerrain(0, 0));
+        var toHex = new Hex(new HexCoordinates(2, 1)) { Level = 0 };
+        toHex.AddTerrain(new RoadTerrain());
+
+        var result = toHex.GetBridgeElevationChange(fromHex, 2);
+
+        // unit is on bridge surface = 0 + 0 = 0, target bottom = 0
+        // elevation change = 0 - 0 = 0
+        result.ShouldBe(0);
+    }
+
+    [Fact]
+    public void GetBridgeElevationChange_ElevatedBridgeOverWaterToClear_UsesBridgeSurface()
+    {
+        var fromHex = new Hex(new HexCoordinates(1, 1)) { Level = 0 };
+        fromHex.AddTerrain(new WaterTerrain(-1));
+        fromHex.AddTerrain(new BridgeTerrain(2, 0));
+        var toHex = new Hex(new HexCoordinates(2, 1)) { Level = 2 };
+        toHex.AddTerrain(new ClearTerrain());
+
+        var result = toHex.GetBridgeElevationChange(fromHex, 2);
+
+        // unit is on bridge surface = 0 + 2 = 2, target bottom = 2
+        // elevation change = 2 - 2 = 0
+        result.ShouldBe(0);
+    }
+
+    [Fact]
     public void GetBridgeElevationChange_ElevatedFromHexWithBridgeClimb_CalculatesCorrectly()
     {
         var fromHex = new Hex(new HexCoordinates(1, 1)) { Level = 3 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bridge terrain elevation calculations to properly handle edge cases where only the source hex contains bridge terrain. This ensures units correctly and consistently compute elevation changes when moving across diverse terrain types and complex map transitions, improving overall movement calculation accuracy.

* **Version**
  * Version 0.59.30 released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->