### PR TITLE
split falling damage skid

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.59.42</VersionPrefix>
+        <VersionPrefix>0.59.43</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Core/Data/Game/Commands/Server/MechFallCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Server/MechFallCommand.cs
@@ -98,22 +98,7 @@ public record struct MechFallCommand : IGameCommand
             stringBuilder.Append(localizationService.GetString("Command_MechFalling_Jumping"));
         }
             
-        stringBuilder.AppendFormat(
-            localizationService.GetString("Command_MechFalling_Damage"),
-            DamageData.HitLocations.TotalDamage);
-            
-        // Add detailed hit locations information - using the location's Render method
-        if (DamageData.HitLocations.HitLocations.Count > 0)
-        {
-            stringBuilder.AppendLine(); // Add a line break after total damage
-            stringBuilder.AppendLine(localizationService.GetString("Command_WeaponAttackResolution_HitLocations"));
-
-            // Render each hit location using the new method
-            foreach (var hitLocation in DamageData.HitLocations.HitLocations)
-            {
-                stringBuilder.Append(hitLocation.Render(localizationService));
-            }
-        }
+        DamageData.Render(stringBuilder, localizationService);
 
         if (PilotDamagePilotingSkillRoll == null) return stringBuilder.ToString().TrimEnd();
         stringBuilder.AppendLine(PilotDamagePilotingSkillRoll.Render(localizationService));

--- a/src/MakaMek.Core/Data/Game/Commands/Server/MechSkidCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Server/MechSkidCommand.cs
@@ -32,20 +32,7 @@ public record struct MechSkidCommand : IGameCommand
             unit.Model,
             command.SkidDistance);
 
-        stringBuilder.AppendFormat(
-            localizationService.GetString("Command_MechFalling_Damage"),
-            DamageData.HitLocations.TotalDamage);
-
-        if (DamageData.HitLocations.HitLocations.Count > 0)
-        {
-            stringBuilder.AppendLine();
-            stringBuilder.AppendLine(localizationService.GetString("Command_WeaponAttackResolution_HitLocations"));
-
-            foreach (var hitLocation in DamageData.HitLocations.HitLocations)
-            {
-                stringBuilder.Append(hitLocation.Render(localizationService));
-            }
-        }
+        DamageData.Render(stringBuilder, localizationService);
 
         return stringBuilder.ToString().TrimEnd();
     }

--- a/src/MakaMek.Core/Data/Game/Commands/Server/MechSkidCommand.cs
+++ b/src/MakaMek.Core/Data/Game/Commands/Server/MechSkidCommand.cs
@@ -1,0 +1,52 @@
+﻿using System.Text;
+using Sanet.MakaMek.Core.Data.Game.Mechanics;
+using Sanet.MakaMek.Core.Models.Game;
+using Sanet.MakaMek.Localization;
+
+namespace Sanet.MakaMek.Core.Data.Game.Commands.Server;
+
+public record struct MechSkidCommand : IGameCommand
+{
+    public required Guid UnitId { get; init; }
+    public required int SkidDistance { get; init; }
+    public required FallingDamageData? DamageData { get; init; }
+    public required Guid GameOriginId { get; set; }
+    public DateTime Timestamp { get; set; }
+
+    public string Render(ILocalizationService localizationService, IGame game)
+    {
+        var command = this;
+        var unit = game.Players
+            .SelectMany(p => p.Units)
+            .FirstOrDefault(u => u.Id == command.UnitId);
+
+        if (unit == null || DamageData == null)
+        {
+            return string.Empty;
+        }
+
+        var stringBuilder = new StringBuilder();
+
+        stringBuilder.AppendFormat(
+            localizationService.GetString("Command_MechSkid_Base"),
+            unit.Model,
+            command.SkidDistance);
+
+        stringBuilder.AppendFormat(
+            localizationService.GetString("Command_MechFalling_Damage"),
+            DamageData.HitLocations.TotalDamage);
+
+        if (DamageData.HitLocations.HitLocations.Count > 0)
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine(localizationService.GetString("Command_WeaponAttackResolution_HitLocations"));
+
+            foreach (var hitLocation in DamageData.HitLocations.HitLocations)
+            {
+                stringBuilder.Append(hitLocation.Render(localizationService));
+            }
+        }
+
+        return stringBuilder.ToString().TrimEnd();
+    }
+}

--- a/src/MakaMek.Core/Data/Game/Mechanics/FallContextData.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/FallContextData.cs
@@ -49,9 +49,18 @@ public record FallContextData
     /// </summary>
     public bool WasJumping { get; init; }
     
+    /// <summary>
+    /// The skid damage data (only applies when skidding during a fall)
+    /// </summary>
+    public FallingDamageData? SkidDamageData { get; init; }
+    
+    /// <summary>
+    /// The distance the unit skidded in hexes
+    /// </summary>
+    public int SkidDistance { get; init; }
+
     public MechFallCommand ToMechFallCommand()
     {
-        // Convert FallContextData to MechFallCommand
         return new MechFallCommand
         {
             UnitId = UnitId,
@@ -61,6 +70,18 @@ public record FallContextData
             DamageData = FallingDamageData,
             FallPilotingSkillRoll = PilotingSkillRoll,
             PilotDamagePilotingSkillRoll = PilotDamagePilotingSkillRoll
+        };
+    }
+
+    public MechSkidCommand? ToMechSkidCommand()
+    {
+        if (SkidDamageData == null) return null;
+        return new MechSkidCommand
+        {
+            UnitId = UnitId,
+            GameOriginId = GameId,
+            SkidDistance = SkidDistance,
+            DamageData = SkidDamageData
         };
     }
 

--- a/src/MakaMek.Core/Data/Game/Mechanics/FallingDamageData.cs
+++ b/src/MakaMek.Core/Data/Game/Mechanics/FallingDamageData.cs
@@ -1,6 +1,7 @@
+using System.Text;
 using Sanet.MakaMek.Core.Models.Game.Dice;
-using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
+using Sanet.MakaMek.Localization;
 using Sanet.MakaMek.Map.Models;
 
 namespace Sanet.MakaMek.Core.Data.Game.Mechanics;
@@ -12,4 +13,21 @@ public record FallingDamageData(
     HexDirection FacingAfterFall,
     HitLocationsData HitLocations,
     DiceResult FacingDiceRoll,
-    HitDirection FallDirection);
+    HitDirection FallDirection)
+{
+    public void Render(StringBuilder stringBuilder, ILocalizationService localizationService)
+    {
+        stringBuilder.AppendFormat(
+            localizationService.GetString("Command_MechFalling_Damage"),
+            HitLocations.TotalDamage);
+
+        if (HitLocations.HitLocations.Count <= 0) return;
+        stringBuilder.AppendLine();
+        stringBuilder.AppendLine(localizationService.GetString("Command_WeaponAttackResolution_HitLocations"));
+
+        foreach (var hitLocation in HitLocations.HitLocations)
+        {
+            stringBuilder.Append(hitLocation.Render(localizationService));
+        }
+    }
+}

--- a/src/MakaMek.Core/Models/Game/BaseGame.cs
+++ b/src/MakaMek.Core/Models/Game/BaseGame.cs
@@ -273,6 +273,15 @@ public abstract class BaseGame : IGame
         mech.ApplyFall(fallCommand);
     }
 
+    internal void OnMechSkidding(MechSkidCommand skidCommand)
+    {
+        if (_players
+                .SelectMany(p => p.Units)
+                .FirstOrDefault(u => u.Id == skidCommand.UnitId) is not Mech mech) return;
+
+        mech.ApplySkid(skidCommand);
+    }
+
     internal void OnMechStandUp(MechStandUpCommand standUpCommand)
     {
         // Find the unit with the given ID across all players
@@ -445,6 +454,7 @@ public abstract class BaseGame : IGame
             TurnEndedCommand => CommandValidationResult.Valid(),
             RequestGameLobbyStatusCommand => CommandValidationResult.Valid(),
             MechFallCommand => CommandValidationResult.Valid(),
+            MechSkidCommand => CommandValidationResult.Valid(),
             TryStandupCommand => CommandValidationResult.Valid(),
             MechStandUpCommand => CommandValidationResult.Valid(),
             UnitShutdownCommand => CommandValidationResult.Valid(),

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallProcessor.cs
@@ -154,11 +154,23 @@ public class FallProcessor : IFallProcessor
                 pilotDamagePsr = _pilotingSkillCalculator.EvaluateRoll(pilotPsrBreakdown, mech, pilotDamageContext);
             }
 
-            var fallingDamageData = isFallingNow
-                ? context is SkidCheckRollContext skidCtx
-                    ? _fallingDamageCalculator.CalculateSkidDamage(mech, skidCtx.SkidDistance)
-                    : _fallingDamageCalculator.CalculateFallingDamage(mech, levelsFallen, wasJumping)
-                : null;
+            FallingDamageData? fallingDamageData = null;
+            FallingDamageData? skidDamageData = null;
+
+            if (isFallingNow)
+            {
+                fallingDamageData = _fallingDamageCalculator.CalculateFallingDamage(mech, levelsFallen, wasJumping);
+
+                if (context is SkidCheckRollContext skidCtx && skidCtx.SkidDistance > 0)
+                {
+                    skidDamageData = _fallingDamageCalculator.CalculateSkidDamage(
+                        mech,
+                        skidCtx.SkidDistance,
+                        fallingDamageData.FacingAfterFall,
+                        fallingDamageData.FacingDiceRoll,
+                        fallingDamageData.FallDirection);
+                }
+            }
 
             var fallContextData = new FallContextData
             {
@@ -169,7 +181,9 @@ public class FallProcessor : IFallProcessor
                 PilotDamagePilotingSkillRoll = pilotDamagePsr,
                 FallingDamageData = fallingDamageData,
                 LevelsFallen = levelsFallen,
-                WasJumping = wasJumping
+                WasJumping = wasJumping,
+                SkidDamageData = skidDamageData,
+                SkidDistance = context is SkidCheckRollContext skidCtx2 ? skidCtx2.SkidDistance : 0
             };
 
             results.Add(fallContextData);

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallingDamageCalculator.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/FallingDamageCalculator.cs
@@ -5,12 +5,10 @@ using Sanet.MakaMek.Core.Models.Game.Dice;
 using Sanet.MakaMek.Core.Models.Game.Rules;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Mechs;
+using Sanet.MakaMek.Map.Models;
 
 namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Mechs.Falling;
 
-/// <summary>
-/// Classic BattleTech implementation of falling damage calculator
-/// </summary>
 public class FallingDamageCalculator : IFallingDamageCalculator
 {
     private readonly ILogger<FallingDamageCalculator> _logger;
@@ -37,8 +35,8 @@ public class FallingDamageCalculator : IFallingDamageCalculator
     /// <param name="wasJumping">Whether the unit was jumping when it fell</param>
     /// <returns>The result of the falling damage calculation</returns>
     public FallingDamageData CalculateFallingDamage(
-        Unit unit, 
-        int levelsFallen, 
+        Unit unit,
+        int levelsFallen,
         bool wasJumping)
     {
         if (unit is not Mech mech)
@@ -48,26 +46,20 @@ public class FallingDamageCalculator : IFallingDamageCalculator
 
         if (mech.Position == null)
         {
-            throw new ArgumentException("Mech must be deployed", nameof(unit)); 
+            throw new ArgumentException("Mech must be deployed", nameof(unit));
         }
 
-        // If the mech was jumping, it only takes damage for 1 level
-        // Otherwise, it takes damage for (levelsFallen + 1) levels
         var effectiveLevels = wasJumping ? 0 : levelsFallen;
-        
-        // Calculate damage based on tonnage (rounded up to nearest 10)
-        var totalDamage = (int)Math.Ceiling(mech.Tonnage / 10.0)*(effectiveLevels + 1);
-        
-        return DistributeDamage(mech, totalDamage);
+        var totalDamage = (int)Math.Ceiling(mech.Tonnage / 10.0) * (effectiveLevels + 1);
+
+        var facingRoll = _diceRoller.RollD6();
+        var newFacing = _rulesProvider.GetFacingAfterFall(facingRoll.Result, mech.Position.Facing);
+        var attackDirection = _rulesProvider.GetAttackDirectionAfterFall(facingRoll.Result);
+
+        return DistributeDamage(mech, totalDamage, newFacing, facingRoll, attackDirection);
     }
 
-    /// <summary>
-    /// Calculates the damage a unit takes when skidding
-    /// </summary>
-    /// <param name="unit">The unit that skidded</param>
-    /// <param name="skidDistance">The distance in hexes the unit skidded</param>
-    /// <returns>The result of the skid damage calculation</returns>
-    public FallingDamageData CalculateSkidDamage(Unit unit, int skidDistance)
+    public FallingDamageData CalculateSkidDamage(Unit unit, int skidDistance, HexDirection facingAfterFall, DiceResult facingRoll, HitDirection attackDirection)
     {
         if (skidDistance < 0)
         {
@@ -77,74 +69,32 @@ public class FallingDamageCalculator : IFallingDamageCalculator
 
         if (unit.Position == null)
         {
-            throw new ArgumentException("Unit must be deployed", nameof(unit)); 
+            throw new ArgumentException("Unit must be deployed", nameof(unit));
         }
 
-        // Skid damage: half the per-level falling damage per hex skidded
         var damagePerHex = Math.Ceiling(unit.Tonnage / 10.0) * 0.5;
         var totalDamage = (int)Math.Ceiling(damagePerHex * skidDistance);
-        
-        return DistributeDamage(unit, totalDamage);
+
+        return DistributeDamage(unit, totalDamage, facingAfterFall, facingRoll, attackDirection);
     }
 
-    /// <summary>
-    /// Shared damage distribution logic: rolls facing, determines hit locations,
-    /// and distributes damage into 5-point groups
-    /// </summary>
-    private FallingDamageData DistributeDamage(Unit unit, int totalDamage)
+    private FallingDamageData DistributeDamage(Unit unit, int totalDamage, HexDirection newFacing, DiceResult facingRoll, HitDirection attackDirection)
     {
-        // Roll for facing after fall (1d6)
-        var facingRoll = _diceRoller.RollD6();
-        
-        // Determine new facing based on current facing and roll
-        var newFacing = _rulesProvider.GetFacingAfterFall(facingRoll.Result, unit.Position!.Facing);
-        
-        // Determine attack direction for hit location purposes
-        var attackDirection = _rulesProvider.GetAttackDirectionAfterFall(facingRoll.Result);
-        
-        // Divide damage into groups of 5 points each
         var hitLocations = new List<LocationHitData>();
-        var remainingDamage = totalDamage;
-        
-        // Calculate how many full 5-point groups we have
-        var fullGroups = remainingDamage / 5;
-        // Calculate the remaining points for the smaller group
-        var remainingPoints = remainingDamage % 5;
-        
-        // Local function to determine hit location and create HitLocationData
-        LocationHitData DetermineHitLocationData(int damageAmount)
-        {
-            var locationRolls = _diceRoller.Roll2D6().Select(d => d.Result).ToArray();
-            var locationRollResult = locationRolls.Sum();
-            var hitLocation = _rulesProvider.GetHitLocation(locationRollResult, attackDirection);
-            
-            var locationDamage = _damageTransferCalculator.CalculateStructureDamage(
-                unit,
-                hitLocation,
-                damageAmount,
-                attackDirection);
-            
-            return new LocationHitData(
-                locationDamage,
-                [],
-                locationRolls,
-                hitLocation
-            );
-        }
-        
-        // Add full 5-point groups
+
+        var fullGroups = totalDamage / 5;
+        var remainingPoints = totalDamage % 5;
+
         for (var i = 0; i < fullGroups; i++)
         {
             hitLocations.Add(DetermineHitLocationData(5));
         }
-        
-        // Add the smaller group if there are remaining points
+
         if (remainingPoints > 0)
         {
             hitLocations.Add(DetermineHitLocationData(remainingPoints));
         }
-        
-        // Create hit locations data
+
         var hitLocationsData = new HitLocationsData(
             hitLocations,
             totalDamage
@@ -156,5 +106,25 @@ public class FallingDamageCalculator : IFallingDamageCalculator
             facingRoll,
             attackDirection
         );
+
+        LocationHitData DetermineHitLocationData(int damageAmount)
+        {
+            var locationRolls = _diceRoller.Roll2D6().Select(d => d.Result).ToArray();
+            var locationRollResult = locationRolls.Sum();
+            var hitLocation = _rulesProvider.GetHitLocation(locationRollResult, attackDirection);
+
+            var locationDamage = _damageTransferCalculator.CalculateStructureDamage(
+                unit,
+                hitLocation,
+                damageAmount,
+                attackDirection);
+
+            return new LocationHitData(
+                locationDamage,
+                [],
+                locationRolls,
+                hitLocation
+            );
+        }
     }
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallingDamageCalculator.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Mechs/Falling/IFallingDamageCalculator.cs
@@ -1,27 +1,14 @@
 using Sanet.MakaMek.Core.Data.Game.Mechanics;
+using Sanet.MakaMek.Core.Models.Game.Dice;
+using Sanet.MakaMek.Core.Models.Map;
 using Sanet.MakaMek.Core.Models.Units;
+using Sanet.MakaMek.Map.Models;
 
 namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Mechs.Falling;
 
-/// <summary>
-/// Interface for calculating damage when a unit falls
-/// </summary>
 public interface IFallingDamageCalculator
 {
-    /// <summary>
-    /// Calculates the damage a unit takes when falling
-    /// </summary>
-    /// <param name="unit">The unit that fell</param>
-    /// <param name="levelsFallen">The number of levels the unit fell</param>
-    /// <param name="wasJumping">Whether the unit was jumping when it fell</param>
-    /// <returns>The result of the falling damage calculation</returns>
     FallingDamageData CalculateFallingDamage(Unit unit, int levelsFallen, bool wasJumping);
 
-    /// <summary>
-    /// Calculates the damage a unit takes when skidding
-    /// </summary>
-    /// <param name="unit">The unit that skidded</param>
-    /// <param name="skidDistance">The distance in hexes the unit skidded</param>
-    /// <returns>The result of the skid damage calculation</returns>
-    FallingDamageData CalculateSkidDamage(Unit unit, int skidDistance);
+    FallingDamageData CalculateSkidDamage(Unit unit, int skidDistance, HexDirection facingAfterFall, DiceResult facingRoll, HitDirection attackDirection);
 }

--- a/src/MakaMek.Core/Models/Game/Mechanics/Movement/Actions/ApplySkidAction.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Movement/Actions/ApplySkidAction.cs
@@ -1,0 +1,33 @@
+﻿using Sanet.MakaMek.Core.Data.Game.Commands;
+using Sanet.MakaMek.Core.Data.Game.Commands.Server;
+using Sanet.MakaMek.Core.Models.Units.Mechs;
+
+namespace Sanet.MakaMek.Core.Models.Game.Mechanics.Movement.Actions;
+
+public class ApplySkidAction(Mech mech, MechSkidCommand command) : IGameAction
+{
+    public IReadOnlyList<IGameCommand> Process(ServerGame game)
+    {
+        var commands = new List<IGameCommand>();
+
+        game.OnMechSkidding(command);
+        commands.Add(command);
+
+        var locationsWithDamagedStructure = command.DamageData?.HitLocations.HitLocations
+            .Where(h => h.Damage.Any(d => d.StructureDamage > 0))
+            .SelectMany(h => h.Damage.Where(d => d.StructureDamage > 0))
+            .ToList() ?? [];
+        if (locationsWithDamagedStructure.Count != 0)
+        {
+            var critCommand = game.CriticalHitsCalculator
+                .CalculateAndApplyCriticalHits(mech, locationsWithDamagedStructure);
+            if (critCommand != null)
+            {
+                critCommand.GameOriginId = game.Id;
+                commands.Add(critCommand);
+            }
+        }
+
+        return commands;
+    }
+}

--- a/src/MakaMek.Core/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandler.cs
+++ b/src/MakaMek.Core/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandler.cs
@@ -61,15 +61,21 @@ public class SkidInterruptHandler : IMovementInterruptHandler
             };
 
             var fallCommand = skidFallContext.ToMechFallCommand();
+            var skidCommand = skidFallContext.ToMechSkidCommand();
+
+            var actions = new List<IGameAction>
+            {
+                new MoveUnitAction(modifiedCommand, publish: true),
+                new ApplyFallAction(mech, fallCommand)
+            };
+            if (skidCommand != null)
+                actions.Add(new ApplySkidAction(mech, skidCommand.Value));
 
             return new MovementInterruptResult
             {
                 ShouldStop = true,
-                GameActions = new List<IGameAction>
-                {
-                    new MoveUnitAction(modifiedCommand, publish: true),
-                    new ApplyFallAction(mech, fallCommand)
-                }
+                DeferStepConsumption = false,
+                GameActions = actions
             };
         }
 

--- a/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
+++ b/src/MakaMek.Core/Models/Game/Phases/MovementPhase.cs
@@ -198,6 +198,8 @@ public class MovementPhase(ServerGame game) : MainGamePhase(game)
             commands.AddRange(action.Process(Game));
             if (unit is Mech fallingMech && action is ApplyFallAction)
                 deferAfterFall = fallingMech.CanStandup();
+            if (action is ApplySkidAction)
+                deferAfterFall = false;
         }
 
         foreach (var cmd in commands)

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -533,6 +533,9 @@ public class Mech : Unit
         if (MovementTaken?.MovementType == MovementType.Jump) 
             return false;
 
+        // Cannot stand up when skidding
+        if (IsSkidding) return false;
+
         if (!IsGyroAvailable) return false;
 
         var destroyedLegs = _parts.Values.OfType<Leg>().Count(p=> p.IsDestroyed);

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -629,6 +629,13 @@ public class Mech : Unit
 
         MovementTaken = MovementTaken?.WithLastSegmentEvent(new SegmentEvent(SegmentEventType.Fall));
     }
+
+    public void ApplySkid(MechSkidCommand skidCommand)
+    {
+        if (skidCommand.DamageData is not { HitLocations.HitLocations: var hits }) return;
+        ApplyDamage(hits, skidCommand.DamageData.FallDirection);
+    }
+    
     
     public override HexPosition? Position
     {

--- a/src/MakaMek.Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Localization/FakeLocalizationService.cs
@@ -2,7 +2,7 @@ namespace Sanet.MakaMek.Localization;
 
 public class FakeLocalizationService : ILocalizationService
 {
-    protected readonly Dictionary<string, string> _strings = new()
+    protected readonly Dictionary<string, string> Strings = new()
     {
         ["Command_JoinGame"] = "{0} has joined game with {1} units",
         ["Command_PlayerLeft"] = "{0} has left the game",
@@ -85,6 +85,7 @@ public class FakeLocalizationService : ILocalizationService
         ["MovementCost_Jump"] = "jump, {0} MP",
         ["MovementCost_StandUpAttempt"] = "stand up attempt, {0} MP",
         ["MovementCost_HexEnter"] = "entered hex, {0} MP",
+        ["Command_MechSkid_Base"] = "{0} skidded {1} hexes (skid damage)",
         ["Command_MechFalling_PsrIntro"] = "{0} may fall",
         ["Command_MechFalling_Base"] = "{0} fell",
         ["Command_MechFalling_Levels"] = " {0} level(s)",
@@ -457,6 +458,6 @@ public class FakeLocalizationService : ILocalizationService
 
     public virtual string GetString(string key)
     {
-        return _strings.TryGetValue(key, out var value) ? value : key;
+        return Strings.TryGetValue(key, out var value) ? value : key;
     }
 }

--- a/tests/MakaMek.Core.Tests/Data/Game/Commands/Server/MechSkidCommandTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Commands/Server/MechSkidCommandTests.cs
@@ -1,0 +1,122 @@
+using NSubstitute;
+using Sanet.MakaMek.Core.Data.Game;
+using Sanet.MakaMek.Core.Data.Game.Commands;
+using Sanet.MakaMek.Core.Data.Game.Commands.Server;
+using Sanet.MakaMek.Core.Data.Game.Mechanics;
+using Sanet.MakaMek.Core.Models.Game;
+using Sanet.MakaMek.Core.Models.Game.Dice;
+using Sanet.MakaMek.Core.Models.Game.Players;
+using Sanet.MakaMek.Core.Models.Game.Rules;
+using Sanet.MakaMek.Core.Models.Units;
+using Sanet.MakaMek.Core.Tests.Utils;
+using Sanet.MakaMek.Core.Utils;
+using Sanet.MakaMek.Localization;
+using Sanet.MakaMek.Map.Models;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Data.Game.Commands.Server;
+
+public class MechSkidCommandTests
+{
+    private readonly ILocalizationService _localizationService = new FakeLocalizationService();
+    private readonly IGame _game = Substitute.For<IGame>();
+    private readonly Guid _gameId = Guid.NewGuid();
+    private readonly Unit _unit;
+
+    public MechSkidCommandTests()
+    {
+        var player = new Player(Guid.NewGuid(), "Player 1", PlayerControlType.Human);
+
+        var mechFactory = new MechFactory(
+            new TotalWarfareRulesProvider(),
+            new ClassicBattletechComponentProvider(),
+            _localizationService);
+        var unitData = MechFactoryTests.CreateDummyMechData();
+        unitData.Id = Guid.NewGuid();
+
+        _unit = mechFactory.Create(unitData);
+
+        player.AddUnit(_unit);
+
+        _game.Players.Returns(new List<IPlayer> { player });
+    }
+
+    private static FallingDamageData CreateTestFallingDamageData(int totalDamage = 5)
+    {
+        var hitLocations = new List<LocationHitData>
+        {
+            new LocationHitData(
+                new List<LocationDamageData>
+                {
+                    new LocationDamageData(PartLocation.CenterTorso, totalDamage, 0, false)
+                },
+                [],
+                [6],
+                PartLocation.CenterTorso)
+        };
+        var hitLocationsData = new HitLocationsData(hitLocations, totalDamage);
+        return new FallingDamageData(HexDirection.Top, hitLocationsData, new DiceResult(1), HitDirection.Front);
+    }
+
+    private MechSkidCommand CreateBasicSkidCommand()
+    {
+        return new MechSkidCommand
+        {
+            GameOriginId = _gameId,
+            UnitId = _unit.Id,
+            SkidDistance = 2,
+            DamageData = CreateTestFallingDamageData(),
+            Timestamp = DateTime.UtcNow
+        };
+    }
+
+    [Fact]
+    public void ShouldImplementIGameCommand()
+    {
+        var sut = CreateBasicSkidCommand();
+        sut.ShouldBeAssignableTo<IGameCommand>();
+    }
+
+    [Fact]
+    public void Render_ShouldFormatSkidCommand_Correctly()
+    {
+        var sut = CreateBasicSkidCommand();
+
+        var result = sut.Render(_localizationService, _game);
+
+        result.ShouldNotBeEmpty();
+        result.ShouldContain("LCT-1V skidded 2 hexes (skid damage)");
+        result.ShouldContain("and took 5 damage");
+    }
+
+    [Fact]
+    public void Render_ShouldIncludeHitLocations_WhenDamageDataHasHitLocations()
+    {
+        var sut = CreateBasicSkidCommand();
+
+        var result = sut.Render(_localizationService, _game);
+
+        result.ShouldNotBeEmpty();
+        result.ShouldContain("Hit Locations:");
+    }
+
+    [Fact]
+    public void Render_ShouldReturnEmpty_WhenUnitNotFound()
+    {
+        var sut = CreateBasicSkidCommand() with { UnitId = Guid.NewGuid() };
+
+        var result = sut.Render(_localizationService, _game);
+
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Render_ShouldReturnEmpty_WhenDamageDataIsNull()
+    {
+        var sut = CreateBasicSkidCommand() with { DamageData = null };
+
+        var result = sut.Render(_localizationService, _game);
+
+        result.ShouldBeEmpty();
+    }
+}

--- a/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallContextDataTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallContextDataTests.cs
@@ -160,4 +160,48 @@ public class FallContextDataTests
         // Assert
         result.ShouldBeNull();
     }
+
+    [Fact]
+    public void ToMechSkidCommand_WhenNoSkidDamageData_ShouldReturnNull()
+    {
+        var fallContextData = new FallContextData
+        {
+            UnitId = _unitId,
+            GameId = _gameId,
+            IsFalling = true,
+            SkidDamageData = null
+        };
+
+        var result = fallContextData.ToMechSkidCommand();
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ToMechSkidCommand_WhenSkidDamageDataExists_ShouldCreateCorrectCommand()
+    {
+        var skidDamageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData([], 5),
+            new DiceResult(4),
+            HitDirection.Front
+        );
+
+        var fallContextData = new FallContextData
+        {
+            UnitId = _unitId,
+            GameId = _gameId,
+            IsFalling = true,
+            SkidDamageData = skidDamageData,
+            SkidDistance = 3
+        };
+
+        var result = fallContextData.ToMechSkidCommand();
+
+        var command = result.ShouldNotBeNull();
+        command.UnitId.ShouldBe(_unitId);
+        command.GameOriginId.ShouldBe(_gameId);
+        command.SkidDistance.ShouldBe(3);
+        command.DamageData.ShouldBe(skidDamageData);
+    }
 }

--- a/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallingDamageDataTests.cs
+++ b/tests/MakaMek.Core.Tests/Data/Game/Mechanics/FallingDamageDataTests.cs
@@ -1,0 +1,88 @@
+using System.Text;
+using Sanet.MakaMek.Core.Data.Game;
+using Sanet.MakaMek.Core.Data.Game.Mechanics;
+using Sanet.MakaMek.Core.Models.Game.Dice;
+using Sanet.MakaMek.Core.Models.Units;
+using Sanet.MakaMek.Localization;
+using Sanet.MakaMek.Map.Models;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Data.Game.Mechanics;
+
+public class FallingDamageDataTests
+{
+    private readonly ILocalizationService _localizationService = new FakeLocalizationService();
+
+    private static FallingDamageData CreateSutWithHitLocations(bool hasHitLocations = true)
+    {
+        var hitLocations = hasHitLocations
+            ? new List<LocationHitData>
+            {
+                new LocationHitData(
+                    new List<LocationDamageData>
+                    {
+                        new LocationDamageData(PartLocation.CenterTorso, 4, 1, false)
+                    },
+                    [],
+                    [6],
+                    PartLocation.CenterTorso)
+            }
+            : new List<LocationHitData>();
+
+        var hitLocationsData = new HitLocationsData(hitLocations, 5);
+        return new FallingDamageData(
+            HexDirection.Top,
+            hitLocationsData,
+            new DiceResult(1),
+            HitDirection.Front);
+    }
+
+    [Fact]
+    public void Render_ShouldIncludeDamageTotal_WhenHitLocationsExist()
+    {
+        var sut = CreateSutWithHitLocations();
+        var stringBuilder = new StringBuilder();
+
+        sut.Render(stringBuilder, _localizationService);
+
+        var result = stringBuilder.ToString();
+        result.ShouldContain("and took 5 damage");
+    }
+
+    [Fact]
+    public void Render_ShouldIncludeHitLocationsSection_WhenHitLocationsExist()
+    {
+        var sut = CreateSutWithHitLocations();
+        var stringBuilder = new StringBuilder();
+
+        sut.Render(stringBuilder, _localizationService);
+
+        var result = stringBuilder.ToString();
+        result.ShouldContain("Hit Locations:");
+    }
+
+    [Fact]
+    public void Render_ShouldIncludeHitLocationDetails_WhenHitLocationsExist()
+    {
+        var sut = CreateSutWithHitLocations();
+        var stringBuilder = new StringBuilder();
+
+        sut.Render(stringBuilder, _localizationService);
+
+        var result = stringBuilder.ToString();
+        result.ShouldContain("CT");
+    }
+
+    [Fact]
+    public void Render_ShouldNotIncludeHitLocationsSection_WhenNoHitLocations()
+    {
+        var sut = CreateSutWithHitLocations(false);
+        var stringBuilder = new StringBuilder();
+
+        sut.Render(stringBuilder, _localizationService);
+
+        var result = stringBuilder.ToString();
+        result.ShouldContain("and took 5 damage");
+        result.ShouldNotContain("Hit Locations:");
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Game/BaseGameTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/BaseGameTests.cs
@@ -30,6 +30,7 @@ using Sanet.MakaMek.Map.Factories;
 using Sanet.MakaMek.Map.Generators;
 using Sanet.MakaMek.Map.Models;
 using Sanet.MakaMek.Map.Models.Terrains;
+using Sanet.MakaMek.Core.Models.Game.Dice;
 
 namespace Sanet.MakaMek.Core.Tests.Models.Game;
 
@@ -1212,6 +1213,73 @@ public sealed class BaseGameTests : BaseGame
     }
     
     [Fact]
+    public void ValidateCommand_ShouldAutoValidateMechFallCommand()
+    {
+        // Arrange
+        var command = new MechFallCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            UnitId = Guid.NewGuid(),
+            DamageData = null
+        };
+
+        // Act
+        var result = ValidateCommand(command);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ValidateCommand_ShouldAutoValidateMechSkidCommand()
+    {
+        // Arrange
+        var command = new MechSkidCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            UnitId = Guid.NewGuid(),
+            SkidDistance = 1,
+            DamageData = null
+        };
+
+        // Act
+        var result = ValidateCommand(command);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ValidateCommand_ShouldAutoValidateMechStandUpCommand()
+    {
+        // Arrange
+        var command = new MechStandUpCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            UnitId = Guid.NewGuid(),
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt),
+                DiceResults = [2, 2],
+                IsSuccessful = true,
+                PsrBreakdown = new PsrBreakdown
+                {
+                    BasePilotingSkill = 0,
+                    Modifiers = []
+                }
+            },
+            NewFacing = HexDirection.Bottom,
+            MovementTypeAfterStandup = MovementType.Walk
+        };
+
+        // Act
+        var result = ValidateCommand(command);
+
+        // Assert
+        result.IsValid.ShouldBeTrue();
+    }
+
+    [Fact]
     public void OnUnitShutdown_DoesNothing_WhenUnitNotFound()
     {
         // Arrange
@@ -1666,6 +1734,93 @@ public sealed class BaseGameTests : BaseGame
 
         // Assert - AttemptStandup was NOT invoked: standup attempts counter remains 0
         mech.StandupAttempts.ShouldBe(0);
+    }
+
+    [Fact]
+    public void OnMechSkidding_DoesNothing_WhenUnitNotFound()
+    {
+        // Arrange
+        var command = new MechSkidCommand
+        {
+            GameOriginId = Id,
+            UnitId = Guid.NewGuid(),
+            SkidDistance = 1,
+            DamageData = null
+        };
+
+        // Act & Assert - Should not throw
+        Should.NotThrow(() => OnMechSkidding(command));
+    }
+
+    [Fact]
+    public void OnMechSkidding_DoesNothing_WhenNoDamageData()
+    {
+        // Arrange
+        var joinCommand = new JoinGameCommand
+        {
+            PlayerId = Guid.NewGuid(),
+            PlayerName = "Player1",
+            GameOriginId = Guid.NewGuid(),
+            Units = [MechFactoryTests.CreateDummyMechData()],
+            Tint = "#FF0000",
+            PilotAssignments = []
+        };
+        OnPlayerJoined(joinCommand);
+        var mech = Players.SelectMany(p => p.Units).First() as Mech;
+
+        var command = new MechSkidCommand
+        {
+            GameOriginId = Id,
+            UnitId = mech!.Id,
+            SkidDistance = 1,
+            DamageData = null
+        };
+
+        // Act & Assert - Should not throw
+        Should.NotThrow(() => OnMechSkidding(command));
+    }
+
+    [Fact]
+    public void OnMechSkidding_AppliesDamage_WhenDamageDataProvided()
+    {
+        // Arrange
+        var joinCommand = new JoinGameCommand
+        {
+            PlayerId = Guid.NewGuid(),
+            PlayerName = "Player1",
+            GameOriginId = Guid.NewGuid(),
+            Units = [MechFactoryTests.CreateDummyMechData()],
+            Tint = "#FF0000",
+            PilotAssignments = []
+        };
+        OnPlayerJoined(joinCommand);
+        var mech = Players.SelectMany(p => p.Units).First() as Mech;
+        mech!.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Bottom), null);
+
+        var hitLocations = new List<LocationHitData>
+        {
+            CreateHitDataForLocation(PartLocation.CenterTorso, 5, [], [])
+        };
+        var centerTorsoPart = mech.Parts[PartLocation.CenterTorso];
+        var initialArmor = centerTorsoPart.CurrentArmor;
+
+        var command = new MechSkidCommand
+        {
+            GameOriginId = Id,
+            UnitId = mech.Id,
+            SkidDistance = 2,
+            DamageData = new FallingDamageData(
+                HexDirection.Bottom,
+                new HitLocationsData(hitLocations, 5),
+                new DiceResult(3),
+                HitDirection.Front)
+        };
+
+        // Act
+        OnMechSkidding(command);
+
+        // Assert
+        centerTorsoPart.CurrentArmor.ShouldBe(initialArmor - 5);
     }
 
     public override void HandleCommand(IGameCommand command)

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallProcessorTests.cs
@@ -1466,8 +1466,12 @@ public class FallProcessorTests
         SetupRollResult(false, PilotingSkillRollType.SkidCheck);
         SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
 
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>())
+            .Returns(fallingDamageData);
+
         var skidDamageData = GetFallingDamageData();
-        _mockFallingDamageCalculator.CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3))
+        _mockFallingDamageCalculator.CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3), Arg.Any<HexDirection>(), Arg.Any<DiceResult>(), Arg.Any<HitDirection>())
             .Returns(skidDamageData);
 
         // Act
@@ -1477,10 +1481,10 @@ public class FallProcessorTests
         result.IsFalling.ShouldBeTrue();
         result.LevelsFallen.ShouldBe(0);
         result.WasJumping.ShouldBeFalse();
-        result.FallingDamageData.ShouldBe(skidDamageData);
+        result.FallingDamageData.ShouldBe(fallingDamageData);
 
-        _mockFallingDamageCalculator.Received(1).CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3));
-        _mockFallingDamageCalculator.DidNotReceive().CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
+        _mockFallingDamageCalculator.Received(1).CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3), Arg.Any<HexDirection>(), Arg.Any<DiceResult>(), Arg.Any<HitDirection>());
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
     }
 
     [Fact]
@@ -1498,7 +1502,7 @@ public class FallProcessorTests
         result.IsFalling.ShouldBeFalse();
         result.FallingDamageData.ShouldBeNull();
 
-        _mockFallingDamageCalculator.DidNotReceive().CalculateSkidDamage(Arg.Any<Unit>(), Arg.Any<int>());
+        _mockFallingDamageCalculator.DidNotReceive().CalculateSkidDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<HexDirection>(), Arg.Any<DiceResult>(), Arg.Any<HitDirection>());
         _mockFallingDamageCalculator.DidNotReceive().CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
     }
 
@@ -1512,8 +1516,12 @@ public class FallProcessorTests
         SetupRollResult(false, PilotingSkillRollType.SkidCheck);
         SetupRollResult(true, PilotingSkillRollType.PilotDamageFromFall);
 
+        var fallingDamageData = GetFallingDamageData();
+        _mockFallingDamageCalculator.CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>())
+            .Returns(fallingDamageData);
+
         var skidDamageData = GetFallingDamageData();
-        _mockFallingDamageCalculator.CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3))
+        _mockFallingDamageCalculator.CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3), Arg.Any<HexDirection>(), Arg.Any<DiceResult>(), Arg.Any<HitDirection>())
             .Returns(skidDamageData);
 
         // Act
@@ -1521,7 +1529,8 @@ public class FallProcessorTests
 
         // Assert
         result.IsFalling.ShouldBeTrue();
-        _mockFallingDamageCalculator.Received(1).CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3));
+        _mockFallingDamageCalculator.Received(1).CalculateSkidDamage(Arg.Any<Unit>(), Arg.Is<int>(h => h == 3), Arg.Any<HexDirection>(), Arg.Any<DiceResult>(), Arg.Any<HitDirection>());
+        _mockFallingDamageCalculator.Received(1).CalculateFallingDamage(Arg.Any<Unit>(), Arg.Any<int>(), Arg.Any<bool>());
     }
 
     [Theory]

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallingDamageCalculatorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Mechs/Falling/FallingDamageCalculatorTests.cs
@@ -325,7 +325,7 @@ public class FallingDamageCalculatorTests
         var unit = new UnitTests.TestUnit("test", "unit", 20, []);
 
         Should.Throw<ArgumentOutOfRangeException>(() =>
-            _sut.CalculateSkidDamage(unit, -1))
+            _sut.CalculateSkidDamage(unit, -1, HexDirection.Top, new DiceResult(1), HitDirection.Front))
             .ParamName.ShouldBe("skidDistance");
     }
 
@@ -335,7 +335,7 @@ public class FallingDamageCalculatorTests
         var unit = new UnitTests.TestUnit("test", "unit", 20, []);
 
         Should.Throw<ArgumentOutOfRangeException>(() =>
-            _sut.CalculateSkidDamage(unit, -1));
+            _sut.CalculateSkidDamage(unit, -1, HexDirection.Top, new DiceResult(1), HitDirection.Front));
 
         _mockLogger.Received(1).Log(
             LogLevel.Error,
@@ -351,7 +351,7 @@ public class FallingDamageCalculatorTests
         var unit = new UnitTests.TestUnit("test", "unit", 20, []);
 
         Should.Throw<ArgumentException>(() =>
-            _sut.CalculateSkidDamage(unit, 1))
+            _sut.CalculateSkidDamage(unit, 1, HexDirection.Top, new DiceResult(1), HitDirection.Front))
             .Message.ShouldContain("must be deployed");
     }
 
@@ -364,7 +364,7 @@ public class FallingDamageCalculatorTests
         _mockDiceRoller.RollD6().Returns(new DiceResult(1));
         _mockDiceRoller.Roll2D6().Returns([new DiceResult(3), new DiceResult(3)]);
 
-        var result = _sut.CalculateSkidDamage(mech, 4);
+        var result = _sut.CalculateSkidDamage(mech, 4, HexDirection.Top, new DiceResult(1), HitDirection.Front);
 
         result.HitLocations.TotalDamage.ShouldBe(4);
     }
@@ -378,7 +378,7 @@ public class FallingDamageCalculatorTests
         _mockDiceRoller.RollD6().Returns(new DiceResult(1));
         _mockDiceRoller.Roll2D6().Returns([new DiceResult(3), new DiceResult(3)]);
 
-        var result = _sut.CalculateSkidDamage(mech, 3);
+        var result = _sut.CalculateSkidDamage(mech, 3, HexDirection.Top, new DiceResult(1), HitDirection.Front);
 
         result.HitLocations.TotalDamage.ShouldBe(8);
     }
@@ -408,7 +408,7 @@ public class FallingDamageCalculatorTests
                 Arg.Any<HitDirection>())
             .Returns([new LocationDamageData(PartLocation.LeftTorso, 3, 0, false)]);
 
-        var result = _sut.CalculateSkidDamage(mech, 3);
+        var result = _sut.CalculateSkidDamage(mech, 3, HexDirection.Top, new DiceResult(1), HitDirection.Front);
 
         result.HitLocations.TotalDamage.ShouldBe(8);
         result.HitLocations.HitLocations.Count.ShouldBe(2);
@@ -434,7 +434,7 @@ public class FallingDamageCalculatorTests
         _mockDiceRoller.RollD6().Returns(new DiceResult(1));
         _mockDiceRoller.Roll2D6().Returns([new DiceResult(3), new DiceResult(3)]);
 
-        var result = _sut.CalculateSkidDamage(mech, 1);
+        var result = _sut.CalculateSkidDamage(mech, 1, HexDirection.Top, new DiceResult(1), HitDirection.Front);
 
         result.HitLocations.TotalDamage.ShouldBe(2);
     }
@@ -448,7 +448,7 @@ public class FallingDamageCalculatorTests
         _mockDiceRoller.RollD6().Returns(new DiceResult(1));
         _mockDiceRoller.Roll2D6().Returns([new DiceResult(3), new DiceResult(3)]);
 
-        var result = _sut.CalculateSkidDamage(mech, 1);
+        var result = _sut.CalculateSkidDamage(mech, 1, HexDirection.Top, new DiceResult(1), HitDirection.Front);
 
         result.HitLocations.TotalDamage.ShouldBe(1);
     }

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Actions/ApplySkidActionTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Actions/ApplySkidActionTests.cs
@@ -1,0 +1,218 @@
+using NSubstitute;
+using Sanet.MakaMek.Core.Data.Game;
+using Sanet.MakaMek.Core.Data.Game.Commands.Server;
+using Sanet.MakaMek.Core.Data.Game.Mechanics;
+using Sanet.MakaMek.Core.Models.Game.Dice;
+using Sanet.MakaMek.Core.Models.Game.Mechanics.Movement.Actions;
+using Sanet.MakaMek.Core.Models.Units;
+using Sanet.MakaMek.Core.Models.Game.Rules;
+using Sanet.MakaMek.Core.Models.Units.Mechs;
+using Sanet.MakaMek.Core.Tests.Models.Game.Phases;
+using Sanet.MakaMek.Core.Utils;
+using Sanet.MakaMek.Core.Tests.Utils;
+using Sanet.MakaMek.Localization;
+using Sanet.MakaMek.Map.Models;
+using Shouldly;
+
+namespace Sanet.MakaMek.Core.Tests.Models.Game.Mechanics.Movement.Actions;
+
+public class ApplySkidActionTests : GamePhaseTestsBase
+{
+    private readonly Mech _mech;
+    private readonly Guid _unitId = Guid.NewGuid();
+
+    protected override void SetupSut()
+    {
+    }
+
+    public ApplySkidActionTests()
+    {
+        var mechFactory = new MechFactory(
+            new TotalWarfareRulesProvider(),
+            new ClassicBattletechComponentProvider(),
+            Substitute.For<ILocalizationService>());
+        var mechData = MechFactoryTests.CreateDummyMechData() with { Id = _unitId };
+        _mech = mechFactory.Create(mechData);
+    }
+
+    [Fact]
+    public void Process_ShouldReturnCommandWithSkidCommand()
+    {
+        var command = new MechSkidCommand
+        {
+            UnitId = _unitId,
+            SkidDistance = 2,
+            DamageData = null,
+            GameOriginId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow
+        };
+        var sut = new ApplySkidAction(_mech, command);
+
+        var result = sut.Process(Game);
+
+        result.ShouldNotBeNull();
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(command);
+    }
+
+    [Fact]
+    public void Process_WhenNoDamageData_ShouldNotCalculateCriticalHits()
+    {
+        var command = new MechSkidCommand
+        {
+            UnitId = _unitId,
+            SkidDistance = 1,
+            DamageData = null,
+            GameOriginId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow
+        };
+        var sut = new ApplySkidAction(_mech, command);
+
+        var result = sut.Process(Game);
+
+        MockCriticalHitsCalculator.DidNotReceive().CalculateAndApplyCriticalHits(Arg.Any<IUnit>(), Arg.Any<List<LocationDamageData>>());
+        result.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Process_WhenDamageDataWithoutStructureDamage_ShouldNotCalculateCriticalHits()
+    {
+        var damageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData(
+                [new LocationHitData(
+                    [new LocationDamageData(PartLocation.CenterTorso, 5, 0, false)],
+                    [],
+                    [],
+                    PartLocation.CenterTorso)],
+                5),
+            new DiceResult(3),
+            HitDirection.Front);
+        var command = new MechSkidCommand
+        {
+            UnitId = _unitId,
+            SkidDistance = 1,
+            DamageData = damageData,
+            GameOriginId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow
+        };
+        var sut = new ApplySkidAction(_mech, command);
+
+        var result = sut.Process(Game);
+
+        MockCriticalHitsCalculator.DidNotReceive().CalculateAndApplyCriticalHits(Arg.Any<IUnit>(), Arg.Any<List<LocationDamageData>>());
+        result.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Process_WhenStructureDamageExistsAndCritCalculatorReturnsCommand_ShouldAddCritCommand()
+    {
+        var damageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData(
+                [new LocationHitData(
+                    [new LocationDamageData(PartLocation.CenterTorso, 0, 3, false)],
+                    [],
+                    [],
+                    PartLocation.CenterTorso)],
+                3),
+            new DiceResult(4),
+            HitDirection.Front);
+        var command = new MechSkidCommand
+        {
+            UnitId = _unitId,
+            SkidDistance = 1,
+            DamageData = damageData,
+            GameOriginId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow
+        };
+        var critCommand = new CriticalHitsResolutionCommand
+        {
+            GameOriginId = Guid.NewGuid(),
+            TargetId = _unitId,
+            CriticalHits = []
+        };
+        MockCriticalHitsCalculator.CalculateAndApplyCriticalHits(_mech, Arg.Any<List<LocationDamageData>>())
+            .Returns(critCommand);
+        var sut = new ApplySkidAction(_mech, command);
+
+        var result = sut.Process(Game);
+
+        result.Count.ShouldBe(2);
+        result[0].ShouldBe(command);
+        result[1].ShouldBe(critCommand);
+        critCommand.GameOriginId.ShouldBe(Game.Id);
+    }
+
+    [Fact]
+    public void Process_WhenStructureDamageExistsAndCritCalculatorReturnsNull_ShouldNotAddCritCommand()
+    {
+        var damageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData(
+                [new LocationHitData(
+                    [new LocationDamageData(PartLocation.CenterTorso, 0, 3, false)],
+                    [],
+                    [],
+                    PartLocation.CenterTorso)],
+                3),
+            new DiceResult(5),
+            HitDirection.Front);
+        var command = new MechSkidCommand
+        {
+            UnitId = _unitId,
+            SkidDistance = 1,
+            DamageData = damageData,
+            GameOriginId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow
+        };
+        MockCriticalHitsCalculator.CalculateAndApplyCriticalHits(_mech, Arg.Any<List<LocationDamageData>>())
+            .Returns((CriticalHitsResolutionCommand?)null);
+        var sut = new ApplySkidAction(_mech, command);
+
+        var result = sut.Process(Game);
+
+        result.Count.ShouldBe(1);
+        result[0].ShouldBe(command);
+    }
+
+    [Fact]
+    public void Process_WithMultipleLocationsHavingStructureDamage_ShouldPassAllToCritCalculator()
+    {
+        var damageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData(
+            [
+                new LocationHitData(
+                    [new LocationDamageData(PartLocation.CenterTorso, 0, 3, false)],
+                    [],
+                    [],
+                    PartLocation.CenterTorso),
+                new LocationHitData(
+                    [new LocationDamageData(PartLocation.LeftTorso, 0, 2, false)],
+                    [],
+                    [],
+                    PartLocation.LeftTorso)
+            ],
+                5),
+            new DiceResult(6),
+            HitDirection.Front);
+        var command = new MechSkidCommand
+        {
+            UnitId = _unitId,
+            SkidDistance = 2,
+            DamageData = damageData,
+            GameOriginId = Guid.NewGuid(),
+            Timestamp = DateTime.UtcNow
+        };
+        MockCriticalHitsCalculator.CalculateAndApplyCriticalHits(_mech, Arg.Any<List<LocationDamageData>>())
+            .Returns((CriticalHitsResolutionCommand?)null);
+        var sut = new ApplySkidAction(_mech, command);
+
+        sut.Process(Game);
+
+        MockCriticalHitsCalculator.Received(1).CalculateAndApplyCriticalHits(
+            _mech,
+            Arg.Is<List<LocationDamageData>>(l => l.Count == 2));
+    }
+}

--- a/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandlerTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Mechanics/Movement/Interrupters/SkidInterruptHandlerTests.cs
@@ -153,6 +153,59 @@ public class SkidInterruptHandlerTests : GamePhaseTestsBase
     }
 
     [Fact]
+    public void SkidInterruptHandler_Check_WhenSkidFailsWithSkidDamage_ReturnsStopWithFallAndSkidAction()
+    {
+        var mech = Game.Players[0].Units[0] as Mech;
+        mech!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+        Game.BattleMap!.GetHex(new HexCoordinates(3, 2))!.AddTerrain(new RoadTerrain());
+
+        var fallContext = new FallContextData
+        {
+            UnitId = mech.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new SkidCheckRollContext(1, 3),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3),
+                HitDirection.Front),
+            SkidDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 3),
+                new DiceResult(2),
+                HitDirection.Front),
+            SkidDistance = 1
+        };
+        MockFallProcessor.ProcessMovementAttempt(
+            mech,
+            Arg.Is<SkidCheckRollContext>(ctx => ctx.SkidDistance == 1 && ctx.HexesMoved == 2),
+            Game,
+            MovementType.Run)
+            .Returns(fallContext);
+
+        var moveCommand = CreateMoveCommand(_unitId, MovementType.Run,
+            new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), []),
+            new PathSegment(new HexPosition(2, 2, HexDirection.Top), new HexPosition(3, 2, HexDirection.Top), []),
+            new PathSegment(new HexPosition(3, 2, HexDirection.Top), new HexPosition(3, 2, HexDirection.Bottom), []),
+            new PathSegment(new HexPosition(3, 2, HexDirection.Bottom), new HexPosition(4, 2, HexDirection.Bottom), []));
+
+        var result = _sut.Check(CreateContext(moveCommand with { PlayerId = Game.Players[0].Id }, 2));
+
+        result.ShouldNotBeNull();
+        result.ShouldStop.ShouldBeTrue();
+        result.GameActions.ShouldContain(a => a is MoveUnitAction);
+        result.GameActions.ShouldContain(a => a is ApplyFallAction);
+        result.GameActions.ShouldContain(a => a is ApplySkidAction);
+    }
+
+    [Fact]
     public void SkidInterruptHandler_Check_WhenRunTurnOnNonRoad_ReturnsNull()
     {
         var mech = Game.Players[0].Units[0] as Mech;

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -1616,6 +1616,69 @@ public class MovementPhaseTests : GamePhaseTestsBase
     }
 
     [Fact]
+    public void ProcessMoveCommand_WhenSkidFall_AndCanStandup_ShouldNotDeferStep()
+    {
+        SetMap();
+        _sut.Enter();
+        MockConsciousnessCalculator.MakeConsciousnessRolls(Arg.Any<IPilot>()).Returns([]);
+
+        var unit = Game.PhaseStepState!.Value.ActivePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+
+        var roadHex = Game.BattleMap!.GetHex(new HexCoordinates(2, 2));
+        roadHex!.AddTerrain(new RoadTerrain());
+
+        var moveCommand = new MoveUnitCommand
+        {
+            MovementType = MovementType.Run,
+            GameOriginId = Game.Id,
+            PlayerId = Game.PhaseStepState!.Value.ActivePlayer.Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top), [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 1 }]).ToData(),
+                new PathSegment(new HexPosition(2, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Bottom), [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 0 }]).ToData(),
+                new PathSegment(new HexPosition(2, 2, HexDirection.Bottom), new HexPosition(3, 2, HexDirection.Bottom), [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 1 }]).ToData()
+            ]
+        };
+
+        var fallContextData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new SkidCheckRollContext(1, 3),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front
+            )
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(unit, Arg.Is<SkidCheckRollContext>(c => c.SkidDistance == 1 && c.HexesMoved == 1), Game, MovementType.Run).Returns(fallContextData);
+
+        CommandPublisher.ClearReceivedCalls();
+
+        // Act
+        _sut.HandleCommand(moveCommand);
+
+        // Assert - ApplySkidAction forces deferAfterFall = false (lines 201-202),
+        // so turn is finalized even though Mech can stand up
+        unit.HasMoved.ShouldBeTrue();
+        unit.Position!.Coordinates.ShouldBe(new HexCoordinates(2, 1));
+        CommandPublisher.Received().PublishCommand(Arg.Is<MoveUnitCommand>(cmd =>
+            cmd.UnitId == _unit1Id && cmd.IsCompleted && cmd.MovementPath.Count == 3));
+        CommandPublisher.Received().PublishCommand(Arg.Is<MechFallCommand>(cmd => cmd.UnitId == _unit1Id));
+        CommandPublisher.Received().PublishCommand(Arg.Any<ChangeActivePlayerCommand>());
+    }
+
+    [Fact]
     public void ProcessMoveCommand_WhenRunSkidOnRoadPasses_ShouldPublishPsrResult()
     {
         SetMap();

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -2091,6 +2091,29 @@ public class MechTests
     }
 
     [Fact]
+    public void CanStandup_ShouldReturnFalse_WhenSkidding()
+    {
+        // Arrange
+        var parts = CreateBasicPartsData();
+        var sut = new Mech("Test", "TST-1A", 50, parts);
+        sut.AssignPilot(new MechWarrior("John", "Doe"));
+        sut.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        sut.Move(new MovementPath([
+            new PathSegment(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top),
+                new HexPosition(new HexCoordinates(2, 1), HexDirection.Top),
+                [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 1 }],
+                Events: [new SegmentEvent(SegmentEventType.Skid)])],
+            MovementType.Walk), null, isCompleted: false);
+        sut.SetProne();
+
+        // Act
+        var canStandup = sut.CanStandup();
+
+        // Assert
+        canStandup.ShouldBeFalse("Mech should not be able to stand up after skidding");
+    }
+
+    [Fact]
     public void CanChangeFacingWhileProne_WhenMechIsNotProne_ShouldReturnFalse()
     {
         // Arrange

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1,5 +1,7 @@
 using NSubstitute;
 using Sanet.MakaMek.Core.Data.Game;
+using Sanet.MakaMek.Core.Data.Game.Commands.Server;
+using Sanet.MakaMek.Core.Data.Game.Mechanics;
 using Sanet.MakaMek.Core.Data.Units;
 using Sanet.MakaMek.Core.Data.Units.Components;
 using Sanet.MakaMek.Core.Events;
@@ -3165,11 +3167,121 @@ public class MechTests
          mech.MaxLevelChangeForward.ShouldBe(2);
      }
 
-     [Fact]
-     public void MaxLevelChangeBackward_ReturnsZero()
-     {
-         var mech = new Mech("Test", "Mech", 50, CreateBasicPartsData());
+    [Fact]
+    public void MaxLevelChangeBackward_ReturnsZero()
+    {
+        var mech = new Mech("Test", "Mech", 50, CreateBasicPartsData());
 
-         mech.MaxLevelChangeBackward.ShouldBe(0);
-     }
+        mech.MaxLevelChangeBackward.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ApplySkid_ShouldNotApplyDamage_WhenDamageDataIsNull()
+    {
+        var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        sut.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        var initialArmor = sut.Parts[PartLocation.LeftArm].CurrentArmor;
+
+        var command = new MechSkidCommand
+        {
+            UnitId = Guid.NewGuid(),
+            SkidDistance = 1,
+            DamageData = null,
+            GameOriginId = Guid.NewGuid()
+        };
+
+        sut.ApplySkid(command);
+
+        sut.Parts[PartLocation.LeftArm].CurrentArmor.ShouldBe(initialArmor);
+    }
+
+    [Fact]
+    public void ApplySkid_ShouldApplyDamage_WhenDamageDataHasValidHitLocations()
+    {
+        var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        sut.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        var initialArmor = sut.Parts[PartLocation.LeftArm].CurrentArmor;
+
+        var hitData = new LocationHitData(
+            [new LocationDamageData(PartLocation.LeftArm, 5, 0, false)],
+            [],
+            [],
+            PartLocation.LeftArm);
+        var damageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData([hitData], 5),
+            new DiceResult(3),
+            HitDirection.Front);
+        var command = new MechSkidCommand
+        {
+            UnitId = Guid.NewGuid(),
+            SkidDistance = 1,
+            DamageData = damageData,
+            GameOriginId = Guid.NewGuid()
+        };
+
+        sut.ApplySkid(command);
+
+        sut.Parts[PartLocation.LeftArm].CurrentArmor.ShouldBe(initialArmor - 5);
+    }
+
+    [Fact]
+    public void ApplySkid_ShouldNotSetProne()
+    {
+        var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        sut.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+
+        var hitData = new LocationHitData(
+            [new LocationDamageData(PartLocation.LeftArm, 0, 1, false)],
+            [],
+            [],
+            PartLocation.LeftArm);
+        var damageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData([hitData], 1),
+            new DiceResult(3),
+            HitDirection.Front);
+        var command = new MechSkidCommand
+        {
+            UnitId = Guid.NewGuid(),
+            SkidDistance = 1,
+            DamageData = damageData,
+            GameOriginId = Guid.NewGuid()
+        };
+
+        sut.ApplySkid(command);
+
+        sut.IsProne.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ApplySkid_ShouldNotDamagePilot()
+    {
+        var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        sut.AssignPilot(new MechWarrior("John", "Doe"));
+        sut.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+
+        var hitData = new LocationHitData(
+            [new LocationDamageData(PartLocation.LeftArm, 0, 1, false)],
+            [],
+            [],
+            PartLocation.LeftArm);
+        var damageData = new FallingDamageData(
+            HexDirection.Top,
+            new HitLocationsData([hitData], 1),
+            new DiceResult(3),
+            HitDirection.Front);
+        var command = new MechSkidCommand
+        {
+            UnitId = Guid.NewGuid(),
+            SkidDistance = 1,
+            DamageData = damageData,
+            GameOriginId = Guid.NewGuid()
+        };
+
+        sut.ApplySkid(command);
+
+        sut.Pilot.ShouldNotBeNull();
+        sut.Pilot.Injuries.ShouldBe(0);
+    }
 }

--- a/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
@@ -183,6 +183,7 @@ public class FakeLocalizationServiceTests
     [InlineData("PilotingSkillRollType_WaterEntry", "Water Entry")]
     [InlineData("PilotingSkillRollType_SkidCheck", "Skid Check")]
     [InlineData("PilotingSkillRollType_SkidCheck_WithHexes", "{0} ({1} hexes)")]
+    [InlineData("Command_MechSkid_Base", "{0} skidded {1} hexes (skid damage)")]
     [InlineData("PilotingSkillRollType_BridgeCollapse", "Bridge Collapse")]
     [InlineData("PilotingSkillRollType_BridgeCollapse_WithHeight", "{0} (Height: {1})")]
     [InlineData("PilotingSkillRollType_WaterEntry_WithDepth", "{0} (Depth {1})")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes
* **Bug Fixes**
  * Mechs can’t stand up while skidding.
  * Movement resolution now correctly handles skid outcomes (including fall + skid actions) without deferring step consumption incorrectly.
* **New Features**
  * Added skid commands and skid mechanics, including applying skid damage and triggering critical-hit resolution when structure damage occurs.
  * Skid/fall output is improved with localized “Hit Locations” details when available.
* **Chores**
  * Updated version to 0.59.43.
* **Tests**
  * Added/updated coverage for skid commands, skid damage rendering, fall context conversions, and skid-related movement/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->