### PR TITLE
remove nuget publishing for hub

### DIFF
--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
   pull_request:
     paths:
@@ -14,8 +12,6 @@ on:
       - 'tests/MakaMek.Hub.Tests/**'
       - '.github/workflows/hub.yml'
   workflow_dispatch:
-env:
-  NuGetDirectory: ${{ github.workspace }}/nuget
 
 jobs:
   test:
@@ -39,34 +35,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: hub
           fail_ci_if_error: true
-
-  publish-nuget:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up .NET
-        uses: actions/setup-dotnet@v6
-        with:
-          dotnet-version: 10.x
-
-      - name: Determine version suffix
-        run: |
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
-            echo "VERSION_SUFFIX=" >> $GITHUB_ENV
-          else
-            echo "VERSION_SUFFIX=preview" >> $GITHUB_ENV
-          fi
-
-      - name: Create nuget packages
-        run: |
-          dotnet pack src/MakaMek.Hub/MakaMek.Hub.csproj --configuration Release --output ${{ env.NuGetDirectory }} -p:VersionSuffix=${{ env.VERSION_SUFFIX }}
-
-      - name: Publish NuGet package
-        run: |
-          for file in "${{ env.NuGetDirectory }}"/*.nupkg; do
-            dotnet nuget push "$file" --api-key "${{ secrets.NUGET_APIKEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
-          done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers to run on changes to the main branch, relevant pull requests, and manual dispatches.
  * Removed the automated NuGet package publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->