### PR TITLE
Fix pilots name

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.61.11</VersionPrefix>
+        <VersionPrefix>0.61.12</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia.Controls/Styles/Panels.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia.Controls/Styles/Panels.axaml
@@ -50,20 +50,20 @@
     
     <!-- Compact Form Group -->
     <Style Selector="StackPanel.formGroupCompact">
-        <Setter Property="Spacing" Value="5"/>
-        <Setter Property="Margin" Value="0,0,0,8"/>
+        <Setter Property="Spacing" Value="2"/>
+        <Setter Property="Margin" Value="0,0,0,4"/>
     </Style>
     
     <!-- Horizontal Spacing -->
     <Style Selector="StackPanel.horizontalSpaced">
         <Setter Property="Orientation" Value="Horizontal"/>
-        <Setter Property="Spacing" Value="5"/>
+        <Setter Property="Spacing" Value="4"/>
     </Style>
     
     <!-- Vertical Spacing -->
     <Style Selector="StackPanel.verticalSpaced">
         <Setter Property="Orientation" Value="Vertical"/>
-        <Setter Property="Spacing" Value="5"/>
+        <Setter Property="Spacing" Value="4"/>
     </Style>
     
     <!-- Dialog Overlay -->

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml
@@ -10,7 +10,7 @@
              x:Name="UnitItemUserControl">
     <Border Classes="card"
             Padding="5"
-            Width="100"
+            Width="120"
             Height="150"
             Background="{StaticResource SurfaceBrush}">
         <Grid>
@@ -18,25 +18,25 @@
                 <!-- Header: Action buttons -->
                 <Grid ColumnDefinitions="*,Auto"
                       Margin="0,0,0,2">
-                    <!-- Edit button (visible when CanEditName is true) -->
+                    <!-- Edit button (visible when CanEditUnitName is true) -->
                     <Button
                         Grid.Column="0"
                         Command="{Binding #UnitItemUserControl.InfoCommand}"
                         CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
                         ToolTip.Tip="{extensions:Localize 'UnitItem_EditName'}"
                         Classes="cornerBadge"
-                        IsVisible="{Binding CanEditName}"
+                        IsVisible="{Binding #UnitItemUserControl.CanEditUnitName}"
                         HorizontalAlignment="Left">
                         <TextBlock Text="&#xf304;"/>
                     </Button>
-                    <!-- Info button (visible when CanEditName is false) -->
+                    <!-- Info button (visible when CanEditUnitName is false) -->
                     <Button
                         Grid.Column="0"
                         Command="{Binding #UnitItemUserControl.InfoCommand}"
                         CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
                         ToolTip.Tip="{extensions:Localize 'UnitItem_Info'}"
                         Classes="cornerBadge"
-                        IsVisible="{Binding !CanEditName}"
+                        IsVisible="{Binding !#UnitItemUserControl.CanEditUnitName}"
                         HorizontalAlignment="Left">
                         <PathIcon Data="{StaticResource RecordSheetIcon}"/>
                     </Button>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml
@@ -4,17 +4,54 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:wrappers="clr-namespace:Sanet.MakaMek.Presentation.ViewModels.Wrappers;assembly=Sanet.MakaMek.Presentation"
              xmlns:extensions="clr-namespace:Sanet.MakaMek.Avalonia.Controls.Extensions;assembly=Sanet.MakaMek.Avalonia.Controls"
-             mc:Ignorable="d" d:DesignWidth="120" d:DesignHeight="140"
+             mc:Ignorable="d" d:DesignWidth="120" d:DesignHeight="160"
              x:Class="Sanet.MakaMek.Avalonia.Controls.UnitItemControl"
              x:DataType="wrappers:UnitViewModel"
              x:Name="UnitItemUserControl">
     <Border Classes="card"
             Padding="5"
             Width="100"
-            Height="140"
+            Height="150"
             Background="{StaticResource SurfaceBrush}">
         <Grid>
-            <StackPanel Spacing="4">
+            <StackPanel Spacing="2">
+                <!-- Header: Action buttons -->
+                <Grid ColumnDefinitions="*,Auto"
+                      Margin="0,0,0,2">
+                    <!-- Edit button (visible when CanEditName is true) -->
+                    <Button
+                        Grid.Column="0"
+                        Command="{Binding #UnitItemUserControl.InfoCommand}"
+                        CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
+                        ToolTip.Tip="{extensions:Localize 'UnitItem_EditName'}"
+                        Classes="cornerBadge"
+                        IsVisible="{Binding CanEditName}"
+                        HorizontalAlignment="Left">
+                        <TextBlock Text="&#xf304;"/>
+                    </Button>
+                    <!-- Info button (visible when CanEditName is false) -->
+                    <Button
+                        Grid.Column="0"
+                        Command="{Binding #UnitItemUserControl.InfoCommand}"
+                        CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
+                        ToolTip.Tip="{extensions:Localize 'UnitItem_Info'}"
+                        Classes="cornerBadge"
+                        IsVisible="{Binding !CanEditName}"
+                        HorizontalAlignment="Left">
+                        <PathIcon Data="{StaticResource RecordSheetIcon}"/>
+                    </Button>
+                    <!-- Remove button -->
+                    <Button
+                        Grid.Column="1"
+                        Command="{Binding #UnitItemUserControl.RemoveCommand}"
+                        CommandParameter="{Binding #UnitItemUserControl.RemoveCommandParameter}"
+                        IsVisible="{Binding #UnitItemUserControl.IsRemoveButtonVisible}"
+                        ToolTip.Tip="{extensions:Localize 'UnitItem_RemoveUnit'}"
+                        Classes="cornerBadge">
+                        <TextBlock Text="&#xf2ed;"/>
+                    </Button>
+                </Grid>
+
                 <!-- Unit Image with Tint Overlay -->
                 <Panel Width="84" Height="84">
                     <Image x:Name="UnitImage"
@@ -36,39 +73,44 @@
                     </Panel.RenderTransform>
                 </Panel>
 
-                <!-- Display Name -->
-                <TextBlock Text="{Binding DisplayName}"
-                           Classes="bodySmall"
-                           Foreground="{StaticResource TextLightBrush}"
-                           TextAlignment="Center"
-                           TextWrapping="Wrap"
-                           MaxLines="2"
-                           HorizontalAlignment="Center"/>
+                <!-- 2x2 Grid: Pilot + Unit names -->
+                <Grid ColumnDefinitions="Auto,*"
+                      RowDefinitions="Auto,Auto"
+                      Margin="2,0">
+                    <!-- Pilot icon -->
+                    <TextBlock Grid.Row="0" Grid.Column="0"
+                               Text="&#xf007;"
+                               FontFamily="{StaticResource AwesomeFontSolid}"
+                               Classes="bodySmall"
+                               Foreground="{StaticResource TextLightBrush}"
+                               Margin="0,0,4,0"
+                               VerticalAlignment="Center"/>
+                    <!-- Pilot name -->
+                    <TextBlock Grid.Row="0" Grid.Column="1"
+                               Text="{Binding PilotName}"
+                               Classes="bodySmall"
+                               Foreground="{StaticResource TextLightBrush}"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis"
+                               VerticalAlignment="Center"/>
+                    <!-- Unit icon -->
+                    <TextBlock Grid.Row="1" Grid.Column="0"
+                               Text="&#xf3ed;"
+                               FontFamily="{StaticResource AwesomeFontSolid}"
+                               Classes="bodySmall"
+                               Foreground="{StaticResource TextLightBrush}"
+                               Margin="0,0,4,0"
+                               VerticalAlignment="Center"/>
+                    <!-- Unit name -->
+                    <TextBlock Grid.Row="1" Grid.Column="1"
+                               Text="{Binding DisplayName}"
+                               Classes="bodySmall"
+                               Foreground="{StaticResource TextLightBrush}"
+                               TextWrapping="NoWrap"
+                               TextTrimming="CharacterEllipsis"
+                               VerticalAlignment="Center"/>
+                </Grid>
             </StackPanel>
-
-            <!-- Info Button in Top Left Corner -->
-            <Button
-                Command="{Binding #UnitItemUserControl.InfoCommand}"
-                CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
-                ToolTip.Tip="{extensions:Localize 'UnitItem_Info'}"
-                Classes="cornerBadge"
-                HorizontalAlignment="Left"
-                Margin="-2,-2,0,0">
-                <PathIcon Data="{StaticResource RecordSheetIcon}"/>
-            </Button>
-
-            <!-- Remove Button in Bottom Right Corner -->
-            <Button
-                Command="{Binding #UnitItemUserControl.RemoveCommand}"
-                CommandParameter="{Binding #UnitItemUserControl.RemoveCommandParameter}"
-                IsVisible="{Binding #UnitItemUserControl.IsRemoveButtonVisible}"
-                ToolTip.Tip="{extensions:Localize 'UnitItem_RemoveUnit'}"
-                Classes="cornerBadge"
-                HorizontalAlignment="Right"
-                VerticalAlignment="Bottom"
-                Margin="0,0,-2,0">
-                <TextBlock Text="&#xf2ed;"/>
-            </Button>
         </Grid>
     </Border>
 </UserControl>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml
@@ -13,104 +13,106 @@
             Width="120"
             Height="150"
             Background="{StaticResource SurfaceBrush}">
-        <Grid>
-            <StackPanel Spacing="2">
-                <!-- Header: Action buttons -->
-                <Grid ColumnDefinitions="*,Auto"
-                      Margin="0,0,0,2">
-                    <!-- Edit button (visible when CanEditUnitName is true) -->
-                    <Button
-                        Grid.Column="0"
-                        Command="{Binding #UnitItemUserControl.InfoCommand}"
-                        CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
-                        ToolTip.Tip="{extensions:Localize 'UnitItem_EditName'}"
-                        Classes="cornerBadge"
-                        IsVisible="{Binding #UnitItemUserControl.CanEditUnitName}"
-                        HorizontalAlignment="Left">
-                        <TextBlock Text="&#xf304;"/>
-                    </Button>
-                    <!-- Info button (visible when CanEditUnitName is false) -->
-                    <Button
-                        Grid.Column="0"
-                        Command="{Binding #UnitItemUserControl.InfoCommand}"
-                        CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
-                        ToolTip.Tip="{extensions:Localize 'UnitItem_Info'}"
-                        Classes="cornerBadge"
-                        IsVisible="{Binding !#UnitItemUserControl.CanEditUnitName}"
-                        HorizontalAlignment="Left">
-                        <PathIcon Data="{StaticResource RecordSheetIcon}"/>
-                    </Button>
-                    <!-- Remove button -->
-                    <Button
-                        Grid.Column="1"
-                        Command="{Binding #UnitItemUserControl.RemoveCommand}"
-                        CommandParameter="{Binding #UnitItemUserControl.RemoveCommandParameter}"
-                        IsVisible="{Binding #UnitItemUserControl.IsRemoveButtonVisible}"
-                        ToolTip.Tip="{extensions:Localize 'UnitItem_RemoveUnit'}"
-                        Classes="cornerBadge">
-                        <TextBlock Text="&#xf2ed;"/>
-                    </Button>
-                </Grid>
+        <Grid RowDefinitions="Auto,*,Auto"
+              RowSpacing="2">
+            <!-- Header: Action buttons -->
+            <Grid Grid.Row="0"
+                  ColumnDefinitions="*,Auto">
+                <!-- Edit button (visible when CanEditUnitName is true) -->
+                <Button
+                    Grid.Column="0"
+                    Command="{Binding #UnitItemUserControl.InfoCommand}"
+                    CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
+                    ToolTip.Tip="{extensions:Localize 'UnitItem_EditName'}"
+                    Classes="cornerBadge"
+                    IsVisible="{Binding #UnitItemUserControl.CanEditUnitName}"
+                    HorizontalAlignment="Left">
+                    <TextBlock Text="&#xf304;"/>
+                </Button>
+                <!-- Info button (visible when CanEditUnitName is false) -->
+                <Button
+                    Grid.Column="0"
+                    Command="{Binding #UnitItemUserControl.InfoCommand}"
+                    CommandParameter="{Binding #UnitItemUserControl.InfoCommandParameter}"
+                    ToolTip.Tip="{extensions:Localize 'UnitItem_Info'}"
+                    Classes="cornerBadge"
+                    IsVisible="{Binding !#UnitItemUserControl.CanEditUnitName}"
+                    HorizontalAlignment="Left">
+                    <PathIcon Data="{StaticResource RecordSheetIcon}"/>
+                </Button>
+                <!-- Remove button -->
+                <Button
+                    Grid.Column="1"
+                    Command="{Binding #UnitItemUserControl.RemoveCommand}"
+                    CommandParameter="{Binding #UnitItemUserControl.RemoveCommandParameter}"
+                    IsVisible="{Binding #UnitItemUserControl.IsRemoveButtonVisible}"
+                    ToolTip.Tip="{extensions:Localize 'UnitItem_RemoveUnit'}"
+                    Classes="cornerBadge">
+                    <TextBlock Text="&#xf2ed;"/>
+                </Button>
+            </Grid>
 
-                <!-- Unit Image with Tint Overlay -->
-                <Panel Width="84" Height="84">
-                    <Image x:Name="UnitImage"
-                           Width="84"
-                           Height="84"
-                           HorizontalAlignment="Center"
-                           VerticalAlignment="Center">
-                    </Image>
+            <!-- Unit Image with Tint Overlay -->
+            <Panel Grid.Row="1" Width="84" Height="84">
+                <Image x:Name="UnitImage"
+                       Width="84"
+                       Height="84"
+                       HorizontalAlignment="Center"
+                       VerticalAlignment="Center">
+                </Image>
 
-                    <!-- Tint Border - uses opacity mask to apply color only to non-transparent pixels -->
-                    <Border x:Name="TintBorder"
-                            Width="84"
-                            Height="84"
-                            Opacity="0.7"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"/>
-                    <Panel.RenderTransform>
-                        <RotateTransform Angle="180"/>
-                    </Panel.RenderTransform>
-                </Panel>
+                <!-- Tint Border - uses opacity mask to apply color only to non-transparent pixels -->
+                <Border x:Name="TintBorder"
+                        Width="84"
+                        Height="84"
+                        Opacity="0.7"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"/>
+                <Panel.RenderTransform>
+                    <RotateTransform Angle="180"/>
+                </Panel.RenderTransform>
+            </Panel>
 
-                <!-- 2x2 Grid: Pilot + Unit names -->
-                <Grid ColumnDefinitions="Auto,*"
-                      RowDefinitions="Auto,Auto"
-                      Margin="2,0">
-                    <!-- Pilot icon -->
-                    <TextBlock Grid.Row="0" Grid.Column="0"
-                               Text="&#xf007;"
-                               FontFamily="{StaticResource AwesomeFontSolid}"
-                               Classes="bodySmall"
-                               Foreground="{StaticResource TextLightBrush}"
-                               Margin="0,0,4,0"
-                               VerticalAlignment="Center"/>
-                    <!-- Pilot name -->
-                    <TextBlock Grid.Row="0" Grid.Column="1"
-                               Text="{Binding PilotName}"
-                               Classes="bodySmall"
-                               Foreground="{StaticResource TextLightBrush}"
-                               TextWrapping="NoWrap"
-                               TextTrimming="CharacterEllipsis"
-                               VerticalAlignment="Center"/>
-                    <!-- Unit icon -->
-                    <TextBlock Grid.Row="1" Grid.Column="0"
-                               Text="&#xf3ed;"
-                               FontFamily="{StaticResource AwesomeFontSolid}"
-                               Classes="bodySmall"
-                               Foreground="{StaticResource TextLightBrush}"
-                               Margin="0,0,4,0"
-                               VerticalAlignment="Center"/>
-                    <!-- Unit name -->
-                    <TextBlock Grid.Row="1" Grid.Column="1"
-                               Text="{Binding DisplayName}"
-                               Classes="bodySmall"
-                               Foreground="{StaticResource TextLightBrush}"
-                               TextWrapping="NoWrap"
-                               TextTrimming="CharacterEllipsis"
-                               VerticalAlignment="Center"/>
-                </Grid>
-            </StackPanel>
+            <!-- Pilot + Unit names -->
+            <Grid Grid.Row="2"
+                  ColumnDefinitions="Auto,*"
+                  RowDefinitions="Auto,Auto"
+                  Margin="2,0">
+                <!-- Pilot icon -->
+                <TextBlock Grid.Row="0" Grid.Column="0"
+                           Text="&#xf007;"
+                           FontFamily="{StaticResource AwesomeFontSolid}"
+                           Classes="bodySmall"
+                           Foreground="{StaticResource TextLightBrush}"
+                           Margin="0,0,4,0"
+                           VerticalAlignment="Center"/>
+                <!-- Pilot name -->
+                <TextBlock Grid.Row="0" Grid.Column="1"
+                           Text="{Binding PilotName}"
+                           Classes="bodySmall"
+                           Foreground="{StaticResource TextLightBrush}"
+                           TextWrapping="WrapWithOverflow"
+                           TextTrimming="CharacterEllipsis"
+                           MaxHeight="36"
+                           VerticalAlignment="Center"/>
+                <!-- Unit icon -->
+                <TextBlock Grid.Row="1" Grid.Column="0"
+                           Text="&#xf3ed;"
+                           FontFamily="{StaticResource AwesomeFontSolid}"
+                           Classes="bodySmall"
+                           Foreground="{StaticResource TextLightBrush}"
+                           Margin="0,0,4,0"
+                           VerticalAlignment="Center"/>
+                <!-- Unit name -->
+                <TextBlock Grid.Row="1" Grid.Column="1"
+                           Text="{Binding DisplayName}"
+                           Classes="bodySmall"
+                           Foreground="{StaticResource TextLightBrush}"
+                           TextWrapping="WrapWithOverflow"
+                           TextTrimming="CharacterEllipsis"
+                           MaxHeight="36"
+                           VerticalAlignment="Center"/>
+            </Grid>
         </Grid>
     </Border>
 </UserControl>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitItemControl.axaml.cs
@@ -6,8 +6,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
-using Sanet.MakaMek.Core.Data.Units;
-using Sanet.MakaMek.Core.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Sanet.MakaMek.Presentation.ViewModels.Wrappers;
 using Sanet.MakaMek.Services;
@@ -32,6 +30,9 @@ public partial class UnitItemControl : UserControl
 
     public static readonly StyledProperty<object?> InfoCommandParameterProperty =
         AvaloniaProperty.Register<UnitItemControl, object?>(nameof(InfoCommandParameter));
+
+    public static readonly StyledProperty<bool> CanEditUnitNameProperty =
+        AvaloniaProperty.Register<UnitItemControl, bool>(nameof(CanEditUnitName), defaultValue: true);
 
     public static readonly StyledProperty<string?> PlayerTintProperty =
         AvaloniaProperty.Register<UnitItemControl, string?>(nameof(PlayerTint));
@@ -70,6 +71,12 @@ public partial class UnitItemControl : UserControl
     {
         get => GetValue(PlayerTintProperty);
         set => SetValue(PlayerTintProperty, value);
+    }
+
+    public bool CanEditUnitName
+    {
+        get => GetValue(CanEditUnitNameProperty);
+        set => SetValue(CanEditUnitNameProperty, value);
     }
 
     public UnitItemControl()

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitPilotInfoPanel.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitPilotInfoPanel.axaml
@@ -51,13 +51,20 @@
                 <TextBlock Grid.Row="0" Grid.Column="3" Text="{Binding Piloting}" Classes="body"/>
             </Grid>
             <!-- Editable skills -->
-            <Grid ColumnDefinitions="Auto,*,Auto,*" RowDefinitions="Auto,Auto"
-                  IsVisible="{Binding #PilotInfoPanel.CanEdit}">
-                <TextBlock Grid.Row="0" Grid.Column="0" Text="{extensions:Localize 'UnitPilot_Gunnery'}" Classes="labelLarge" />
-                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EditableGunnery, Mode=TwoWay}" MinWidth="50"/>
-                <TextBlock Grid.Row="0" Grid.Column="2" Text="{extensions:Localize 'UnitPilot_Piloting'}" Classes="labelLarge" />
-                <TextBox Grid.Row="0" Grid.Column="3" Text="{Binding EditablePiloting, Mode=TwoWay}" MinWidth="50"/>
-            </Grid>
+            <StackPanel Classes="verticalSpaced"
+                        IsVisible="{Binding #PilotInfoPanel.CanEdit}">
+                <TextBlock Text="{extensions:Localize 'UnitPilot_SkillsHint'}" Classes="bodySmall" Opacity="0.6"/>
+                <StackPanel Classes="formGroupCompact">
+                    <TextBlock Text="{extensions:Localize 'UnitPilot_Gunnery'}" Classes="labelLarge"/>
+                    <Slider Value="{Binding EditableGunnery}" Minimum="0" Maximum="7" TickFrequency="1" IsSnapToTickEnabled="True" Classes="gameSlider"/>
+                    <TextBlock Text="{Binding EditableGunnery}" Classes="bodySmall"/>
+                </StackPanel>
+                <StackPanel Classes="formGroupCompact">
+                    <TextBlock Text="{extensions:Localize 'UnitPilot_Piloting'}" Classes="labelLarge"/>
+                    <Slider Value="{Binding EditablePiloting}" Minimum="0" Maximum="7" TickFrequency="1" IsSnapToTickEnabled="True" Classes="gameSlider"/>
+                    <TextBlock Text="{Binding EditablePiloting}" Classes="bodySmall"/>
+                </StackPanel>
+            </StackPanel>
         </StackPanel>
 
         <!-- Health Section -->

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitPilotInfoPanel.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitPilotInfoPanel.axaml
@@ -26,17 +26,14 @@
                 <TextBlock Text="{Binding FullName}" Classes="body"/>
             </StackPanel>
             <!-- Editable name -->
-            <StackPanel Classes="verticalSpaced"
-                        IsVisible="{Binding #PilotInfoPanel.CanEdit}">
-                <StackPanel Classes="horizontalSpaced">
-                    <TextBlock Text="{extensions:Localize 'UnitPilot_FirstName'}" Classes="labelLarge"/>
-                    <TextBox Text="{Binding EditableFirstName, Mode=TwoWay}" MinWidth="120"/>
-                </StackPanel>
-                <StackPanel Classes="horizontalSpaced">
-                    <TextBlock Text="{extensions:Localize 'UnitPilot_LastName'}" Classes="labelLarge"/>
-                    <TextBox Text="{Binding EditableLastName, Mode=TwoWay}" MinWidth="120"/>
-                </StackPanel>
-            </StackPanel>
+            <Grid ColumnDefinitions="Auto,*"
+                  RowDefinitions="Auto,Auto"
+                  IsVisible="{Binding #PilotInfoPanel.CanEdit}">
+                <TextBlock Grid.Row="0" Grid.Column="0" Text="{extensions:Localize 'UnitPilot_FirstName'}" Classes="labelLarge"/>
+                <TextBox Grid.Row="0" Grid.Column="1" Text="{Binding EditableFirstName, Mode=TwoWay}" MinWidth="120" Margin="8,0,0,0"/>
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="{extensions:Localize 'UnitPilot_LastName'}" Classes="labelLarge"/>
+                <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding EditableLastName, Mode=TwoWay}" MinWidth="120" Margin="8,0,0,0"/>
+            </Grid>
         </StackPanel>
 
         <!-- Skills Section -->

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitPilotInfoPanel.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitPilotInfoPanel.axaml
@@ -55,14 +55,18 @@
                         IsVisible="{Binding #PilotInfoPanel.CanEdit}">
                 <TextBlock Text="{extensions:Localize 'UnitPilot_SkillsHint'}" Classes="bodySmall" Opacity="0.6"/>
                 <StackPanel Classes="formGroupCompact">
-                    <TextBlock Text="{extensions:Localize 'UnitPilot_Gunnery'}" Classes="labelLarge"/>
+                    <StackPanel Classes="horizontalSpaced">
+                        <TextBlock Text="{extensions:Localize 'UnitPilot_Gunnery'}" Classes="labelLarge"/>
+                        <TextBlock Text="{Binding EditableGunnery}" Classes="labelLarge"/>
+                    </StackPanel>
                     <Slider Value="{Binding EditableGunnery}" Minimum="0" Maximum="7" TickFrequency="1" IsSnapToTickEnabled="True" Classes="gameSlider"/>
-                    <TextBlock Text="{Binding EditableGunnery}" Classes="bodySmall"/>
                 </StackPanel>
                 <StackPanel Classes="formGroupCompact">
-                    <TextBlock Text="{extensions:Localize 'UnitPilot_Piloting'}" Classes="labelLarge"/>
+                    <StackPanel Classes="horizontalSpaced">
+                        <TextBlock Text="{extensions:Localize 'UnitPilot_Piloting'}" Classes="labelLarge"/>
+                        <TextBlock Text="{Binding EditablePiloting}" Classes="labelLarge"/>
+                    </StackPanel>
                     <Slider Value="{Binding EditablePiloting}" Minimum="0" Maximum="7" TickFrequency="1" IsSnapToTickEnabled="True" Classes="gameSlider"/>
-                    <TextBlock Text="{Binding EditablePiloting}" Classes="bodySmall"/>
                 </StackPanel>
             </StackPanel>
         </StackPanel>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitRecordSheet.axaml.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Controls/UnitRecordSheet.axaml.cs
@@ -112,9 +112,16 @@ public partial class UnitRecordSheet : UserControl
     {
         var pilot = Unit?.Pilot;
         HasPilot = pilot is not null;
-        if (pilot is not null && EditablePilot is null)
+        if (pilot is not null)
         {
-            EditablePilot = new PilotViewModel(pilot);
+            if (EditablePilot?.Pilot != pilot)
+            {
+                EditablePilot = new PilotViewModel(pilot);
+            }
+        }
+        else
+        {
+            EditablePilot = null;
         }
     }
 }

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/PlayersFragment.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/PlayersFragment.axaml
@@ -134,7 +134,7 @@
                                         </ItemsControl>
                                         
                                         <Border Padding="5"
-                                                Width="120"
+                                                Width="100"
                                                 Height="120"
                                                 Classes="card"
                                                 IsVisible="{Binding CanAddUnit}">

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/PlayersFragment.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/PlayersFragment.axaml
@@ -127,13 +127,14 @@
                                                         InfoCommandParameter="{Binding Id}"
                                                         RemoveCommand="{Binding $parent[ItemsControl].((wrappers:PlayerViewModel)DataContext).RemoveUnitCommand}"
                                                         RemoveCommandParameter="{Binding Id}"
-                                                        IsRemoveButtonVisible="{Binding $parent[ItemsControl].((wrappers:PlayerViewModel)DataContext).CanRemoveUnit}"/>
+                                                        IsRemoveButtonVisible="{Binding $parent[ItemsControl].((wrappers:PlayerViewModel)DataContext).CanRemoveUnit}"
+                                                        CanEditUnitName="{Binding $parent[ItemsControl].((wrappers:PlayerViewModel)DataContext).CanEditName}"/>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
                                         
                                         <Border Padding="5"
-                                                Width="100"
+                                                Width="120"
                                                 Height="120"
                                                 Classes="card"
                                                 IsVisible="{Binding CanAddUnit}">

--- a/src/MakaMek.Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Localization/FakeLocalizationService.cs
@@ -358,6 +358,7 @@ public class FakeLocalizationService : ILocalizationService
         ["UnitPilot_Skills"] = "Skills",
         ["UnitPilot_Gunnery"] = "Gunnery:",
         ["UnitPilot_Piloting"] = "Piloting:",
+        ["UnitPilot_SkillsHint"] = "Lower is better (0 = Elite, 7 = Green)",
         ["UnitPilot_HealthStatus"] = "Health Status",
         ["UnitPilot_Injuries"] = "Injuries: {0}/{1}",
         ["UnitPilot_Status"] = "Status",

--- a/src/MakaMek.Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Localization/FakeLocalizationService.cs
@@ -374,6 +374,7 @@ public class FakeLocalizationService : ILocalizationService
         ["UnitItem_Info"] = "Unit Info",
         ["UnitItem_EditName"] = "Edit unit name",
         ["UnitItem_SaveName"] = "Save name",
+        ["UnitItem_NoPilot"] = "No Pilot",
         ["UnitPilot_FirstName"] = "First Name:",
         ["UnitPilot_LastName"] = "Last Name:",
         ["UnitInfo_Save"] = "Save",
@@ -471,6 +472,6 @@ public class FakeLocalizationService : ILocalizationService
 
     public virtual string GetString(string key)
     {
-        return Strings.TryGetValue(key, out var value) ? value : key;
+        return Strings.GetValueOrDefault(key, key);
     }
 }

--- a/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/NewGameViewModel.cs
@@ -85,10 +85,14 @@ public abstract class NewGameViewModel : BaseViewModel
         var unitsData = playerVm.GetUnitsData();
 
         // Create pilot assignments for each unit
-        var pilotAssignments = unitsData.Select(unit => new PilotAssignmentData
+        var pilotAssignments = unitsData.Select(unit => 
         {
-            UnitId = unit.Id ?? Guid.NewGuid(),
-            PilotData = playerVm.GetPilotDataForUnit(unit.Id ?? Guid.NewGuid())?? PilotData.CreateDefaultPilot("MechWarrior","")
+            var unitId = unit.Id ?? Guid.NewGuid();
+            return new PilotAssignmentData
+            {
+                UnitId = unitId,
+                PilotData = playerVm.GetPilotDataForUnit(unitId) ?? PilotData.CreateDefaultPilot("MechWarrior", "")
+            };
         }).ToList();
 
         if (playerVm.Player.ControlType == PlayerControlType.Bot)

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/PilotViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/PilotViewModel.cs
@@ -7,7 +7,7 @@ namespace Sanet.MakaMek.Presentation.ViewModels.Wrappers;
 public class PilotViewModel : BindableBase
 {
     private const int MinSkill = 0;
-    private const int MaxSkill = 8;
+    private const int MaxSkill = 7;
 
     private readonly IPilot _pilot;
 

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/PilotViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/PilotViewModel.cs
@@ -10,15 +10,13 @@ public class PilotViewModel : BindableBase
     private const int MaxSkill = 8;
 
     private readonly IPilot _pilot;
-    private string _editableFirstName = string.Empty;
-    private string _editableLastName = string.Empty;
-    private int _editableGunnery;
-    private int _editablePiloting;
 
     public PilotViewModel(IPilot pilot)
     {
         _pilot = pilot;
     }
+
+    public IPilot Pilot => _pilot;
 
     public Guid Id => _pilot.Id;
 
@@ -46,26 +44,26 @@ public class PilotViewModel : BindableBase
 
     public string EditableFirstName
     {
-        get => _editableFirstName;
-        set => SetProperty(ref _editableFirstName, value);
-    }
+        get;
+        set => SetProperty(ref field, value);
+    } = string.Empty;
 
     public string EditableLastName
     {
-        get => _editableLastName;
-        set => SetProperty(ref _editableLastName, value);
-    }
+        get;
+        set => SetProperty(ref field, value);
+    } = string.Empty;
 
     public int EditableGunnery
     {
-        get => _editableGunnery;
-        set => SetProperty(ref _editableGunnery, value);
+        get;
+        set => SetProperty(ref field, value);
     }
 
     public int EditablePiloting
     {
-        get => _editablePiloting;
-        set => SetProperty(ref _editablePiloting, value);
+        get;
+        set => SetProperty(ref field, value);
     }
 
     public void StartEditing()

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/PlayerViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/PlayerViewModel.cs
@@ -172,16 +172,11 @@ public class PlayerViewModel : BindableBase
             var result = await _showUnitInfo.Invoke(unit.UnitData, pilotData, canEdit);
             if (result != null)
             {
+                var updatedUnitData = result.UnitData with { Id = unit.UnitData.Id };
+                unit.UpdateUnitData(updatedUnitData);
                 if (result.PilotData is { } editedPilot)
                 {
                     UpdatePilotForUnit(unitId, editedPilot);
-                }
-                if (!string.IsNullOrWhiteSpace(result.UnitData.Name) &&
-                    result.UnitData.Name != unit.UnitData.Name)
-                {
-                    unit.StartEditingName();
-                    unit.EditableName = result.UnitData.Name;
-                    unit.SaveName();
                 }
             }
         }
@@ -212,10 +207,10 @@ public class PlayerViewModel : BindableBase
         {
             unit = unit with { Id = Guid.NewGuid() };
         }
-        Units.Add(new UnitViewModel(unit));
+        var resolvedPilot = pilotData ?? PilotData.CreateDefaultPilot("MechWarrior","");
+        Units.Add(new UnitViewModel(unit, resolvedPilot));
 
-        // Create a default pilot for this unit
-        _unitPilots[unit.Id!.Value] = pilotData ?? PilotData.CreateDefaultPilot("MechWarrior","");
+        _unitPilots[unit.Id!.Value] = resolvedPilot;
 
         NotifyPropertyChanged(nameof(CanJoin));
         _onUnitChanged?.Invoke();
@@ -293,6 +288,8 @@ public class PlayerViewModel : BindableBase
     public void UpdatePilotForUnit(Guid unitId, PilotData pilotData)
     {
         _unitPilots[unitId] = pilotData;
+        var unit = Units.FirstOrDefault(u => u.Id == unitId);
+        unit?.UpdatePilot(pilotData);
     }
 
     /// <summary>

--- a/src/MakaMek.Presentation/ViewModels/Wrappers/UnitViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/Wrappers/UnitViewModel.cs
@@ -1,4 +1,5 @@
 using Sanet.MakaMek.Core.Data.Units;
+using Sanet.MakaMek.Localization;
 using Sanet.MVVM.Core.ViewModels;
 
 namespace Sanet.MakaMek.Presentation.ViewModels.Wrappers;
@@ -6,12 +7,16 @@ namespace Sanet.MakaMek.Presentation.ViewModels.Wrappers;
 public class UnitViewModel : BindableBase
 {
     private UnitData _unitData;
+    private PilotData? _pilotData;
+    private readonly ILocalizationService? _localizationService;
     private bool _isEditingName;
     private string _editableName = string.Empty;
 
-    public UnitViewModel(UnitData unitData)
+    public UnitViewModel(UnitData unitData, PilotData? pilotData = null, ILocalizationService? localizationService = null)
     {
         _unitData = unitData;
+        _pilotData = pilotData;
+        _localizationService = localizationService;
     }
 
     public Guid Id => _unitData.Id ?? Guid.Empty;
@@ -47,6 +52,23 @@ public class UnitViewModel : BindableBase
     public bool CanEditName => !IsEditingName;
 
     public UnitData UnitData => _unitData;
+
+    public string PilotName => _pilotData is { } pilot
+        ? $"{pilot.FirstName} {pilot.LastName}".Trim()
+        : _localizationService?.GetString("UnitItem_NoPilot") ?? "No Pilot";
+
+    public void UpdatePilot(PilotData pilotData)
+    {
+        _pilotData = pilotData;
+        NotifyPropertyChanged(nameof(PilotName));
+    }
+
+    public void UpdateUnitData(UnitData unitData)
+    {
+        _unitData = unitData;
+        NotifyPropertyChanged(nameof(DisplayName));
+        NotifyPropertyChanged(nameof(UnitData));
+    }
 
     public void StartEditingName()
     {

--- a/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
@@ -699,8 +699,10 @@ public class FakeLocalizationServiceTests
 
     [Theory]
     [InlineData("UnitItem_RemoveUnit", "Remove unit")]
+    [InlineData("UnitItem_Info", "Unit Info")]
     [InlineData("UnitItem_EditName", "Edit unit name")]
     [InlineData("UnitItem_SaveName", "Save name")]
+    [InlineData("UnitItem_NoPilot", "No Pilot")]
     public void GetString_UnitItem_ReturnsExpectedString(string key, string expected)
     {
         // Arrange

--- a/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
@@ -645,6 +645,7 @@ public class FakeLocalizationServiceTests
     [InlineData("UnitPilot_Skills", "Skills")]
     [InlineData("UnitPilot_Gunnery", "Gunnery:")]
     [InlineData("UnitPilot_Piloting", "Piloting:")]
+    [InlineData("UnitPilot_SkillsHint", "Lower is better (0 = Elite, 7 = Green)")]
     [InlineData("UnitPilot_HealthStatus", "Health Status")]
     [InlineData("UnitPilot_Injuries", "Injuries: {0}/{1}")]
     [InlineData("UnitPilot_Status", "Status")]

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PilotViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PilotViewModelTests.cs
@@ -72,7 +72,7 @@ public class PilotViewModelTests
 
         sut.EditableGunnery = 10;
         var resultHigh = sut.SaveEdit();
-        resultHigh.Gunnery.ShouldBe(8);
+        resultHigh.Gunnery.ShouldBe(7);
 
         sut.StartEditing();
         sut.EditableGunnery = -5;
@@ -89,7 +89,7 @@ public class PilotViewModelTests
 
         sut.EditablePiloting = 10;
         var resultHigh = sut.SaveEdit();
-        resultHigh.Piloting.ShouldBe(8);
+        resultHigh.Piloting.ShouldBe(7);
 
         sut.StartEditing();
         sut.EditablePiloting = -5;

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PlayerViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/PlayerViewModelTests.cs
@@ -294,4 +294,95 @@ public class PlayerViewModelTests
 
         onUnitChangedCalled.ShouldBeTrue();
     }
+
+    [Fact]
+    public async Task AddUnit_ShouldPassPilotData_ToUnitViewModel()
+    {
+        var player = new Player(PlayerData.CreateDefault(), PlayerControlType.Human);
+        var sut = new PlayerViewModel(player, true);
+        var unitData = MechFactoryTests.CreateDummyMechData();
+        var pilotData = new PilotData
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            Gunnery = 3,
+            Piloting = 4
+        };
+
+        await sut.AddUnit(unitData, pilotData);
+
+        sut.Units.First().PilotName.ShouldBe("John Doe");
+    }
+
+    [Fact]
+    public async Task AddUnit_ShouldSetDefaultPilotName_WhenNoPilotProvided()
+    {
+        var player = new Player(PlayerData.CreateDefault(), PlayerControlType.Human);
+        var sut = new PlayerViewModel(player, true);
+        var unitData = MechFactoryTests.CreateDummyMechData();
+
+        await sut.AddUnit(unitData);
+
+        sut.Units.First().PilotName.ShouldBe("MechWarrior");
+    }
+
+    [Fact]
+    public async Task UpdatePilotForUnit_ShouldRefreshUnitViewModelPilotName()
+    {
+        var player = new Player(PlayerData.CreateDefault(), PlayerControlType.Human);
+        var sut = new PlayerViewModel(player, true);
+        var unitData = MechFactoryTests.CreateDummyMechData();
+        var pilotData = new PilotData
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+        await sut.AddUnit(unitData, pilotData);
+        var unitId = sut.Units.First().Id;
+        sut.Units.First().PilotName.ShouldBe("John Doe");
+
+        var updatedPilot = new PilotData
+        {
+            FirstName = "Jane",
+            LastName = "Smith"
+        };
+        sut.UpdatePilotForUnit(unitId, updatedPilot);
+
+        sut.Units.First().PilotName.ShouldBe("Jane Smith");
+        sut.GetPilotDataForUnit(unitId)!.Value.FirstName.ShouldBe("Jane");
+        sut.GetPilotDataForUnit(unitId)!.Value.LastName.ShouldBe("Smith");
+    }
+
+    [Fact]
+    public async Task ExecuteShowUnitInfo_ShouldRefreshDisplayNameAndPilotName_WhenEditResultReturned()
+    {
+        var pilotData = new PilotData
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+        var unitData = MechFactoryTests.CreateDummyMechData() with { Name = "OldName" };
+        var editedUnitData = unitData with { Name = "NewName" };
+        var editedPilot = new PilotData
+        {
+            FirstName = "Jane",
+            LastName = "Smith"
+        };
+        var editedResult = new PilotEditResult(editedUnitData, editedPilot);
+        var showUnitInfo = Substitute.For<Func<UnitData, PilotData?, bool, Task<PilotEditResult?>>>();
+        showUnitInfo.Invoke(Arg.Any<UnitData>(), Arg.Any<PilotData?>(), Arg.Any<bool>())
+            .Returns(Task.FromResult<PilotEditResult?>(editedResult));
+
+        var player = new Player(PlayerData.CreateDefault(), PlayerControlType.Human);
+        var sut = new PlayerViewModel(player, true, showUnitInfo: showUnitInfo);
+        await sut.AddUnit(unitData, pilotData);
+        var unitId = sut.Units.First().Id;
+        sut.Units.First().DisplayName.ShouldBe("OldName");
+        sut.Units.First().PilotName.ShouldBe("John Doe");
+
+        await ((IAsyncCommand<Guid>)sut.ShowUnitInfoCommand).ExecuteAsync(unitId);
+
+        sut.Units.First().DisplayName.ShouldBe("NewName");
+        sut.Units.First().PilotName.ShouldBe("Jane Smith");
+    }
 }

--- a/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/UnitViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/Wrappers/UnitViewModelTests.cs
@@ -1,7 +1,9 @@
+using NSubstitute;
 using Sanet.MakaMek.Core.Data.Units;
 using Sanet.MakaMek.Core.Data.Units.Components;
 using Sanet.MakaMek.Core.Models.Units;
 using Sanet.MakaMek.Core.Models.Units.Components.Engines;
+using Sanet.MakaMek.Localization;
 using Sanet.MakaMek.Presentation.ViewModels.Wrappers;
 using Shouldly;
 
@@ -236,5 +238,120 @@ public class UnitViewModelTests
         var sut = new UnitViewModel(unitData);
 
         sut.Id.ShouldBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void PilotName_ReturnsPilotName_WhenPilotDataProvided()
+    {
+        var unitData = CreateUnitData();
+        var pilotData = new PilotData
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+        var sut = new UnitViewModel(unitData, pilotData);
+
+        sut.PilotName.ShouldBe("John Doe");
+    }
+
+    [Fact]
+    public void PilotName_ReturnsFallback_WhenPilotDataIsNull()
+    {
+        var unitData = CreateUnitData();
+        var sut = new UnitViewModel(unitData);
+
+        sut.PilotName.ShouldBe("No Pilot");
+    }
+
+    [Fact]
+    public void PilotName_ReturnsLocalizedFallback_WhenPilotDataIsNullAndServiceProvided()
+    {
+        var unitData = CreateUnitData();
+        var localizationService = Substitute.For<ILocalizationService>();
+        localizationService.GetString("UnitItem_NoPilot").Returns("Sin Piloto");
+        var sut = new UnitViewModel(unitData, null, localizationService);
+
+        sut.PilotName.ShouldBe("Sin Piloto");
+    }
+
+    [Fact]
+    public void PilotName_TrimsSpaces_WhenLastNameIsEmpty()
+    {
+        var unitData = CreateUnitData();
+        var pilotData = new PilotData
+        {
+            FirstName = "John",
+            LastName = ""
+        };
+        var sut = new UnitViewModel(unitData, pilotData);
+
+        sut.PilotName.ShouldBe("John");
+    }
+
+    [Fact]
+    public void UpdatePilot_RaisesPropertyChanged()
+    {
+        var unitData = CreateUnitData();
+        var pilotData = new PilotData
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+        var sut = new UnitViewModel(unitData, pilotData);
+        var changedProperties = new List<string>();
+        sut.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != null) changedProperties.Add(e.PropertyName);
+        };
+
+        var updatedPilot = new PilotData
+        {
+            FirstName = "Jane",
+            LastName = "Smith"
+        };
+        sut.UpdatePilot(updatedPilot);
+
+        changedProperties.ShouldContain(nameof(sut.PilotName));
+        sut.PilotName.ShouldBe("Jane Smith");
+    }
+
+    [Fact]
+    public void UpdatePilot_UpdatesPilotName()
+    {
+        var unitData = CreateUnitData();
+        var pilotData = new PilotData
+        {
+            FirstName = "John",
+            LastName = "Doe"
+        };
+        var sut = new UnitViewModel(unitData, pilotData);
+
+        var updatedPilot = new PilotData
+        {
+            FirstName = "Jane",
+            LastName = "Smith"
+        };
+        sut.UpdatePilot(updatedPilot);
+
+        sut.PilotName.ShouldBe("Jane Smith");
+    }
+
+    [Fact]
+    public void UpdateUnitData_RaisesPropertyChanged()
+    {
+        var unitData = CreateUnitData("OldName");
+        var sut = new UnitViewModel(unitData);
+        var changedProperties = new List<string>();
+        sut.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != null) changedProperties.Add(e.PropertyName);
+        };
+
+        var newUnitData = CreateUnitData("NewName");
+        sut.UpdateUnitData(newUnitData);
+
+        changedProperties.ShouldContain(nameof(sut.DisplayName));
+        changedProperties.ShouldContain(nameof(sut.UnitData));
+        sut.DisplayName.ShouldBe("NewName");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated unit cards with a clearer header layout: edit/view-name actions, and remove when visible, plus improved pilot/unit name presentation.
  * Pilot skills editing now uses sliders (0–7) with a localized skills hint.
  * Improved localization for missing pilots, and the “Add Unit” card is wider for easier use.
* **Bug Fixes**
  * Improved syncing of pilot/unit details so changes reliably refresh both unit display and pilot name.
  * Fixed pilot assignment consistency when creating/joining a game, and ensured skills clamp correctly to the 0–7 range.
* **Chores**
  * Bumped the app version to **0.61.12**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->