### PR TITLE
add cocodif step to pipelines

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Assets.Tests/coverage.opencover.xml
           title: Assets Coverage

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,6 +1,5 @@
 name: MakaMek Assets Library
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -21,11 +20,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -62,6 +64,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
         
       - name: Set up .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -1,5 +1,6 @@
 name: MakaMek Assets Library
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -23,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -39,6 +42,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: assets
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Assets.Tests/coverage.opencover.xml
+          title: Assets Coverage
+          comment-marker: '<!-- cocodif-assets -->'
+          include: 'src/MakaMek.Assets/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Assets.Tests/coverage.opencover.xml
           title: Assets Coverage

--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Assets.Tests/coverage.opencover.xml
           title: Assets Coverage

--- a/.github/workflows/avalonia.yml
+++ b/.github/workflows/avalonia.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
           title: Avalonia Coverage

--- a/.github/workflows/avalonia.yml
+++ b/.github/workflows/avalonia.yml
@@ -1,6 +1,5 @@
 name: MakaMek Avalonia Library
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -26,11 +25,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -39,20 +41,6 @@ jobs:
 
       - name: Run Avalonia tests
         run: dotnet test tests/MakaMek.Avalonia.Tests/MakaMek.Avalonia.Tests.csproj /p:CollectCoverage=true /p:CoverletOutputFormat=opencover /p:ExcludeByAttribute=GeneratedCodeAttribute "/p:Include=\"[Sanet.MakaMek.Avalonia]Sanet.MakaMek.Avalonia.Converters*,[Sanet.MakaMek.Avalonia]Sanet.MakaMek.Avalonia.Game*\""
-
-      - name: Upload coverage report as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
-          if-no-files-found: error
-
-      - name: Upload Avalonia tests results
-        uses: codecov/codecov-action@v7
-        with:
-          files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
@@ -65,6 +53,13 @@ jobs:
           exclude: '**/obj/**,**/bin/**'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload Avalonia tests results
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
   
   publish-nuget:
     runs-on: ubuntu-latest
@@ -73,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
         
       - name: Set up .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/avalonia.yml
+++ b/.github/workflows/avalonia.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
           title: Avalonia Coverage

--- a/.github/workflows/avalonia.yml
+++ b/.github/workflows/avalonia.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
           title: Avalonia Coverage

--- a/.github/workflows/avalonia.yml
+++ b/.github/workflows/avalonia.yml
@@ -1,5 +1,6 @@
 name: MakaMek Avalonia Library
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -28,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -50,6 +53,18 @@ jobs:
           files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
+          title: Avalonia Coverage
+          comment-marker: '<!-- cocodif-avalonia -->'
+          include: 'src/MakaMek.Avalonia/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Bots.Tests/coverage.opencover.xml
           title: Bots Coverage

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -1,5 +1,6 @@
 name: MakaMek Bots Library
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -26,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -42,6 +45,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: bots
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Bots.Tests/coverage.opencover.xml
+          title: Bots Coverage
+          comment-marker: '<!-- cocodif-bots -->'
+          include: 'src/MakaMek.Bots/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Bots.Tests/coverage.opencover.xml
           title: Bots Coverage

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -1,6 +1,5 @@
 name: MakaMek Bots Library
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -24,11 +23,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
         
       - name: Set up .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Bots.Tests/coverage.opencover.xml
           title: Bots Coverage

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Core.Tests/coverage.opencover.xml
           title: Core Coverage

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,5 +1,6 @@
 name: MakaMek Core Library
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -26,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -42,6 +45,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: core
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Core.Tests/coverage.opencover.xml
+          title: Core Coverage
+          comment-marker: '<!-- cocodif-core -->'
+          include: 'src/MakaMek.Core/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v1
         with:
           coverage-files: ./tests/MakaMek.Core.Tests/coverage.opencover.xml
           title: Core Coverage

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -1,6 +1,5 @@
 name: MakaMek Core Library
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -22,6 +21,8 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     env:
       COVERAGE_EXCLUSIONS: "**/FileCommandLogger.cs"
     steps:
@@ -29,6 +30,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
         
       - name: Set up .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Core.Tests/coverage.opencover.xml
           title: Core Coverage

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Core.Tests/coverage.opencover.xml
           title: Core Coverage

--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -1,5 +1,6 @@
 name: MakaMek Hub
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -19,6 +20,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -35,3 +38,15 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: hub
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Hub.Tests/coverage.opencover.xml
+          title: Hub Coverage
+          comment-marker: '<!-- cocodif-hub -->'
+          include: 'src/MakaMek.Hub/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Hub.Tests/coverage.opencover.xml
           title: Hub Coverage

--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Hub.Tests/coverage.opencover.xml
           title: Hub Coverage

--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -1,6 +1,5 @@
 name: MakaMek Hub
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -17,11 +16,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Hub.Tests/coverage.opencover.xml
           title: Hub Coverage

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Localization.Tests/coverage.opencover.xml
           title: Localization Coverage

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,5 +1,6 @@
 name: MakaMek Localization Library
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -23,6 +24,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -39,6 +42,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: localization
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Localization.Tests/coverage.opencover.xml
+          title: Localization Coverage
+          comment-marker: '<!-- cocodif-localization -->'
+          include: 'src/MakaMek.Localization/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,6 +1,5 @@
 name: MakaMek Localization Library
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -21,11 +20,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -62,6 +64,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
         
       - name: Set up .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Localization.Tests/coverage.opencover.xml
           title: Localization Coverage

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Localization.Tests/coverage.opencover.xml
           title: Localization Coverage

--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Map.Tests/coverage.opencover.xml
           title: Map Coverage

--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Map.Tests/coverage.opencover.xml
           title: Map Coverage

--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -1,5 +1,6 @@
 name: MakaMek Map Library
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -24,6 +25,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -40,6 +43,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: map
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Map.Tests/coverage.opencover.xml
+          title: Map Coverage
+          comment-marker: '<!-- cocodif-map -->'
+          include: 'src/MakaMek.Map/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Map.Tests/coverage.opencover.xml
           title: Map Coverage

--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -1,6 +1,5 @@
 name: MakaMek Map Library
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -22,11 +21,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -63,6 +65,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
         
       - name: Set up .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/presentation.yml
+++ b/.github/workflows/presentation.yml
@@ -1,6 +1,5 @@
 name: MakaMek Presentation Library
 permissions:
-  pull-requests: write
   contents: read
 on:
   push:
@@ -25,11 +24,14 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -66,6 +68,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
         
       - name: Set up .NET
         uses: actions/setup-dotnet@v6

--- a/.github/workflows/presentation.yml
+++ b/.github/workflows/presentation.yml
@@ -1,5 +1,6 @@
 name: MakaMek Presentation Library
 permissions:
+  pull-requests: write
   contents: read
 on:
   push:
@@ -27,6 +28,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
@@ -43,6 +46,18 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: presentation
           fail_ci_if_error: true
+
+      - name: Diff coverage report
+        if: github.event_name == 'pull_request'
+        uses: sanet/Cocodif@v1
+        with:
+          coverage-files: ./tests/MakaMek.Presentation.Tests/coverage.opencover.xml
+          title: Presentation Coverage
+          comment-marker: '<!-- cocodif-presentation -->'
+          include: 'src/MakaMek.Presentation/**'
+          exclude: '**/obj/**,**/bin/**'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   publish-nuget:
     runs-on: ubuntu-latest

--- a/.github/workflows/presentation.yml
+++ b/.github/workflows/presentation.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: sanet/Cocodif@v1
+        uses: anton-makarevich/Cocodif@v0.1.1
         with:
           coverage-files: ./tests/MakaMek.Presentation.Tests/coverage.opencover.xml
           title: Presentation Coverage

--- a/.github/workflows/presentation.yml
+++ b/.github/workflows/presentation.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.1.1
+        uses: anton-makarevich/Cocodif@main
         with:
           coverage-files: ./tests/MakaMek.Presentation.Tests/coverage.opencover.xml
           title: Presentation Coverage

--- a/.github/workflows/presentation.yml
+++ b/.github/workflows/presentation.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@main
+        uses: anton-makarevich/Cocodif@v0.1.2
         with:
           coverage-files: ./tests/MakaMek.Presentation.Tests/coverage.opencover.xml
           title: Presentation Coverage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ MakaMek is a cross-platform, turn-based tactical BattleTech implementation built
     /p:ExcludeByAttribute=GeneratedCodeAttribute /p:Include=[Sanet.MakaMek.Core]*
   ```
   The coverage filter uses the source assembly name (test assembly name minus `.Tests`). See `skills/coverage-check`.
+- **Diff-coverage (PR pipeline):** [Cocodif](https://github.com/sanet/Cocodif) runs as a composite GitHub Action in each coverage workflow. It parses the coverlet OpenCover XML, computes `git diff --merge-base` against the PR base branch, and posts a per-file diff-coverage report as a sticky PR comment (one per module). The action is informational only — no `fail-under` gate. Each module workflow passes its own `coverage.opencover.xml`, `include` globs scoped to `src/<Module>/**`, and a unique `comment-marker` so reports don't collide. For local diff-coverage, install the CLI: `dotnet tool install --global Sanet.Cocodif`.
 - **Run the desktop app:** `dotnet run --project src/MakaMek.Avalonia/MakaMek.Avalonia.Desktop`
 
 Assembly/root namespaces are prefixed `Sanet.` (e.g. `MakaMek.Core` → `Sanet.MakaMek.Core`), even though project/folder names omit it.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.62.5</VersionPrefix>
+        <VersionPrefix>0.62.6</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/skills/coverage-check/SKILL.md
+++ b/skills/coverage-check/SKILL.md
@@ -5,7 +5,7 @@ description: Run tests for a project with code coverage and report uncovered sou
 
 # Coverage Check
 
-Run tests with coverlet coverage, parse the opencover XML, and report uncovered lines — mirroring the CI pipeline locally.
+Run tests with coverlet coverage and produce a diff-coverage report — mirroring the CI pipeline locally.
 
 **Input:** test project path relative to the repo root (e.g. `tests/MakaMek.Core.Tests/MakaMek.Core.Tests.csproj`).
 
@@ -33,25 +33,27 @@ Stop and report if tests fail. Do not proceed to parsing.
 
 **Completion criterion:** tests pass and `coverage.opencover.xml` exists in the test project directory.
 
-## Step 4: Parse the coverage XML
+## Step 4: Diff-coverage report with Cocodif
 
-Locate `{testProjectDir}/coverage.opencover.xml`. Parse the XML:
+[Cocodif](https://github.com/sanet/Cocodif) is a .NET global tool that parses the OpenCover XML, filters changed files via `git diff`, and produces a Markdown diff-coverage report.
 
-1. Build a file map from `<Files>` — each `<File uid="N" fullPath="..." />` maps a numeric ID to a source file path.
-2. For every `<SequencePoint>` with `vc="0"` (zero visits), record the file ID (`fileid` attribute) and start line (`sl` attribute).
-3. Group uncovered lines by source file.
-4. Filter to source files under `src/` only — skip generated files under `obj/`.
+**Install** (if not already available):
 
-**Completion criterion:** a map of source file → sorted list of uncovered line numbers extracted.
+```bash
+dotnet tool install --global Sanet.Cocodif
+```
 
-## Step 5: Report uncovered lines
+**Run** against the module (after Step 3 produces `coverage.opencover.xml`):
 
-For each file with uncovered lines:
+```bash
+Cocodif \
+  -c tests/{TestProjectDir}/coverage.opencover.xml \
+  -o diff-coverage.md \
+  --include 'src/{ModuleName}/**' \
+  --exclude '**/obj/**,**/bin/**' \
+  --title '{ModuleName} Coverage'
+```
 
-1. Show the file path (relative to repo root) and the count of uncovered lines.
-2. List the uncovered line numbers.
-3. Read those lines from the source file to show the actual code.
+If Cocodif cannot be installed, skip this step — the `coverage.opencover.xml` is still available for manual inspection.
 
-End with a summary: total source files checked, files with gaps, total uncovered lines.
-
-**Completion criterion:** every uncovered line presented with its source code, grouped by file.
+**Completion criterion:** `diff-coverage.md` produced with per-file diff-coverage breakdown, or step skipped.

--- a/src/MakaMek.Assets/MakaMek.Assets.csproj
+++ b/src/MakaMek.Assets/MakaMek.Assets.csproj
@@ -14,7 +14,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia.Android/MakaMek.Avalonia.Android.csproj
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia.Android/MakaMek.Avalonia.Android.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Avalonia.Android" Version="12.1.0" />
         <PackageReference Include="Sanet.MVVM.ExternalNavigation.Android" Version="1.6.0" />
         <PackageReference Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.3" />
-        <PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.17.0.2" ExcludeAssets="all" />
+        <PackageReference Include="Xamarin.AndroidX.Core.Core.Ktx" Version="1.19.0.1" ExcludeAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia.Controls/MakaMek.Avalonia.Controls.csproj
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia.Controls/MakaMek.Avalonia.Controls.csproj
@@ -22,10 +22,10 @@
     <PackageReference Include="AsyncAwaitBestPractices" Version="10.0.0" />
     <PackageReference Include="Avalonia" Version="12.1.0" />
     <PackageReference Include="Avalonia.Skia" Version="12.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Sanet.MVVM.Core" Version="1.6.0" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="System.Reactive" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia.Desktop/MakaMek.Avalonia.Desktop.csproj
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia.Desktop/MakaMek.Avalonia.Desktop.csproj
@@ -22,7 +22,7 @@
 
     <ItemGroup>
         <PackageReference Include="Avalonia.Desktop" Version="12.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
         <PackageReference Include="Sanet.MVVM.ExternalNavigation.Desktop" Version="1.6.0" />
         <PackageReference Include="Sanet.Transport.SignalR.Server" Version="1.1.0" />
         <PackageReference Include="Velopack" Version="0.0.1298" />

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/MakaMek.Avalonia.csproj
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/MakaMek.Avalonia.csproj
@@ -22,12 +22,12 @@
         <PackageReference Include="Avalonia.Skia" Version="12.1.0" />
         <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.0" />
         <PackageReference Include="Avalonia.Fonts.Inter" Version="12.1.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
         <PackageReference Include="Sanet.MVVM.DI.Avalonia" Version="1.6.1210" />
         <PackageReference Include="Sanet.MVVM.Navigation.Avalonia" Version="1.6.1210" />
         <PackageReference Include="Sanet.MVVM.Views.Avalonia" Version="1.6.1210" />
-        <PackageReference Include="System.Reactive" Version="6.1.0" />
+        <PackageReference Include="System.Reactive" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MakaMek.Core/MakaMek.Core.csproj
+++ b/src/MakaMek.Core/MakaMek.Core.csproj
@@ -15,12 +15,12 @@
     
     <ItemGroup>
       <PackageReference Include="AsyncAwaitBestPractices" Version="10.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+      <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
       <PackageReference Include="Sanet.Transport.Rx" Version="1.1.0" />
       <PackageReference Include="Sanet.Transport.SignalR.Client" Version="1.1.0" />
-      <PackageReference Include="System.Reactive" Version="6.1.0" />
+      <PackageReference Include="System.Reactive" Version="7.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MakaMek.Map/MakaMek.Map.csproj
+++ b/src/MakaMek.Map/MakaMek.Map.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Reactive" Version="6.1.0" />
+        <PackageReference Include="System.Reactive" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/MakaMek.Presentation/MakaMek.Presentation.csproj
+++ b/src/MakaMek.Presentation/MakaMek.Presentation.csproj
@@ -15,7 +15,7 @@
     
     <ItemGroup>
       <PackageReference Include="Sanet.MVVM.Core" Version="1.6.0" />
-      <PackageReference Include="System.Reactive" Version="6.1.0" />
+      <PackageReference Include="System.Reactive" Version="7.0.0" />
     </ItemGroup>
     
     <ItemGroup>

--- a/src/MakaMek.Services/MakaMek.Services.csproj
+++ b/src/MakaMek.Services/MakaMek.Services.csproj
@@ -14,9 +14,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+      <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
       <PackageReference Include="PDFsharp" Version="6.2.4" />
-      <PackageReference Include="System.Reactive" Version="6.1.0" />
+      <PackageReference Include="System.Reactive" Version="7.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/MakaMek.Tools/BotAgent/BotAgent.csproj
+++ b/src/MakaMek.Tools/BotAgent/BotAgent.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-preview.260108.1" />
-    <PackageReference Include="Microsoft.Extensions.AI" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.7.0" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.7.0" />
+    <PackageReference Include="Microsoft.Extensions.AI" Version="10.8.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="10.8.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="ModelContextProtocol" Version="0.6.0-preview.1" />
   </ItemGroup>
 

--- a/src/MakaMek.Tools/BotContainer/BotContainer.csproj
+++ b/src/MakaMek.Tools/BotContainer/BotContainer.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="ModelContextProtocol" Version="0.6.0-preview.1" />
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.6.0-preview.1" />
-    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="System.Reactive" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/MakaMek.Assets.Tests/MakaMek.Assets.Tests.csproj
+++ b/tests/MakaMek.Assets.Tests/MakaMek.Assets.Tests.csproj
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Avalonia.Tests/MakaMek.Avalonia.Tests.csproj
+++ b/tests/MakaMek.Avalonia.Tests/MakaMek.Avalonia.Tests.csproj
@@ -17,8 +17,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Bots.Tests/MakaMek.Bots.Tests.csproj
+++ b/tests/MakaMek.Bots.Tests/MakaMek.Bots.Tests.csproj
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Core.Tests/MakaMek.Core.Tests.csproj
+++ b/tests/MakaMek.Core.Tests/MakaMek.Core.Tests.csproj
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Hub.Tests/MakaMek.Hub.Tests.csproj
+++ b/tests/MakaMek.Hub.Tests/MakaMek.Hub.Tests.csproj
@@ -18,8 +18,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Localization.Tests/MakaMek.Localization.Tests.csproj
+++ b/tests/MakaMek.Localization.Tests/MakaMek.Localization.Tests.csproj
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Map.Tests/MakaMek.Map.Tests.csproj
+++ b/tests/MakaMek.Map.Tests/MakaMek.Map.Tests.csproj
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Presentation.Tests/MakaMek.Presentation.Tests.csproj
+++ b/tests/MakaMek.Presentation.Tests/MakaMek.Presentation.Tests.csproj
@@ -19,8 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JetBrains.Annotations" Version="2026.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/MakaMek.Services.Tests/MakaMek.Services.Tests.csproj
+++ b/tests/MakaMek.Services.Tests/MakaMek.Services.Tests.csproj
@@ -18,8 +18,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="NSubstitute" Version="5.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="NSubstitute" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated diff-coverage PR reports that post/update module-scoped coverage comments highlighting changes since the PR base (informational only, no fail-under gate).
* **Documentation**
  * Updated contributor guidance with the new CI diff-coverage pipeline and a local command option.
  * Revised coverage-check instructions to mirror CI by generating `diff-coverage.md` from the OpenCover XML rather than manual parsing/reporting.
* **Chores**
  * Improved CI checkout behavior and PR-comment permissions to support consistent coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->