### PR TITLE
do not connect roads over unpassable level change

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.60.4</VersionPrefix>
+        <VersionPrefix>0.60.5</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/BattleMapView.axaml.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/BattleMapView.axaml.cs
@@ -66,7 +66,7 @@ public partial class BattleMapView : BaseView<BattleMapViewModel>
             CanonicalBitmaskResult? roadBitmask = null;
             if (bitmaskService != null && game.BattleMap != null && (hex.HasTerrain(MakaMekTerrains.Road) || hex.HasTerrain(MakaMekTerrains.Bridge)))
             {
-                var rawRoad = bitmaskService.ComputeRawBitmask(game.BattleMap, hex.Coordinates, MakaMekTerrains.Road);
+                var rawRoad = bitmaskService.ComputeRawBitmask(game.BattleMap, hex.Coordinates, MakaMekTerrains.Road, (current, neighbor) => current.CanRoadConnectTo(neighbor));
                 var rawBridge = bitmaskService.ComputeRawBitmask(game.BattleMap, hex.Coordinates, MakaMekTerrains.Bridge);
                 roadBitmask = bitmaskService.CanonicalizeRawMask((byte)(rawRoad | rawBridge));
             }

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/BattleMapView.axaml.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/BattleMapView.axaml.cs
@@ -67,7 +67,7 @@ public partial class BattleMapView : BaseView<BattleMapViewModel>
             if (bitmaskService != null && game.BattleMap != null && (hex.HasTerrain(MakaMekTerrains.Road) || hex.HasTerrain(MakaMekTerrains.Bridge)))
             {
                 var rawRoad = bitmaskService.ComputeRawBitmask(game.BattleMap, hex.Coordinates, MakaMekTerrains.Road, (current, neighbor) => current.CanRoadConnectTo(neighbor));
-                var rawBridge = bitmaskService.ComputeRawBitmask(game.BattleMap, hex.Coordinates, MakaMekTerrains.Bridge);
+                var rawBridge = bitmaskService.ComputeRawBitmask(game.BattleMap, hex.Coordinates, MakaMekTerrains.Bridge, (current, neighbor) => current.CanRoadConnectTo(neighbor));
                 roadBitmask = bitmaskService.CanonicalizeRawMask((byte)(rawRoad | rawBridge));
             }
 

--- a/src/MakaMek.Map/Generators/MapGeneratorBuilder.cs
+++ b/src/MakaMek.Map/Generators/MapGeneratorBuilder.cs
@@ -162,7 +162,8 @@ public class MapGeneratorBuilder
                 waterHexes = (_lakePatches?.Keys ?? Enumerable.Empty<HexCoordinates>())
                     .Concat(_riverPatches?.Keys ?? Enumerable.Empty<HexCoordinates>())
                     .ToHashSet();
-                var generator = new RoadPathGenerator(_width, _height, rng, waterHexes);
+                var generator = new RoadPathGenerator(_width, _height, rng, waterHexes,
+                    coords => _levelProvider?.GetLevel(coords) ?? 0);
                 var roads = generator.GenerateRoads(roadCount);
                 _roadPatches = roads;
                 return roads;

--- a/src/MakaMek.Map/Generators/MapGeneratorBuilder.cs
+++ b/src/MakaMek.Map/Generators/MapGeneratorBuilder.cs
@@ -143,9 +143,10 @@ public class MapGeneratorBuilder
     /// map edge. Where a road hex coincides with water (a lake or river hex produced
     /// by an earlier overlay) a <see cref="BridgeTerrain"/> is placed instead of a
     /// plain <see cref="RoadTerrain"/>, modelling a bridge spanning the water.
-    /// Must be called after <see cref="WithLakes"/> and <see cref="WithRivers"/> if
-    /// bridges over those water bodies are desired, so the last-overlay-wins pattern
-    /// lets roads/bridges override the underlying water.
+    /// When <see cref="WithHills"/> is enabled, roads also avoid crossing elevation
+    /// changes greater than one level. Must be called after <see cref="WithLakes"/>
+    /// and <see cref="WithRivers"/> if bridges over those water bodies are desired,
+    /// so the last-overlay-wins pattern lets roads/bridges override the underlying water.
     /// </summary>
     /// <param name="roadCount">Number of roads to generate.</param>
     public MapGeneratorBuilder WithRoads(int roadCount)

--- a/src/MakaMek.Map/Generators/RoadPathGenerator.cs
+++ b/src/MakaMek.Map/Generators/RoadPathGenerator.cs
@@ -7,6 +7,7 @@ namespace Sanet.MakaMek.Map.Generators;
 /// Unlike rivers (which follow a single meandering path), roads branch: at every
 /// hex each of the six directions is rolled independently against a probability
 /// that favors continuing straight, producing organic forks and junctions.
+/// Roads cannot cross elevation changes greater than 1 level.
 /// </summary>
 public class RoadPathGenerator
 {
@@ -19,12 +20,14 @@ public class RoadPathGenerator
     private readonly Random _random;
     private readonly HashSet<HexCoordinates> _existingRoadHexes = [];
     private readonly HashSet<HexCoordinates>? _existingWaterHexes;
+    private readonly Func<HexCoordinates, int>? _levelLookup;
 
     public RoadPathGenerator(
         int width,
         int height,
         Random? random = null,
-        HashSet<HexCoordinates>? existingWaterHexes = null)
+        HashSet<HexCoordinates>? existingWaterHexes = null,
+        Func<HexCoordinates, int>? levelLookup = null)
     {
         if (width < 1)
             throw new ArgumentOutOfRangeException(nameof(width), "Width must be at least 1.");
@@ -35,6 +38,7 @@ public class RoadPathGenerator
         _height = height;
         _random = random ?? new Random();
         _existingWaterHexes = existingWaterHexes;
+        _levelLookup = levelLookup;
     }
 
     public Dictionary<HexCoordinates, int> GenerateRoads(int roadCount)
@@ -79,6 +83,9 @@ public class RoadPathGenerator
                     continue;
 
                 if (road.Contains(targetHex) || _existingRoadHexes.Contains(targetHex))
+                    continue;
+
+                if (_levelLookup != null && Math.Abs(_levelLookup(targetHex) - _levelLookup(hex)) > 1)
                     continue;
 
                 var probability = GetProbabilityForDirection(candidate, straightDirection);

--- a/src/MakaMek.Map/Generators/RoadPathGenerator.cs
+++ b/src/MakaMek.Map/Generators/RoadPathGenerator.cs
@@ -14,6 +14,7 @@ public class RoadPathGenerator
     private const int StraightProbability = 85;
     private const int AdjacentProbability = 10;
     private const int OtherProbability = 5;
+    private const int MaxPassableLevelDifference = 1;
 
     private readonly int _width;
     private readonly int _height;
@@ -73,6 +74,7 @@ public class RoadPathGenerator
         while (queue.Count > 0)
         {
             var (hex, straightDirection) = queue.Dequeue();
+            var hexLevel = _levelLookup?.Invoke(hex);
 
             foreach (var candidate in HexDirectionExtensions.AllDirections)
             {
@@ -85,7 +87,7 @@ public class RoadPathGenerator
                 if (road.Contains(targetHex) || _existingRoadHexes.Contains(targetHex))
                     continue;
 
-                if (_levelLookup != null && Math.Abs(_levelLookup(targetHex) - _levelLookup(hex)) > 1)
+                if (hexLevel != null && Math.Abs(_levelLookup!(targetHex) - hexLevel.Value) > MaxPassableLevelDifference)
                     continue;
 
                 var probability = GetProbabilityForDirection(candidate, straightDirection);

--- a/src/MakaMek.Map/Models/HexExtensions.cs
+++ b/src/MakaMek.Map/Models/HexExtensions.cs
@@ -100,6 +100,23 @@ public static class HexExtensions
             return hex.GetTerrain(MakaMekTerrains.Bridge);
         }
 
+        public int? GetRoadSurfaceLevel()
+        {
+            var roadTerrain = hex.GetRoadOrPavedTerrain();
+            if (roadTerrain == null) return null;
+            return roadTerrain.Id == MakaMekTerrains.Bridge
+                ? hex.GetStandingLevel(HexSurface.Bridge)
+                : hex.GetStandingLevel(HexSurface.Ground);
+        }
+
+        public bool CanRoadConnectTo(Hex neighbor)
+        {
+            var myLevel = hex.GetRoadSurfaceLevel();
+            var neighborLevel = neighbor.GetRoadSurfaceLevel();
+            if (myLevel == null || neighborLevel == null) return false;
+            return Math.Abs(myLevel.Value - neighborLevel.Value) < 2;
+        }
+
         public bool IsOnRoadOrBridge(Hex fromHex, HexSurface fromSurface, HexSurface toSurface)
         {
             var toTerrain = hex.GetRoadOrPavedTerrain();

--- a/src/MakaMek.Map/Services/ITerrainBitmaskService.cs
+++ b/src/MakaMek.Map/Services/ITerrainBitmaskService.cs
@@ -16,13 +16,21 @@ public interface ITerrainBitmaskService
     /// Bit N is set when the neighbor in direction N has the terrain.
     /// Out-of-bounds neighbors are treated as not having the terrain.
     /// </summary>
-    byte ComputeRawBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType);
+    /// <param name="neighborFilter">
+    /// Optional predicate evaluated against (currentHex, neighborHex).
+    /// When non-null, a direction bit is only set if the filter returns true.
+    /// </param>
+    byte ComputeRawBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType, Func<Hex, Hex, bool>? neighborFilter = null);
 
     /// <summary>
     /// Computes the raw bitmask and then canonicalizes it by rotating across all
     /// 6 possible 60° orientations, selecting the lowest numeric value.
     /// </summary>
-    CanonicalBitmaskResult ComputeCanonicalBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType);
+    /// <param name="neighborFilter">
+    /// Optional predicate evaluated against (currentHex, neighborHex).
+    /// When non-null, a direction bit is only set if the filter returns true.
+    /// </param>
+    CanonicalBitmaskResult ComputeCanonicalBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType, Func<Hex, Hex, bool>? neighborFilter = null);
 
     /// <summary>
     /// Canonicalizes a precomputed 6-bit raw bitmask by rotating across all 6 possible 60° orientations,

--- a/src/MakaMek.Map/Services/TerrainBitmaskService.cs
+++ b/src/MakaMek.Map/Services/TerrainBitmaskService.cs
@@ -9,16 +9,18 @@ namespace Sanet.MakaMek.Map.Services;
 public class TerrainBitmaskService : ITerrainBitmaskService
 {
     /// <inheritdoc />
-    public byte ComputeRawBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType)
+    public byte ComputeRawBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType, Func<Hex, Hex, bool>? neighborFilter = null)
     {
         byte mask = 0;
         var directions = HexDirectionExtensions.AllDirections;
+        var currentHex = map.GetHex(coordinates);
 
         for (var i = 0; i < directions.Length; i++)
         {
             var neighborCoords = coordinates.GetNeighbour(directions[i]);
             var neighborHex = map.GetHex(neighborCoords);
-            if (neighborHex != null && neighborHex.HasTerrain(terrainType))
+            if (neighborHex != null && neighborHex.HasTerrain(terrainType)
+                                     && (neighborFilter == null || (currentHex != null && neighborFilter(currentHex, neighborHex))))
             {
                 mask |= (byte)(1 << i);
             }
@@ -28,9 +30,9 @@ public class TerrainBitmaskService : ITerrainBitmaskService
     }
 
     /// <inheritdoc />
-    public CanonicalBitmaskResult ComputeCanonicalBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType)
+    public CanonicalBitmaskResult ComputeCanonicalBitmask(IBattleMap map, HexCoordinates coordinates, MakaMekTerrains terrainType, Func<Hex, Hex, bool>? neighborFilter = null)
     {
-        var raw = ComputeRawBitmask(map, coordinates, terrainType);
+        var raw = ComputeRawBitmask(map, coordinates, terrainType, neighborFilter);
         return Canonicalize(raw);
     }
 

--- a/tests/MakaMek.Map.Tests/Generators/RoadPathGeneratorTests.cs
+++ b/tests/MakaMek.Map.Tests/Generators/RoadPathGeneratorTests.cs
@@ -199,4 +199,55 @@ public class RoadPathGeneratorTests
         var allHexes = roads.Keys.ToList();
         allHexes.Count.ShouldBe(allHexes.Distinct().Count());
     }
+
+    [Fact]
+    public void RoadsRespectElevationConstraint_WithinSingleNetwork()
+    {
+        const int mapWidth = 10;
+        const int mapHeight = 10;
+
+        // Flat on the left (level 0), elevated plateau on the right (level 3).
+        // The steep step between col 5 and 6 creates a diff of 3 (> 1).
+        // A single road network should never cross such a steep boundary.
+        int LevelLookup(HexCoordinates coords) => coords.Q <= mapWidth / 2 ? 0 : 3;
+
+        var generator = new RoadPathGenerator(mapWidth, mapHeight, new Random(42), null, LevelLookup);
+        var roads = generator.GenerateRoads(1);
+
+        foreach (var hex in roads.Keys)
+        {
+            var hexLevel = LevelLookup(hex);
+            foreach (var neighbor in hex.GetAllNeighbours())
+            {
+                if (!roads.ContainsKey(neighbor)) continue;
+                var diff = Math.Abs(hexLevel - LevelLookup(neighbor));
+                diff.ShouldBeLessThanOrEqualTo(1,
+                    $"Road hex {hex} (level {hexLevel}) and neighbor {neighbor} " +
+                    $"(level {LevelLookup(neighbor)}) have elevation difference {diff} > 1");
+            }
+        }
+    }
+
+    [Fact]
+    public void SingleRoad_StaysOnOneSideOfSteepSlope()
+    {
+        const int mapWidth = 10;
+        const int mapHeight = 10;
+
+        // Level 0 on left (Q <= 5), level 3 on right (Q >= 6).
+        // With the elevation constraint the road cannot cross the boundary.
+        int LevelLookup(HexCoordinates coords) => coords.Q <= mapWidth / 2 ? 0 : 3;
+
+        var generator = new RoadPathGenerator(mapWidth, mapHeight, new Random(42), null, LevelLookup);
+        var roads = generator.GenerateRoads(1);
+
+        var leftSide = roads.Keys.Where(c => LevelLookup(c) == 0).ToList();
+        var rightSide = roads.Keys.Where(c => LevelLookup(c) == 3).ToList();
+
+        // The starting edge hex determines which side the road occupies,
+        // but it must remain entirely on one side of the steep slope.
+        (leftSide.Count == 0 || rightSide.Count == 0).ShouldBeTrue(
+            $"Road hexes found on both sides of the steep boundary: " +
+            $"{leftSide.Count} on left, {rightSide.Count} on right");
+    }
 }

--- a/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
+++ b/tests/MakaMek.Map.Tests/Models/HexExtensionsTests.cs
@@ -582,4 +582,177 @@ public class HexExtensionsTests
 
         result.ShouldBe(HexSurface.Ground);
     }
+
+    [Fact]
+    public void GetRoadSurfaceLevel_NoRoadTerrain_ReturnsNull()
+    {
+        var sut = new Hex(new HexCoordinates(1, 1));
+        sut.AddTerrain(new ClearTerrain());
+
+        var result = sut.GetRoadSurfaceLevel();
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void GetRoadSurfaceLevel_GroundRoad_ReturnsBottomLevel()
+    {
+        var sut = new Hex(new HexCoordinates(1, 1)) { Level = 3 };
+        sut.AddTerrain(new RoadTerrain());
+
+        var result = sut.GetRoadSurfaceLevel();
+
+        result.ShouldBe(3);
+    }
+
+    [Fact]
+    public void GetRoadSurfaceLevel_Pavement_ReturnsBottomLevel()
+    {
+        var sut = new Hex(new HexCoordinates(1, 1)) { Level = 2 };
+        sut.AddTerrain(new PavementTerrain());
+
+        var result = sut.GetRoadSurfaceLevel();
+
+        result.ShouldBe(2);
+    }
+
+    [Fact]
+    public void GetRoadSurfaceLevel_Bridge_ReturnsLevelPlusBridgeHeight()
+    {
+        var sut = new Hex(new HexCoordinates(1, 1)) { Level = 1 };
+        sut.AddTerrain(new BridgeTerrain(2, 0));
+
+        var result = sut.GetRoadSurfaceLevel();
+
+        result.ShouldBe(3);
+    }
+
+    [Fact]
+    public void GetRoadSurfaceLevel_BridgeOverWater_ReturnsBridgeSurfaceLevel()
+    {
+        var sut = new Hex(new HexCoordinates(1, 1)) { Level = 0 };
+        sut.AddTerrain(new BridgeTerrain(1, 0));
+        sut.AddTerrain(new WaterTerrain(-1));
+
+        var result = sut.GetRoadSurfaceLevel();
+
+        result.ShouldBe(1);
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_NoRoadOnEither_ReturnsFalse()
+    {
+        var current = new Hex(new HexCoordinates(1, 1));
+        current.AddTerrain(new ClearTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1));
+        neighbor.AddTerrain(new ClearTerrain());
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_NoRoadOnNeighbor_ReturnsFalse()
+    {
+        var current = new Hex(new HexCoordinates(1, 1)) { Level = 0 };
+        current.AddTerrain(new RoadTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1));
+        neighbor.AddTerrain(new ClearTerrain());
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_NoRoadOnCurrent_ReturnsFalse()
+    {
+        var current = new Hex(new HexCoordinates(1, 1));
+        current.AddTerrain(new ClearTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1)) { Level = 0 };
+        neighbor.AddTerrain(new RoadTerrain());
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_EqualLevelGroundRoads_ReturnsTrue()
+    {
+        var current = new Hex(new HexCoordinates(1, 1)) { Level = 2 };
+        current.AddTerrain(new RoadTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1)) { Level = 2 };
+        neighbor.AddTerrain(new RoadTerrain());
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_DifferenceOfOne_ReturnsTrue()
+    {
+        var current = new Hex(new HexCoordinates(1, 1)) { Level = 3 };
+        current.AddTerrain(new RoadTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1)) { Level = 2 };
+        neighbor.AddTerrain(new RoadTerrain());
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_DifferenceOfTwo_ReturnsFalse()
+    {
+        var current = new Hex(new HexCoordinates(1, 1)) { Level = 2 };
+        current.AddTerrain(new RoadTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1)) { Level = 0 };
+        neighbor.AddTerrain(new RoadTerrain());
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_RoadToBridgeWithHeightOne_ReturnsTrue()
+    {
+        var current = new Hex(new HexCoordinates(1, 1)) { Level = 2 };
+        current.AddTerrain(new RoadTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1)) { Level = 0 };
+        neighbor.AddTerrain(new BridgeTerrain(1, 0));
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_RoadToBridgeWithHeightZero_ReturnsFalseWhenDifferenceTooLarge()
+    {
+        var current = new Hex(new HexCoordinates(1, 1)) { Level = 2 };
+        current.AddTerrain(new RoadTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1)) { Level = 0 };
+        neighbor.AddTerrain(new BridgeTerrain(0, 0));
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void CanRoadConnectTo_PavementToPavementEqualLevel_ReturnsTrue()
+    {
+        var current = new Hex(new HexCoordinates(1, 1)) { Level = 1 };
+        current.AddTerrain(new PavementTerrain());
+        var neighbor = new Hex(new HexCoordinates(2, 1)) { Level = 1 };
+        neighbor.AddTerrain(new PavementTerrain());
+
+        var result = current.CanRoadConnectTo(neighbor);
+
+        result.ShouldBeTrue();
+    }
 }

--- a/tests/MakaMek.Map.Tests/Services/TerrainBitmaskServiceTests.cs
+++ b/tests/MakaMek.Map.Tests/Services/TerrainBitmaskServiceTests.cs
@@ -803,4 +803,28 @@ public class TerrainBitmaskServiceTests
     {
         Should.Throw<ArgumentOutOfRangeException>(() => _ = new CanonicalBitmaskResult(0, steps));
     }
+
+    [Fact]
+    public void ComputeRawBitmask_NullCurrentHexWithFilter_NoBitsSet()
+    {
+        var map = Substitute.For<IBattleMap>();
+        var centerCoords = new HexCoordinates(3, 3);
+
+        // currentHex is null (out of bounds or not found)
+        map.GetHex(centerCoords).Returns((Hex?)null);
+
+        // All neighbors have the matching terrain
+        foreach (var direction in HexDirectionExtensions.AllDirections)
+        {
+            var neighborCoords = centerCoords.GetNeighbour(direction);
+            var neighborHex = CreateHexWithTerrain(MakaMekTerrains.Road);
+            map.GetHex(neighborCoords).Returns(neighborHex);
+        }
+
+        Func<Hex, Hex, bool> filter = (current, neighbor) => true;
+
+        var result = _sut.ComputeRawBitmask(map, centerCoords, MakaMekTerrains.Road, filter);
+
+        result.ShouldBe((byte)0);
+    }
 }

--- a/tests/MakaMek.Map.Tests/Services/TerrainBitmaskServiceTests.cs
+++ b/tests/MakaMek.Map.Tests/Services/TerrainBitmaskServiceTests.cs
@@ -523,9 +523,10 @@ public class TerrainBitmaskServiceTests
         result.RotationSteps.ShouldBe(2);
     }
 
-    private static Hex CreateHexWithTerrain(MakaMekTerrains terrainType)
+    private static Hex CreateHexWithTerrain(MakaMekTerrains terrainType, int? level = null)
     {
         var hex = new Hex(new HexCoordinates(0, 0));
+        if (level.HasValue) hex.Level = level.Value;
         Terrain terrain = terrainType switch
         {
             MakaMekTerrains.Clear => new ClearTerrain(),
@@ -533,6 +534,7 @@ public class TerrainBitmaskServiceTests
             MakaMekTerrains.HeavyWoods => new HeavyWoodsTerrain(),
             MakaMekTerrains.Rough => new RoughTerrain(),
             MakaMekTerrains.Water => new WaterTerrain(),
+            MakaMekTerrains.Road => new RoadTerrain(),
             _ => throw new ArgumentOutOfRangeException(nameof(terrainType))
         };
 
@@ -637,6 +639,140 @@ public class TerrainBitmaskServiceTests
 
         result.CanonicalMask.ShouldBe((byte)0b000111);
         result.RotationSteps.ShouldBe(3);
+    }
+
+    [Fact]
+    public void ComputeRawBitmask_WithRoadFilter_ConnectedNeighbor_SetsBit()
+    {
+        // Arrange
+        var map = Substitute.For<IBattleMap>();
+        var centerCoords = new HexCoordinates(3, 3);
+        var directions = HexDirectionExtensions.AllDirections;
+
+        var centerHex = CreateHexWithTerrain(MakaMekTerrains.Road, level: 3);
+        map.GetHex(centerCoords).Returns(centerHex);
+
+        foreach (var direction in directions)
+        {
+            var neighborCoords = centerCoords.GetNeighbour(direction);
+            var neighborHex = direction == HexDirection.Top
+                ? CreateHexWithTerrain(MakaMekTerrains.Road, level: 3)
+                : CreateHexWithTerrain(MakaMekTerrains.Clear);
+            map.GetHex(neighborCoords).Returns(neighborHex);
+        }
+
+        Func<Hex, Hex, bool> filter = (current, neighbor) => current.CanRoadConnectTo(neighbor);
+
+        // Act
+        var result = _sut.ComputeRawBitmask(map, centerCoords, MakaMekTerrains.Road, filter);
+
+        // Assert
+        result.ShouldBe((byte)0b000001);
+    }
+
+    [Fact]
+    public void ComputeRawBitmask_WithRoadFilter_LevelDifferenceTooLarge_DoesNotSetBit()
+    {
+        // Arrange
+        var map = Substitute.For<IBattleMap>();
+        var centerCoords = new HexCoordinates(3, 3);
+        var directions = HexDirectionExtensions.AllDirections;
+
+        var centerHex = CreateHexWithTerrain(MakaMekTerrains.Road, level: 2);
+        map.GetHex(centerCoords).Returns(centerHex);
+
+        foreach (var direction in directions)
+        {
+            var neighborCoords = centerCoords.GetNeighbour(direction);
+            var neighborHex = direction == HexDirection.Top
+                ? CreateHexWithTerrain(MakaMekTerrains.Road, level: 0)
+                : CreateHexWithTerrain(MakaMekTerrains.Clear);
+            map.GetHex(neighborCoords).Returns(neighborHex);
+        }
+
+        Func<Hex, Hex, bool> filter = (current, neighbor) => current.CanRoadConnectTo(neighbor);
+
+        // Act
+        var result = _sut.ComputeRawBitmask(map, centerCoords, MakaMekTerrains.Road, filter);
+
+        // Assert
+        result.ShouldBe((byte)0);
+    }
+
+    [Fact]
+    public void ComputeCanonicalBitmask_WithRoadFilter_ConnectedNeighbor_CanonicalizesCorrectly()
+    {
+        // Arrange
+        var map = Substitute.For<IBattleMap>();
+        var centerCoords = new HexCoordinates(3, 3);
+        var directions = HexDirectionExtensions.AllDirections;
+
+        var centerHex = CreateHexWithTerrain(MakaMekTerrains.Road, level: 1);
+        map.GetHex(centerCoords).Returns(centerHex);
+
+        foreach (var direction in directions)
+        {
+            var neighborCoords = centerCoords.GetNeighbour(direction);
+            var neighborHex = direction == HexDirection.Top
+                ? CreateHexWithTerrain(MakaMekTerrains.Road, level: 1)
+                : CreateHexWithTerrain(MakaMekTerrains.Clear);
+            map.GetHex(neighborCoords).Returns(neighborHex);
+        }
+
+        Func<Hex, Hex, bool> filter = (current, neighbor) => current.CanRoadConnectTo(neighbor);
+
+        // Act
+        var result = _sut.ComputeCanonicalBitmask(map, centerCoords, MakaMekTerrains.Road, filter);
+
+        // Assert
+        result.CanonicalMask.ShouldBe((byte)0b000001);
+        result.RotationSteps.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ComputeRawBitmask_NonRoadTerrain_NullFilter_BehavesSameAsNoFilter()
+    {
+        var map = Substitute.For<IBattleMap>();
+        var centerCoords = new HexCoordinates(3, 3);
+        var directions = HexDirectionExtensions.AllDirections;
+
+        var centerHex = CreateHexWithTerrain(MakaMekTerrains.Water);
+        map.GetHex(centerCoords).Returns(centerHex);
+
+        SetupNeighborsByBitmask(map, centerCoords, directions, MakaMekTerrains.Water);
+
+        var result = _sut.ComputeRawBitmask(map, centerCoords, MakaMekTerrains.Water, null);
+
+        result.ShouldBe((byte)0b111111);
+    }
+
+    [Fact]
+    public void ComputeCanonicalBitmask_NonRoadTerrain_NullFilter_BehavesSameAsNoFilter()
+    {
+        var map = Substitute.For<IBattleMap>();
+        var centerCoords = new HexCoordinates(3, 3);
+        var directions = HexDirectionExtensions.AllDirections;
+
+        SetupNeighborsByBitmask(map, centerCoords, directions, MakaMekTerrains.Water);
+
+        var result = _sut.ComputeCanonicalBitmask(map, centerCoords, MakaMekTerrains.Water, null);
+
+        result.CanonicalMask.ShouldBe((byte)0b111111);
+        result.RotationSteps.ShouldBe(0);
+    }
+
+    [Fact]
+    public void ComputeRawBitmask_WithRoadFilter_DefaultParameter_DoesNotFilter()
+    {
+        var map = Substitute.For<IBattleMap>();
+        var centerCoords = new HexCoordinates(3, 3);
+        var directions = HexDirectionExtensions.AllDirections;
+
+        SetupNeighborsByBitmask(map, centerCoords, directions, MakaMekTerrains.Road);
+
+        var result = _sut.ComputeRawBitmask(map, centerCoords, MakaMekTerrains.Road);
+
+        result.ShouldBe((byte)0b111111);
     }
 
     [Theory]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Roads and bridges now use elevation-aware connection rules, preventing unrealistic transitions and improving how road/bridge surfaces join between adjacent hexes.
* **Bug Fixes**
  * Terrain bitmasking for road/bridge edges is now neighbor-aware, so connection indicators only appear when the adjacent road surfaces can actually connect.
  * Roads no longer span steep elevation changes beyond the allowed level difference.
* **Chores**
  * Updated the project version to **0.60.5**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->