### PR TITLE
refactor: extract common pathfinding

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.59.35</VersionPrefix>
+        <VersionPrefix>0.59.36</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Map/Models/BattleMap.cs
+++ b/src/MakaMek.Map/Models/BattleMap.cs
@@ -155,7 +155,12 @@ public class BattleMap(int width, int height, string biome = "makamek.biomes.gra
         {
             var cachedPath = cache.Get(start, target, false, maxLevelChange, unitHeight);
             if (cachedPath != null)
-                return cachedPath.TotalCost <= maxMovementPoints ? cachedPath : null;
+            {
+                if (cachedPath.TotalCost <= maxMovementPoints)
+                    return cachedPath;
+                if (mode == PathFindingMode.Shortest)
+                    return null;
+            }
         }
 
         if (start.Coordinates == target.Coordinates)
@@ -252,20 +257,22 @@ public class BattleMap(int width, int height, string biome = "makamek.biomes.gra
 
                     visited[nextPos] = (totalCost, newHexesTraveled);
 
-                    var priority = mode == PathFindingMode.Shortest
-                        ? (totalCost + nextCoord.DistanceTo(target.Coordinates), 0)
-                        : (-newHexesTraveled, nextCoord.DistanceTo(target.Coordinates));
-
                     if (nextCoord == target.Coordinates && requiredFacing != target.Facing)
                     {
                         var finalTurningSteps = nextPos.GetTurningSteps(target.Facing).ToList();
                         var finalCost = totalCost + finalTurningSteps.Count;
                         if (finalCost > maxMovementPoints) continue;
                         newPath.AddRange(finalTurningSteps);
-                        frontier.Enqueue(new PathfindingState(new HexPosition(nextCoord, target.Facing, toSurface), newPath, finalCost, newHexesTraveled), priority);
+                        var finalPriority = mode == PathFindingMode.Shortest
+                            ? (finalCost, 0)
+                            : (-newHexesTraveled, 0);
+                        frontier.Enqueue(new PathfindingState(new HexPosition(nextCoord, target.Facing, toSurface), newPath, finalCost, newHexesTraveled), finalPriority);
                     }
                     else
                     {
+                        var priority = mode == PathFindingMode.Shortest
+                            ? (totalCost + nextCoord.DistanceTo(target.Coordinates), 0)
+                            : (-newHexesTraveled, nextCoord.DistanceTo(target.Coordinates));
                         frontier.Enqueue(new PathfindingState(nextPos, newPath, totalCost, newHexesTraveled), priority);
                     }
                 }

--- a/src/MakaMek.Map/Models/BattleMap.cs
+++ b/src/MakaMek.Map/Models/BattleMap.cs
@@ -236,7 +236,8 @@ public class BattleMap(int width, int height, string biome = "makamek.biomes.gra
                     newPath.Add(nextPos);
 
                     var totalCost = current.Cost + hex.GetEnterMovementCost(currentHex).Sum(c => c.Value) + turningCost + levelCost;
-                    var newHexesTraveled = current.HexesTraveled + 1;
+                    var isNewCoord = current.Path.All(p => p.Coordinates != nextCoord);
+                    var newHexesTraveled = current.HexesTraveled + (isNewCoord ? 1 : 0);
 
                     if (totalCost > maxMovementPoints)
                         continue;

--- a/src/MakaMek.Map/Models/BattleMap.cs
+++ b/src/MakaMek.Map/Models/BattleMap.cs
@@ -56,9 +56,7 @@ public class BattleMap(int width, int height, string biome = "makamek.biomes.gra
             return FindJumpPath(start, target, maxMovementPoints);
         }
 
-        return pathFindingMode == PathFindingMode.Shortest
-            ? FindShortestPath(start, target, movementType, maxMovementPoints, prohibitedHexes, unitHeight, maxLevelChange)
-            : FindLongestPath(start, target, movementType, maxMovementPoints, prohibitedHexes, unitHeight, maxLevelChange);
+        return FindPathCore(pathFindingMode, start, target, movementType, maxMovementPoints, prohibitedHexes, unitHeight, maxLevelChange);
     }
 
     /// <summary>
@@ -129,272 +127,159 @@ public class BattleMap(int width, int height, string biome = "makamek.biomes.gra
         return segments;
     }
 
-    /// <summary>
-    /// Finds the shortest path between two positions (original behavior)
-    /// </summary>
-    private MovementPath? FindShortestPath(HexPosition start,
+    private readonly record struct PathfindingState(
+        HexPosition Position,
+        List<HexPosition> Path,
+        int Cost,
+        int HexesTraveled
+    );
+
+    private MovementPath? FindPathCore(
+        PathFindingMode mode,
+        HexPosition start,
         HexPosition target,
         MovementType movementType,
         int maxMovementPoints,
         IReadOnlySet<HexCoordinates>? prohibitedHexes,
         int unitHeight,
-        int? maxLevelChange = null)
-    {
-        prohibitedHexes??= new HashSet<HexCoordinates>();
-        var useCache = prohibitedHexes.Count == 0;
-
-        if (useCache)
-        {
-            var cachedPath = _movementPathCache.Get(start, target, false, maxLevelChange, unitHeight);
-            if (cachedPath != null)
-            {
-                return cachedPath.TotalCost <= maxMovementPoints ? cachedPath : null;
-            }
-        }
-
-        // If start and target are in the same hex, just return turning segments
-        if (start.Coordinates == target.Coordinates)
-        {
-            if (start.Surface != target.Surface)
-                return null;
-            var path = CreateTurningPath(start, target, maxMovementPoints, movementType);
-            if (path != null && useCache) _movementPathCache.Add(path, unitHeight);
-            return path;
-        }
-
-        var frontier = new PriorityQueue<(HexPosition pos, List<HexPosition> path, int cost), int>();
-        var visited = new Dictionary<HexPosition, int>();
-
-        frontier.Enqueue((start, [start], 0), 0);
-        visited[start] = 0;
-
-        while (frontier.Count > 0)
-        {
-            var (current, path, currentCost) = frontier.Dequeue();
-
-            // Check if we've reached the target
-            if (current == target)
-            {
-                // Convert path to segments
-                var segments = ConvertPathToSegments(path);
-                var result = new MovementPath(segments, movementType, maxLevelChange);
-                if (useCache) _movementPathCache.Add(result, unitHeight);
-                return result;
-            }
-
-            // For each adjacent hex
-            foreach (var nextCoord in current.Coordinates.GetAllNeighbours())
-            {
-                var hex = GetHex(nextCoord);
-                if (hex == null || prohibitedHexes.Contains(nextCoord))
-                    continue;
-
-                var currentHex = GetHex(current.Coordinates);
-                if (currentHex == null) continue;
-
-                // Get required facing for movement
-                var requiredFacing = current.Coordinates.GetDirectionToNeighbour(nextCoord);
-
-                // Calculate turning steps and cost if needed
-                var turningSteps = current.GetTurningSteps(requiredFacing).ToList();
-                var turningCost = turningSteps.Count;
-
-                // Branch on destination surface — physical possibility filter only.
-                foreach (var toSurface in hex.GetHexSurfaces())
-                {
-                    if (toSurface == HexSurface.Ground && hex.GetBridgeHeight() != null
-                        && !hex.CanStandOnGround(unitHeight)) continue;
-
-                    var elevationChange = hex.GetElevationChange(currentHex, current.Surface, toSurface);
-                    var levelCost = Math.Abs(elevationChange);
-
-                    if (levelCost > maxLevelChange)
-                        continue;
-
-                    var nextPos = new HexPosition(nextCoord, requiredFacing, toSurface);
-                    var newPath = new List<HexPosition>(path);
-                    newPath.AddRange(turningSteps);
-                    newPath.Add(nextPos);
-
-                    // Calculate total cost including terrain, hex entry, and level change
-                    var totalCost = currentCost + hex.GetEnterMovementCost(currentHex).Sum(c => c.Value) + turningCost + levelCost;
-
-                    if (totalCost > maxMovementPoints)
-                        continue;
-
-                    // Skip if we've visited this state with a lower or equal cost
-                    if (visited.TryGetValue(nextPos, out var visitedCost) && totalCost >= visitedCost)
-                        continue;
-
-                    visited[nextPos] = totalCost;
-
-                    // Calculate priority based on remaining distance plus current cost
-                    var priority = totalCost + nextCoord.DistanceTo(target.Coordinates);
-
-                    // If we're at target coordinates but wrong facing, add turning steps to target facing
-                    if (nextCoord == target.Coordinates && requiredFacing != target.Facing)
-                    {
-                        var finalTurningSteps = nextPos.GetTurningSteps(target.Facing).ToList();
-                        var finalCost = totalCost + finalTurningSteps.Count;
-                        if (finalCost > maxMovementPoints) continue;
-                        newPath.AddRange(finalTurningSteps);
-                        frontier.Enqueue((new HexPosition(nextCoord, target.Facing, toSurface), newPath, finalCost), priority);
-                    }
-                    else
-                    {
-                        frontier.Enqueue((nextPos, newPath, totalCost), priority);
-                    }
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Finds the longest path that maximizes hexes traversed within the movement budget.
-    /// The method does not guarantee to find the longest actual path, but it's good enough for the purpose.
-    /// </summary>
-    private MovementPath? FindLongestPath(HexPosition start,
-        HexPosition target,
-        MovementType movementType,
-        int maxMovementPoints,
-        IReadOnlySet<HexCoordinates>? prohibitedHexes,
-        int unitHeight,
-        int? maxLevelChange = null)
+        int? maxLevelChange)
     {
         prohibitedHexes ??= new HashSet<HexCoordinates>();
         var useCache = prohibitedHexes.Count == 0;
 
+        var cache = mode == PathFindingMode.Shortest
+            ? _movementPathCache
+            : _movementLongPathCache;
+
         if (useCache)
         {
-            var cachedPath = _movementLongPathCache.Get(start, target, false, maxLevelChange, unitHeight);
+            var cachedPath = cache.Get(start, target, false, maxLevelChange, unitHeight);
             if (cachedPath != null)
-            {
                 return cachedPath.TotalCost <= maxMovementPoints ? cachedPath : null;
-            }
         }
 
-        // If start and target are in the same hex, just return turning segments
         if (start.Coordinates == target.Coordinates)
         {
             if (start.Surface != target.Surface)
                 return null;
             var path = CreateTurningPath(start, target, maxMovementPoints, movementType);
-            if (path != null && useCache) _movementLongPathCache.Add(path, unitHeight);
+            if (path != null && useCache) cache.Add(path, unitHeight);
             return path;
         }
 
-        // Track the best path found so far (highest hexes traveled)
         MovementPath? bestPath = null;
         var bestHexesTraveled = 0;
 
-        // Use a priority queue that prioritizes higher hex counts
-        var frontier = new PriorityQueue<(HexPosition pos, List<HexPosition> path, int cost, int hexesTraveled), (int, int)>();
-        var visited = new Dictionary<HexPosition, (int cost, int hexesTraveled)>();
+        var frontier = new PriorityQueue<PathfindingState, (int, int)>();
+        var visited = new Dictionary<HexPosition, (int cost, int hexes)>();
 
-        frontier.Enqueue((start, [start], 0, 0), (0, 0));
+        frontier.Enqueue(new PathfindingState(start, [start], 0, 0), (0, 0));
         visited[start] = (0, 0);
 
         while (frontier.Count > 0)
         {
-            var (current, path, currentCost, hexesTraveled) = frontier.Dequeue();
+            var current = frontier.Dequeue();
 
-            // Check if we've reached the target
-            if (current == target)
+            if (current.Position == target)
             {
-                // Convert path to segments
-                var segments = ConvertPathToSegments(path);
+                var segments = ConvertPathToSegments(current.Path);
                 var candidatePath = new MovementPath(segments, movementType, maxLevelChange);
 
-                // Update the best path if this one has more hexes traveled
+                if (mode == PathFindingMode.Shortest)
+                {
+                    if (useCache) _movementPathCache.Add(candidatePath, unitHeight);
+                    return candidatePath;
+                }
+
                 if (candidatePath.HexesTraveled > bestHexesTraveled)
                 {
                     bestPath = candidatePath;
                     bestHexesTraveled = candidatePath.HexesTraveled;
                 }
 
-                // Continue searching for longer paths
                 continue;
             }
 
-            // For each adjacent hex
-            foreach (var nextCoord in current.Coordinates.GetAllNeighbours())
+            foreach (var nextCoord in current.Position.Coordinates.GetAllNeighbours())
             {
                 var hex = GetHex(nextCoord);
                 if (hex == null || prohibitedHexes.Contains(nextCoord))
                     continue;
 
-                var currentHex = GetHex(current.Coordinates);
+                var currentHex = GetHex(current.Position.Coordinates);
                 if (currentHex == null) continue;
 
-                // Get required facing for movement
-                var requiredFacing = current.Coordinates.GetDirectionToNeighbour(nextCoord);
+                var requiredFacing = current.Position.Coordinates.GetDirectionToNeighbour(nextCoord);
 
-                // Calculate turning steps and cost if needed
-                var turningSteps = current.GetTurningSteps(requiredFacing).ToList();
+                var turningSteps = current.Position.GetTurningSteps(requiredFacing).ToList();
                 var turningCost = turningSteps.Count;
 
-                // Branch on destination surface — physical possibility filter only.
                 foreach (var toSurface in hex.GetHexSurfaces())
                 {
                     if (toSurface == HexSurface.Ground && hex.GetBridgeHeight() != null
                         && !hex.CanStandOnGround(unitHeight)) continue;
 
-                    var elevationChange = hex.GetElevationChange(currentHex, current.Surface, toSurface);
+                    var elevationChange = hex.GetElevationChange(currentHex, current.Position.Surface, toSurface);
                     var levelCost = Math.Abs(elevationChange);
 
                     if (levelCost > maxLevelChange)
                         continue;
 
                     var nextPos = new HexPosition(nextCoord, requiredFacing, toSurface);
-                    var newPath = new List<HexPosition>(path);
+                    var newPath = new List<HexPosition>(current.Path);
                     newPath.AddRange(turningSteps);
                     newPath.Add(nextPos);
 
-                    // Calculate total cost including terrain, hex entry, and level change
-                    var totalCost = currentCost + hex.GetEnterMovementCost(currentHex).Sum(c => c.Value) + turningCost + levelCost;
-                    var newHexesTraveled = hexesTraveled + 1;
+                    var totalCost = current.Cost + hex.GetEnterMovementCost(currentHex).Sum(c => c.Value) + turningCost + levelCost;
+                    var newHexesTraveled = current.HexesTraveled + 1;
 
                     if (totalCost > maxMovementPoints)
                         continue;
 
-                    // For the longest path, allow revisiting if we have the same cost but more hexes traveled
                     if (visited.TryGetValue(nextPos, out var visitedState))
                     {
-                        // Skip only if we've visited with both lower-or-equal cost AND more-or-equal hexes
-                        if (visitedState.cost <= totalCost && visitedState.hexesTraveled >= newHexesTraveled)
-                            continue;
+                        if (mode == PathFindingMode.Shortest)
+                        {
+                            if (visitedState.cost <= totalCost)
+                                continue;
+                        }
+                        else
+                        {
+                            if (visitedState.cost <= totalCost && visitedState.hexes >= newHexesTraveled)
+                                continue;
+                        }
                     }
 
                     visited[nextPos] = (totalCost, newHexesTraveled);
 
-                    // Priority: negative hexes traveled (to maximize), then distance (to reach target)
-                    var priority = (-newHexesTraveled, nextCoord.DistanceTo(target.Coordinates));
+                    var priority = mode == PathFindingMode.Shortest
+                        ? (totalCost + nextCoord.DistanceTo(target.Coordinates), 0)
+                        : (-newHexesTraveled, nextCoord.DistanceTo(target.Coordinates));
 
-                    // If we're at target coordinates but wrong facing, add turning steps to target facing
                     if (nextCoord == target.Coordinates && requiredFacing != target.Facing)
                     {
                         var finalTurningSteps = nextPos.GetTurningSteps(target.Facing).ToList();
                         var finalCost = totalCost + finalTurningSteps.Count;
                         if (finalCost > maxMovementPoints) continue;
                         newPath.AddRange(finalTurningSteps);
-                        frontier.Enqueue((new HexPosition(nextCoord, target.Facing, toSurface), newPath, finalCost, newHexesTraveled), priority);
+                        frontier.Enqueue(new PathfindingState(new HexPosition(nextCoord, target.Facing, toSurface), newPath, finalCost, newHexesTraveled), priority);
                     }
                     else
                     {
-                        frontier.Enqueue((nextPos, newPath, totalCost, newHexesTraveled), priority);
+                        frontier.Enqueue(new PathfindingState(nextPos, newPath, totalCost, newHexesTraveled), priority);
                     }
                 }
             }
         }
 
-        if (bestPath != null && useCache)
+        if (mode == PathFindingMode.Longest)
         {
-            _movementLongPathCache.Add(bestPath, unitHeight);
+            if (bestPath != null && useCache)
+                _movementLongPathCache.Add(bestPath, unitHeight);
+            return bestPath;
         }
 
-        return bestPath;
+        return null;
     }
 
     /// <summary>

--- a/tests/MakaMek.Map.Tests/Models/BattleMapTests.cs
+++ b/tests/MakaMek.Map.Tests/Models/BattleMapTests.cs
@@ -2690,4 +2690,47 @@ public class BattleMapTests
         bridgePath.ShouldNotBeNull();
         bridgePath.TotalCost.ShouldBe(3);
     }
+
+    [Fact]
+    public void FindPath_ShortestMode_CachedPathExceedsBudget_ReturnsNull()
+    {
+        var sut = BattleMapFactory.GenerateMap(3, 3, new SingleTerrainGenerator(3, 3, new ClearTerrain()));
+        var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.Top);
+        var target = new HexPosition(new HexCoordinates(3, 3), HexDirection.Bottom);
+
+        var initialPath = sut.FindPath(start, target, MovementType.Walk, 20, 1);
+        initialPath.ShouldNotBeNull();
+
+        var path = sut.FindPath(start, target, MovementType.Walk, 1, 1);
+
+        path.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FindPath_LongestMode_CachedPathExceedsBudget_SearchesAgain()
+    {
+        var sut = BattleMapFactory.GenerateMap(3, 3, new SingleTerrainGenerator(3, 3, new ClearTerrain()));
+        var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.Top);
+        var target = new HexPosition(new HexCoordinates(3, 3), HexDirection.Bottom);
+
+        var initialPath = sut.FindPath(start, target, MovementType.Walk, 20, 1, null, PathFindingMode.Longest);
+        initialPath.ShouldNotBeNull();
+
+        var path = sut.FindPath(start, target, MovementType.Walk, 3, 1, null, PathFindingMode.Longest);
+
+        path.ShouldBeNull();
+    }
+
+    [Fact]
+    public void FindPath_ShortestMode_VisitedPruning_SkipsMoreExpensiveConvergentPaths()
+    {
+        var sut = BattleMapFactory.GenerateMap(3, 3, new SingleTerrainGenerator(3, 3, new ClearTerrain()));
+        var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.Top);
+        var target = new HexPosition(new HexCoordinates(3, 3), HexDirection.Bottom);
+
+        var path = sut.FindPath(start, target, MovementType.Walk, 15, 1);
+
+        path.ShouldNotBeNull();
+        path.TotalCost.ShouldBeLessThanOrEqualTo(15);
+    }
 }

--- a/tests/MakaMek.Map.Tests/Models/BattleMapTests.cs
+++ b/tests/MakaMek.Map.Tests/Models/BattleMapTests.cs
@@ -2758,4 +2758,24 @@ public class BattleMapTests
         path.ShouldNotBeNull();
         path.TotalCost.ShouldBe(5); // Optimal cost via cheap route; expensive convergent route was pruned
     }
+
+    [Fact]
+    public void FindPath_LongestMode_LoopPath_PrefersMoreDistinctHexes()
+    {
+        // Arrange: 2×2 clear map. Two routes from (1,1) to (2,2):
+        // Direct: (1,1) → (2,1) → (2,2)          — HexesTraveled=2, ~5 MP
+        // Loop:   (1,1) → (2,1) → (1,2) → (2,2)  — HexesTraveled=3, ~10 MP
+        // Longest mode must prefer the loop (more distinct hexes) within the 12 MP budget.
+        // The pruning condition (cost<=c AND hexes>=h) must NOT discard the loop path when
+        // it arrives at an intermediate hex with more distinct hexes than the direct route did.
+        var sut = BattleMapFactory.GenerateMap(2, 2, new SingleTerrainGenerator(2, 2, new ClearTerrain()));
+        var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.Top);
+        var target = new HexPosition(new HexCoordinates(2, 2), HexDirection.Bottom);
+
+        var path = sut.FindPath(start, target, MovementType.Walk, 12, 1, null, PathFindingMode.Longest);
+
+        path.ShouldNotBeNull();
+        path.TotalCost.ShouldBeLessThanOrEqualTo(12);
+        path.HexesTraveled.ShouldBe(3); // Loop chosen over the direct 2-hex route
+    }
 }

--- a/tests/MakaMek.Map.Tests/Models/BattleMapTests.cs
+++ b/tests/MakaMek.Map.Tests/Models/BattleMapTests.cs
@@ -453,8 +453,8 @@ public class BattleMapTests
         var lightWoodsSegment = movementSegments
             .FirstOrDefault(s => s.To.Coordinates == new HexCoordinates(1, 2));
         lightWoodsSegment.ShouldNotBeNull();
-        lightWoodsSegment.Costs.Any(c => c is HexEnterMovementCost h && h.Value == 1).ShouldBeTrue();
-        lightWoodsSegment.Costs.Any(c => c is TerrainMovementCost t && t.TerrainId == MakaMekTerrains.LightWoods && t.Value == 1).ShouldBeTrue();
+        lightWoodsSegment.Costs.Any(c => c is HexEnterMovementCost { Value: 1 }).ShouldBeTrue();
+        lightWoodsSegment.Costs.Any(c => c is TerrainMovementCost { TerrainId: MakaMekTerrains.LightWoods, Value: 1 }).ShouldBeTrue();
         lightWoodsSegment.Cost.ShouldBe(2); // 1 entry + 1 terrain
     }
 
@@ -680,7 +680,7 @@ public class BattleMapTests
         var sut = new BattleMap(2, 2);
         var hex = new Hex(new HexCoordinates(1, 1));
         sut.AddHex(hex);
-        var start = new HexPosition(hex.Coordinates, HexDirection.Top, HexSurface.Ground);
+        var start = new HexPosition(hex.Coordinates, HexDirection.Top);
         var target = new HexPosition(hex.Coordinates, HexDirection.Bottom, HexSurface.Bridge);
 
         // Act
@@ -697,7 +697,7 @@ public class BattleMapTests
         var sut = new BattleMap(2, 2);
         var hex = new Hex(new HexCoordinates(1, 1));
         sut.AddHex(hex);
-        var start = new HexPosition(hex.Coordinates, HexDirection.Top, HexSurface.Ground);
+        var start = new HexPosition(hex.Coordinates, HexDirection.Top);
         var target = new HexPosition(hex.Coordinates, HexDirection.Bottom, HexSurface.Bridge);
 
         // Act
@@ -892,8 +892,8 @@ public class BattleMapTests
         var result = sut.GetLineOfSight(attacker, target, 2);
 
         // Assert
-        // LOS should be blocked because the line passes through multiple heavy woods hexes
-        // Each heavy wood has an intervening factor of 2, and total intervening factor >= 3 blocks LOS
+        // LOS should be blocked because the line passes through multiple heavy woods hexes.
+        // Each heavy wood has an intervening factor of 2, and a total intervening factor >= 3 blocks LOS
         result.HasLineOfSight.ShouldBeFalse($"LOS should be blocked by heavy woods cluster between {attacker} and {target}");
     }
 
@@ -1563,8 +1563,8 @@ public class BattleMapTests
 
         var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.BottomRight);
 
-        // Act - With limited MP, elevated hexes may be unreachable
-        // Hex 2: 1 terrain + 1 level = 2 MP
+        // Act - With limited MP, elevated hexes may be unreachable.
+        // Hex 2: 1 terrain + 1 level = 2 MP.
         // Hex 3: 1+1 + 1+1 = 4 MP (through hex 2)
         var reachable = sut.GetReachableHexes(start, 3, 1, maxLevelChange: 2).ToList();
 
@@ -2076,7 +2076,7 @@ public class BattleMapTests
         toHex.AddTerrain(new ClearTerrain());
         sut.AddHex(toHex);
 
-        // Act - Shallow water (depth 0) < unit height (1), so not submerged. Target also not submerged (height 1)
+        // Act - Shallow water (depth 0) < unit height (1), so not submerged. Target also isn't submerged (height 1)
         var result = sut.GetLineOfSight(from, to, 1, 1);
 
         // Assert
@@ -2680,7 +2680,7 @@ public class BattleMapTests
             "Bridge surface should be reachable at cost 3 (1 terrain + 2 climb)");
 
         // Verify costs match FindPath results for each surface
-        var groundTarget = new HexPosition(new HexCoordinates(2, 1), HexDirection.BottomRight, HexSurface.Ground);
+        var groundTarget = new HexPosition(new HexCoordinates(2, 1), HexDirection.BottomRight);
         var groundPath = sut.FindPath(start, groundTarget, MovementType.Walk, mpBudget, unitHeight: 1);
         groundPath.ShouldNotBeNull();
         groundPath.TotalCost.ShouldBe(1);
@@ -2709,28 +2709,53 @@ public class BattleMapTests
     [Fact]
     public void FindPath_LongestMode_CachedPathExceedsBudget_SearchesAgain()
     {
-        var sut = BattleMapFactory.GenerateMap(3, 3, new SingleTerrainGenerator(3, 3, new ClearTerrain()));
+        var sut = BattleMapFactory.GenerateMap(5, 5, new SingleTerrainGenerator(5, 5, new ClearTerrain()));
         var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.Top);
         var target = new HexPosition(new HexCoordinates(3, 3), HexDirection.Bottom);
+        const int tightBudget = 10;
 
+        // Cache a long path using the full budget
         var initialPath = sut.FindPath(start, target, MovementType.Walk, 20, 1, null, PathFindingMode.Longest);
         initialPath.ShouldNotBeNull();
+        // Confirm the cached long path exceeds the tight budget, which is required to trigger re-search
+        initialPath.TotalCost.ShouldBeGreaterThan(tightBudget);
 
-        var path = sut.FindPath(start, target, MovementType.Walk, 3, 1, null, PathFindingMode.Longest);
+        // When the cached path exceeds budget in Longest mode, the algorithm re-searches
+        // (unlike Shortest mode which returns null without re-searching)
+        var path = sut.FindPath(start, target, MovementType.Walk, tightBudget, 1, null, PathFindingMode.Longest);
 
-        path.ShouldBeNull();
+        path.ShouldNotBeNull(); // Re-search found a valid path within the tight budget
+        path.TotalCost.ShouldBeLessThanOrEqualTo(tightBudget);
+        path.HexesTraveled.ShouldBeLessThan(initialPath.HexesTraveled); // Re-searched path is shorter than the cached long path
     }
 
     [Fact]
     public void FindPath_ShortestMode_VisitedPruning_SkipsMoreExpensiveConvergentPaths()
     {
-        var sut = BattleMapFactory.GenerateMap(3, 3, new SingleTerrainGenerator(3, 3, new ClearTerrain()));
-        var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.Top);
-        var target = new HexPosition(new HexCoordinates(3, 3), HexDirection.Bottom);
+        // Build a map with two routes converging at (2,2):
+        // Route A (cheap):     (1,1) → (2,1)[Clear]      → (2,2): 2 turns + 1 MP + 1 turn + 1 MP = 5 MP
+        // Route B (expensive): (1,1) → (1,2)[HeavyWoods] → (2,2): 3 turns + 3 MP + 1 turn + 1 MP + 1 turn = 9 MP.
+        // Visited pruning must discard Route B once (2,2) is already reached cheaper via Route A
+        var sut = new BattleMap(2, 2);
+        var hex11 = new Hex(new HexCoordinates(1, 1));
+        hex11.AddTerrain(new ClearTerrain());
+        sut.AddHex(hex11);
+        var hex21 = new Hex(new HexCoordinates(2, 1));
+        hex21.AddTerrain(new ClearTerrain());
+        sut.AddHex(hex21);
+        var hex12 = new Hex(new HexCoordinates(1, 2));
+        hex12.AddTerrain(new HeavyWoodsTerrain());
+        sut.AddHex(hex12);
+        var hex22 = new Hex(new HexCoordinates(2, 2));
+        hex22.AddTerrain(new ClearTerrain());
+        sut.AddHex(hex22);
 
-        var path = sut.FindPath(start, target, MovementType.Walk, 15, 1);
+        var start = new HexPosition(new HexCoordinates(1, 1), HexDirection.Top);
+        var target = new HexPosition(new HexCoordinates(2, 2), HexDirection.Bottom);
+
+        var path = sut.FindPath(start, target, MovementType.Walk, 20, 1);
 
         path.ShouldNotBeNull();
-        path.TotalCost.ShouldBeLessThanOrEqualTo(15);
+        path.TotalCost.ShouldBe(5); // Optimal cost via cheap route; expensive convergent route was pruned
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the app version to **0.59.36**.

* **Refactor**
  * Streamlined battle map pathfinding so shortest/longest routing follow a unified search approach with refined movement-budget and cache handling, improving consistency and performance.

* **Tests**
  * Added unit tests to verify pathfinding cache behavior when movement budgets change (shortest returning `null` when over budget, longest re-searching within the tighter limit, and pruning/visited-route correctness).
  * Updated a few assertions and test setups related to movement cost breakdowns and surface defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->