### PR TITLE
add misisng file

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Assets.Tests/coverage.opencover.xml
           title: Assets Coverage

--- a/.github/workflows/avalonia.yml
+++ b/.github/workflows/avalonia.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Avalonia.Tests/coverage.opencover.xml
           title: Avalonia Coverage

--- a/.github/workflows/bots.yml
+++ b/.github/workflows/bots.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Bots.Tests/coverage.opencover.xml
           title: Bots Coverage

--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Core.Tests/coverage.opencover.xml
           title: Core Coverage

--- a/.github/workflows/hub.yml
+++ b/.github/workflows/hub.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Hub.Tests/coverage.opencover.xml
           title: Hub Coverage

--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Localization.Tests/coverage.opencover.xml
           title: Localization Coverage

--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Map.Tests/coverage.opencover.xml
           title: Map Coverage

--- a/.github/workflows/presentation.yml
+++ b/.github/workflows/presentation.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Diff coverage report
         if: github.event_name == 'pull_request'
-        uses: anton-makarevich/Cocodif@v0.2.0
+        uses: anton-makarevich/Cocodif@v0.2.1
         with:
           coverage-files: ./tests/MakaMek.Presentation.Tests/coverage.opencover.xml
           title: Presentation Coverage

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.62.7</VersionPrefix>
+        <VersionPrefix>0.62.8</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Hub/Contracts/CloseRequest.cs
+++ b/src/MakaMek.Hub/Contracts/CloseRequest.cs
@@ -1,3 +1,0 @@
-﻿namespace Sanet.MakaMek.Hub.Contracts;
-
-public sealed record CloseRequest(string SessionToken);

--- a/src/MakaMek.Hub/Contracts/ReadyRequest.cs
+++ b/src/MakaMek.Hub/Contracts/ReadyRequest.cs
@@ -1,3 +1,0 @@
-namespace Sanet.MakaMek.Hub.Contracts;
-
-public sealed record ReadyRequest(string SessionToken);

--- a/src/MakaMek.Hub/Controllers/RoomsController.cs
+++ b/src/MakaMek.Hub/Controllers/RoomsController.cs
@@ -144,18 +144,18 @@ public sealed class RoomsController(IRoomManager roomManager) : ControllerBase
     [ProducesResponseType<ReadyResponse>(StatusCodes.Status200OK)]
     [ProducesResponseType<ReadyResponse>(StatusCodes.Status404NotFound)]
     [ProducesResponseType<ReadyResponse>(StatusCodes.Status409Conflict)]
-    public ActionResult<ReadyResponse> MarkRoomReady(string roomCode, [FromBody] ReadyRequest request)
+    public ActionResult<ReadyResponse> MarkRoomReady(string roomCode)
     {
-        if (string.IsNullOrWhiteSpace(request.SessionToken))
+        if (!TryGetSessionToken(out var sessionToken))
         {
             return ValidationProblem(new ValidationProblemDetails(
                 new Dictionary<string, string[]>
                 {
-                    [nameof(request.SessionToken)] = ["SessionToken is required."]
+                    ["Session-Token"] = ["Session-Token header is required."]
                 }));
         }
 
-        var result = roomManager.MarkRoomReady(roomCode, request.SessionToken);
+        var result = roomManager.MarkRoomReady(roomCode, sessionToken);
 
         return result.Outcome switch
         {
@@ -181,18 +181,18 @@ public sealed class RoomsController(IRoomManager roomManager) : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType<CloseResponse>(StatusCodes.Status404NotFound)]
     [ProducesResponseType<CloseResponse>(StatusCodes.Status409Conflict)]
-    public ActionResult<CloseResponse> CloseRoom(string roomCode, [FromBody] CloseRequest request)
+    public ActionResult<CloseResponse> CloseRoom(string roomCode)
     {
-        if (string.IsNullOrWhiteSpace(request.SessionToken))
+        if (!TryGetSessionToken(out var sessionToken))
         {
             return ValidationProblem(new ValidationProblemDetails(
                 new Dictionary<string, string[]>
                 {
-                    [nameof(request.SessionToken)] = ["SessionToken is required."]
+                    ["Session-Token"] = ["Session-Token header is required."]
                 }));
         }
 
-        var result = roomManager.CloseRoom(roomCode, request.SessionToken);
+        var result = roomManager.CloseRoom(roomCode, sessionToken);
 
         return result.Outcome switch
         {
@@ -221,7 +221,7 @@ public sealed class RoomsController(IRoomManager roomManager) : ControllerBase
     [ProducesResponseType<RemoveMemberResponse>(StatusCodes.Status409Conflict)]
     public ActionResult<RemoveMemberResponse> RemoveMember(string roomCode, Guid playerId)
     {
-        if (!TryGetSessionTokenFromAuthorizationHeader(out var sessionToken))
+        if (!TryGetSessionToken(out var sessionToken))
         {
             return Unauthorized();
         }
@@ -250,25 +250,15 @@ public sealed class RoomsController(IRoomManager roomManager) : ControllerBase
         };
     }
 
-    private bool TryGetSessionTokenFromAuthorizationHeader(out string sessionToken)
+    private bool TryGetSessionToken(out string sessionToken)
     {
         sessionToken = string.Empty;
-        var authorization = Request.Headers.Authorization.ToString();
-        if (string.IsNullOrWhiteSpace(authorization))
+        if (!Request.Headers.TryGetValue("Session-Token", out var values))
         {
             return false;
         }
 
-        const string bearerPrefix = "Bearer ";
-        if (authorization.StartsWith(bearerPrefix, StringComparison.OrdinalIgnoreCase))
-        {
-            sessionToken = authorization[bearerPrefix.Length..].Trim();
-        }
-        else
-        {
-            sessionToken = authorization.Trim();
-        }
-
+        sessionToken = values.ToString().Trim();
         return !string.IsNullOrWhiteSpace(sessionToken);
     }
 }

--- a/tests/MakaMek.Hub.Tests/Rooms/JoinRoomEndpointTests.cs
+++ b/tests/MakaMek.Hub.Tests/Rooms/JoinRoomEndpointTests.cs
@@ -282,7 +282,7 @@ public class JoinRoomEndpointTests
         string? apiKey)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, $"/api/rooms/{roomCode}/ready");
-        request.Content = JsonContent.Create(new ReadyRequest(sessionToken));
+        request.Headers.Add("Session-Token", sessionToken);
 
         if (apiKey is not null)
         {

--- a/tests/MakaMek.Hub.Tests/Rooms/RoomLifecycleEndpointTests.cs
+++ b/tests/MakaMek.Hub.Tests/Rooms/RoomLifecycleEndpointTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -292,14 +291,17 @@ public class RoomLifecycleEndpointTests
         using var client = factory.CreateClient();
 
         using var request = new HttpRequestMessage(HttpMethod.Post, "/api/rooms/ABC234/close");
-        request.Content = JsonContent.Create(new CloseRequest(sessionToken!));
+        if (sessionToken is not null)
+        {
+            request.Headers.Add("Session-Token", sessionToken);
+        }
         request.Headers.Add(ApiKeyAuthenticationDefaults.HeaderName, HubApplicationFactory.ApiKey);
 
         using var response = await client.SendAsync(request);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
-        body.ShouldContain("SessionToken");
+        body.ShouldContain("Session-Token");
     }
 
     [Theory]
@@ -312,18 +314,21 @@ public class RoomLifecycleEndpointTests
         using var client = factory.CreateClient();
 
         using var request = new HttpRequestMessage(HttpMethod.Post, "/api/rooms/ABC234/ready");
-        request.Content = JsonContent.Create(new ReadyRequest(sessionToken!));
+        if (sessionToken is not null)
+        {
+            request.Headers.Add("Session-Token", sessionToken);
+        }
         request.Headers.Add(ApiKeyAuthenticationDefaults.HeaderName, HubApplicationFactory.ApiKey);
 
         using var response = await client.SendAsync(request);
 
         response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
-        body.ShouldContain("SessionToken");
+        body.ShouldContain("Session-Token");
     }
 
     [Fact]
-    public async Task RemoveMember_NonBearerToken_ReturnsOk()
+    public async Task RemoveMember_WithSessionToken_ReturnsOk()
     {
         await using var factory = new HubApplicationFactory();
         using var client = factory.CreateClient();
@@ -335,7 +340,7 @@ public class RoomLifecycleEndpointTests
         joinResponse.StatusCode.ShouldBe(HttpStatusCode.OK);
 
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/rooms/{roomCode}/members/{playerId}");
-        request.Headers.TryAddWithoutValidation("Authorization", hostToken);
+        request.Headers.Add("Session-Token", hostToken);
         request.Headers.Add(ApiKeyAuthenticationDefaults.HeaderName, HubApplicationFactory.ApiKey);
 
         using var removeResponse = await client.SendAsync(request);
@@ -461,7 +466,7 @@ public class RoomLifecycleEndpointTests
         string? apiKey)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, $"/api/rooms/{roomCode}/ready");
-        request.Content = JsonContent.Create(new ReadyRequest(sessionToken));
+        request.Headers.Add("Session-Token", sessionToken);
 
         if (apiKey is not null)
         {
@@ -478,7 +483,7 @@ public class RoomLifecycleEndpointTests
         string? apiKey)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, $"/api/rooms/{roomCode}/close");
-        request.Content = JsonContent.Create(new CloseRequest(sessionToken));
+        request.Headers.Add("Session-Token", sessionToken);
 
         if (apiKey is not null)
         {
@@ -496,7 +501,7 @@ public class RoomLifecycleEndpointTests
         string? apiKey)
     {
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"/api/rooms/{roomCode}/members/{playerId}");
-        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", sessionToken);
+        request.Headers.Add("Session-Token", sessionToken);
 
         if (apiKey is not null)
         {

--- a/tests/MakaMek.Hub.Tests/Rooms/RoomsControllerTests.cs
+++ b/tests/MakaMek.Hub.Tests/Rooms/RoomsControllerTests.cs
@@ -139,11 +139,11 @@ public class RoomsControllerTests
     [Fact]
     public void CloseRoom_ValidRequest_ReturnsOk()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         _roomManager.CloseRoom(RoomCode, SessionToken)
             .Returns(RoomCloseResult.Closed());
 
-        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+        var result = _sut.CloseRoom(RoomCode);
 
         var ok = result.Result.ShouldBeOfType<OkObjectResult>();
         var response = ok.Value.ShouldBeOfType<CloseResponse>();
@@ -153,7 +153,7 @@ public class RoomsControllerTests
     [Fact]
     public void CloseRoom_MissingSessionToken_ReturnsValidationProblem()
     {
-        var result = _sut.CloseRoom(RoomCode, new CloseRequest(""));
+        var result = _sut.CloseRoom(RoomCode);
 
         result.Result.ShouldBeOfType<BadRequestObjectResult>();
     }
@@ -161,11 +161,11 @@ public class RoomsControllerTests
     [Fact]
     public void CloseRoom_RoomNotFound_ReturnsNotFound()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         _roomManager.CloseRoom(RoomCode, SessionToken)
             .Returns(RoomCloseResult.NotFound());
 
-        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+        var result = _sut.CloseRoom(RoomCode);
 
         var notFound = result.Result.ShouldBeOfType<NotFoundObjectResult>();
         var response = notFound.Value.ShouldBeOfType<CloseResponse>();
@@ -176,11 +176,11 @@ public class RoomsControllerTests
     [Fact]
     public void CloseRoom_RoomExpired_ReturnsConflict()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         _roomManager.CloseRoom(RoomCode, SessionToken)
             .Returns(RoomCloseResult.Expired());
 
-        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+        var result = _sut.CloseRoom(RoomCode);
 
         var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
         var response = conflict.Value.ShouldBeOfType<CloseResponse>();
@@ -191,11 +191,11 @@ public class RoomsControllerTests
     [Fact]
     public void CloseRoom_NotHost_ReturnsConflict()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         _roomManager.CloseRoom(RoomCode, SessionToken)
             .Returns(RoomCloseResult.NotHost());
 
-        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+        var result = _sut.CloseRoom(RoomCode);
 
         var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
         var response = conflict.Value.ShouldBeOfType<CloseResponse>();
@@ -206,11 +206,11 @@ public class RoomsControllerTests
     [Fact]
     public void CloseRoom_InvalidRoomState_ReturnsConflict()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         _roomManager.CloseRoom(RoomCode, SessionToken)
             .Returns(RoomCloseResult.InvalidState());
 
-        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+        var result = _sut.CloseRoom(RoomCode);
 
         var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
         var response = conflict.Value.ShouldBeOfType<CloseResponse>();
@@ -235,7 +235,7 @@ public class RoomsControllerTests
     [Fact]
     public void RemoveMember_ValidRequest_ReturnsOk()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         var targetId = Guid.NewGuid();
         _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
             .Returns(RoomRemoveMemberResult.Removed());
@@ -250,7 +250,7 @@ public class RoomsControllerTests
     [Fact]
     public void RemoveMember_RoomNotFound_ReturnsNotFound()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         var targetId = Guid.NewGuid();
         _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
             .Returns(RoomRemoveMemberResult.NotFound());
@@ -266,7 +266,7 @@ public class RoomsControllerTests
     [Fact]
     public void RemoveMember_MemberNotFound_ReturnsNotFound()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         var targetId = Guid.NewGuid();
         _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
             .Returns(RoomRemoveMemberResult.MemberNotFound());
@@ -282,7 +282,7 @@ public class RoomsControllerTests
     [Fact]
     public void RemoveMember_RoomExpired_ReturnsConflict()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         var targetId = Guid.NewGuid();
         _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
             .Returns(RoomRemoveMemberResult.Expired());
@@ -298,7 +298,7 @@ public class RoomsControllerTests
     [Fact]
     public void RemoveMember_NotHost_ReturnsConflict()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         var targetId = Guid.NewGuid();
         _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
             .Returns(RoomRemoveMemberResult.NotHost());
@@ -314,7 +314,7 @@ public class RoomsControllerTests
     [Fact]
     public void RemoveMember_CannotRemoveHost_ReturnsConflict()
     {
-        SetAuthorizationHeader(SessionToken);
+        SetSessionTokenHeader(SessionToken);
         var targetId = Guid.NewGuid();
         _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
             .Returns(RoomRemoveMemberResult.CannotRemoveHost());
@@ -329,9 +329,9 @@ public class RoomsControllerTests
 
     #endregion
 
-    private void SetAuthorizationHeader(string token)
+    private void SetSessionTokenHeader(string token)
     {
-        _sut.ControllerContext.HttpContext.Request.Headers.Authorization = $"Bearer {token}";
+        _sut.ControllerContext.HttpContext.Request.Headers["Session-Token"] = token;
     }
 
     private static Room CreateRoom()

--- a/tests/MakaMek.Hub.Tests/Rooms/RoomsControllerTests.cs
+++ b/tests/MakaMek.Hub.Tests/Rooms/RoomsControllerTests.cs
@@ -220,6 +220,92 @@ public class RoomsControllerTests
 
     #endregion
 
+    #region MarkRoomReady
+
+    [Fact]
+    public void MarkRoomReady_MissingSessionToken_ReturnsValidationProblem()
+    {
+        var result = _sut.MarkRoomReady(RoomCode);
+
+        result.Result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void MarkRoomReady_ValidRequest_ReturnsOk()
+    {
+        SetSessionTokenHeader(SessionToken);
+        _roomManager.MarkRoomReady(RoomCode, SessionToken)
+            .Returns(RoomReadyResult.Ready());
+
+        var result = _sut.MarkRoomReady(RoomCode);
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        var response = ok.Value.ShouldBeOfType<ReadyResponse>();
+        response.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void MarkRoomReady_RoomNotFound_ReturnsNotFound()
+    {
+        SetSessionTokenHeader(SessionToken);
+        _roomManager.MarkRoomReady(RoomCode, SessionToken)
+            .Returns(RoomReadyResult.NotFound());
+
+        var result = _sut.MarkRoomReady(RoomCode);
+
+        var notFound = result.Result.ShouldBeOfType<NotFoundObjectResult>();
+        var response = notFound.Value.ShouldBeOfType<ReadyResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomNotFound);
+    }
+
+    [Fact]
+    public void MarkRoomReady_RoomExpired_ReturnsConflict()
+    {
+        SetSessionTokenHeader(SessionToken);
+        _roomManager.MarkRoomReady(RoomCode, SessionToken)
+            .Returns(RoomReadyResult.Expired());
+
+        var result = _sut.MarkRoomReady(RoomCode);
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<ReadyResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomExpired);
+    }
+
+    [Fact]
+    public void MarkRoomReady_NotHost_ReturnsConflict()
+    {
+        SetSessionTokenHeader(SessionToken);
+        _roomManager.MarkRoomReady(RoomCode, SessionToken)
+            .Returns(RoomReadyResult.NotHost());
+
+        var result = _sut.MarkRoomReady(RoomCode);
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<ReadyResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.NotHost);
+    }
+
+    [Fact]
+    public void MarkRoomReady_InvalidRoomState_ReturnsConflict()
+    {
+        SetSessionTokenHeader(SessionToken);
+        _roomManager.MarkRoomReady(RoomCode, SessionToken)
+            .Returns(RoomReadyResult.InvalidState());
+
+        var result = _sut.MarkRoomReady(RoomCode);
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<ReadyResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.InvalidRoomState);
+    }
+
+    #endregion
+
     #region RemoveMember
 
     [Fact]

--- a/tests/MakaMek.Hub.Tests/Rooms/RoomsControllerTests.cs
+++ b/tests/MakaMek.Hub.Tests/Rooms/RoomsControllerTests.cs
@@ -1,0 +1,344 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Sanet.MakaMek.Hub.Controllers;
+using Sanet.MakaMek.Hub.Contracts;
+using Sanet.MakaMek.Hub.Rooms;
+using Shouldly;
+
+namespace Sanet.MakaMek.Hub.Tests.Rooms;
+
+public class RoomsControllerTests
+{
+    private readonly IRoomManager _roomManager = Substitute.For<IRoomManager>();
+    private readonly RoomsController _sut;
+
+    private static readonly Guid PlayerId = Guid.NewGuid();
+    private const string SessionToken = "test-session-token";
+    private const string RoomCode = "ABC123";
+
+    public RoomsControllerTests()
+    {
+        _sut = new RoomsController(_roomManager)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
+    }
+
+    #region JoinRoom
+
+    [Fact]
+    public void JoinRoom_ValidRequest_ReturnsOk()
+    {
+        var room = CreateRoom();
+        var session = new RoomSession(SessionToken, RoomCode, PlayerId, RoomRole.Client, DateTimeOffset.UtcNow);
+        _roomManager.JoinRoom(RoomCode, "Grace", PlayerId)
+            .Returns(RoomJoinResult.Joined(room, session));
+
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("Grace", PlayerId));
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        var response = ok.Value.ShouldBeOfType<JoinResponse>();
+        response.Success.ShouldBeTrue();
+        response.SessionToken.ShouldBe(SessionToken);
+    }
+
+    [Fact]
+    public void JoinRoom_RoomNotFound_ReturnsNotFound()
+    {
+        _roomManager.JoinRoom(RoomCode, "Grace", PlayerId)
+            .Returns(RoomJoinResult.NotFound());
+
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("Grace", PlayerId));
+
+        var notFound = result.Result.ShouldBeOfType<NotFoundObjectResult>();
+        var response = notFound.Value.ShouldBeOfType<JoinResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomNotFound);
+    }
+
+    [Fact]
+    public void JoinRoom_RoomExpired_ReturnsConflict()
+    {
+        _roomManager.JoinRoom(RoomCode, "Grace", PlayerId)
+            .Returns(RoomJoinResult.Expired());
+
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("Grace", PlayerId));
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<JoinResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomExpired);
+    }
+
+    [Fact]
+    public void JoinRoom_HostNotReady_ReturnsConflict()
+    {
+        _roomManager.JoinRoom(RoomCode, "Grace", PlayerId)
+            .Returns(RoomJoinResult.NotReady());
+
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("Grace", PlayerId));
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<JoinResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.HostNotReady);
+    }
+
+    [Fact]
+    public void JoinRoom_HostPlayerIdConflict_ReturnsConflict()
+    {
+        _roomManager.JoinRoom(RoomCode, "Grace", PlayerId)
+            .Returns(RoomJoinResult.HostPlayerIdConflict());
+
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("Grace", PlayerId));
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<JoinResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.HostPlayerIdConflict);
+    }
+
+    [Fact]
+    public void JoinRoom_RoomFull_ReturnsConflict()
+    {
+        _roomManager.JoinRoom(RoomCode, "Grace", PlayerId)
+            .Returns(RoomJoinResult.Full());
+
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("Grace", PlayerId));
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<JoinResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomFull);
+    }
+
+    [Fact]
+    public void JoinRoom_EmptyPlayerName_ReturnsValidationProblem()
+    {
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("", PlayerId));
+
+        result.Result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void JoinRoom_EmptyPlayerId_ReturnsValidationProblem()
+    {
+        var result = _sut.JoinRoom(RoomCode, new JoinRequest("Grace", Guid.Empty));
+
+        result.Result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    #endregion
+
+    #region CloseRoom
+
+    [Fact]
+    public void CloseRoom_ValidRequest_ReturnsOk()
+    {
+        SetAuthorizationHeader(SessionToken);
+        _roomManager.CloseRoom(RoomCode, SessionToken)
+            .Returns(RoomCloseResult.Closed());
+
+        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        var response = ok.Value.ShouldBeOfType<CloseResponse>();
+        response.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CloseRoom_MissingSessionToken_ReturnsValidationProblem()
+    {
+        var result = _sut.CloseRoom(RoomCode, new CloseRequest(""));
+
+        result.Result.ShouldBeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public void CloseRoom_RoomNotFound_ReturnsNotFound()
+    {
+        SetAuthorizationHeader(SessionToken);
+        _roomManager.CloseRoom(RoomCode, SessionToken)
+            .Returns(RoomCloseResult.NotFound());
+
+        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+
+        var notFound = result.Result.ShouldBeOfType<NotFoundObjectResult>();
+        var response = notFound.Value.ShouldBeOfType<CloseResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomNotFound);
+    }
+
+    [Fact]
+    public void CloseRoom_RoomExpired_ReturnsConflict()
+    {
+        SetAuthorizationHeader(SessionToken);
+        _roomManager.CloseRoom(RoomCode, SessionToken)
+            .Returns(RoomCloseResult.Expired());
+
+        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<CloseResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomExpired);
+    }
+
+    [Fact]
+    public void CloseRoom_NotHost_ReturnsConflict()
+    {
+        SetAuthorizationHeader(SessionToken);
+        _roomManager.CloseRoom(RoomCode, SessionToken)
+            .Returns(RoomCloseResult.NotHost());
+
+        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<CloseResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.NotHost);
+    }
+
+    [Fact]
+    public void CloseRoom_InvalidRoomState_ReturnsConflict()
+    {
+        SetAuthorizationHeader(SessionToken);
+        _roomManager.CloseRoom(RoomCode, SessionToken)
+            .Returns(RoomCloseResult.InvalidState());
+
+        var result = _sut.CloseRoom(RoomCode, new CloseRequest(SessionToken));
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<CloseResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.InvalidRoomState);
+    }
+
+    #endregion
+
+    #region RemoveMember
+
+    [Fact]
+    public void RemoveMember_MissingAuthorization_ReturnsUnauthorized()
+    {
+        var targetId = Guid.NewGuid();
+
+        var result = _sut.RemoveMember(RoomCode, targetId);
+
+        result.Result.ShouldBeOfType<UnauthorizedResult>();
+    }
+
+    [Fact]
+    public void RemoveMember_ValidRequest_ReturnsOk()
+    {
+        SetAuthorizationHeader(SessionToken);
+        var targetId = Guid.NewGuid();
+        _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
+            .Returns(RoomRemoveMemberResult.Removed());
+
+        var result = _sut.RemoveMember(RoomCode, targetId);
+
+        var ok = result.Result.ShouldBeOfType<OkObjectResult>();
+        var response = ok.Value.ShouldBeOfType<RemoveMemberResponse>();
+        response.Success.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void RemoveMember_RoomNotFound_ReturnsNotFound()
+    {
+        SetAuthorizationHeader(SessionToken);
+        var targetId = Guid.NewGuid();
+        _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
+            .Returns(RoomRemoveMemberResult.NotFound());
+
+        var result = _sut.RemoveMember(RoomCode, targetId);
+
+        var notFound = result.Result.ShouldBeOfType<NotFoundObjectResult>();
+        var response = notFound.Value.ShouldBeOfType<RemoveMemberResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomNotFound);
+    }
+
+    [Fact]
+    public void RemoveMember_MemberNotFound_ReturnsNotFound()
+    {
+        SetAuthorizationHeader(SessionToken);
+        var targetId = Guid.NewGuid();
+        _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
+            .Returns(RoomRemoveMemberResult.MemberNotFound());
+
+        var result = _sut.RemoveMember(RoomCode, targetId);
+
+        var notFound = result.Result.ShouldBeOfType<NotFoundObjectResult>();
+        var response = notFound.Value.ShouldBeOfType<RemoveMemberResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.MemberNotFound);
+    }
+
+    [Fact]
+    public void RemoveMember_RoomExpired_ReturnsConflict()
+    {
+        SetAuthorizationHeader(SessionToken);
+        var targetId = Guid.NewGuid();
+        _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
+            .Returns(RoomRemoveMemberResult.Expired());
+
+        var result = _sut.RemoveMember(RoomCode, targetId);
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<RemoveMemberResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.RoomExpired);
+    }
+
+    [Fact]
+    public void RemoveMember_NotHost_ReturnsConflict()
+    {
+        SetAuthorizationHeader(SessionToken);
+        var targetId = Guid.NewGuid();
+        _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
+            .Returns(RoomRemoveMemberResult.NotHost());
+
+        var result = _sut.RemoveMember(RoomCode, targetId);
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<RemoveMemberResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.NotHost);
+    }
+
+    [Fact]
+    public void RemoveMember_CannotRemoveHost_ReturnsConflict()
+    {
+        SetAuthorizationHeader(SessionToken);
+        var targetId = Guid.NewGuid();
+        _roomManager.RemoveMember(RoomCode, SessionToken, targetId)
+            .Returns(RoomRemoveMemberResult.CannotRemoveHost());
+
+        var result = _sut.RemoveMember(RoomCode, targetId);
+
+        var conflict = result.Result.ShouldBeOfType<ConflictObjectResult>();
+        var response = conflict.Value.ShouldBeOfType<RemoveMemberResponse>();
+        response.Success.ShouldBeFalse();
+        response.Error!.Code.ShouldBe(HubErrorCode.CannotRemoveHost);
+    }
+
+    #endregion
+
+    private void SetAuthorizationHeader(string token)
+    {
+        _sut.ControllerContext.HttpContext.Request.Headers.Authorization = $"Bearer {token}";
+    }
+
+    private static Room CreateRoom()
+    {
+        var hostId = Guid.NewGuid();
+        var hostMember = new RoomMember(hostId, "Host", RoomRole.Host, DateTimeOffset.UtcNow);
+        var hostSession = new RoomSession("host-token", RoomCode, hostId, RoomRole.Host, DateTimeOffset.UtcNow.AddHours(2));
+        return new Room(RoomCode, hostMember, hostSession, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddHours(2));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes (Breaking)**
  * Room lifecycle endpoints now require the session token via the `Session-Token` request header (instead of request bodies).
  * Missing `Session-Token` now produces validation errors for close/ready operations.
  * Member removal also now relies on `Session-Token` for session lookup.
* **Tests**
  * Added and expanded controller/endpoint coverage for joining, closing, readiness, and member removal, including success and mapped error responses.
  * Updated test request helpers to use header-based session tokens.
* **Chores**
  * Updated diff coverage workflow action to `Cocodif@v0.2.1` and bumped NuGet version prefix to `0.62.8`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->