### PR TITLE
apply apikey to relay publisher

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.62.18</VersionPrefix>
+        <VersionPrefix>0.62.19</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/NetworkFragment.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/NetworkFragment.axaml
@@ -18,9 +18,11 @@
             <StackPanel Orientation="Horizontal" Spacing="12">
                 <RadioButton Content="{extensions:Localize 'Network_HostModeLan'}"
                              IsChecked="{Binding IsLanMode, Mode=TwoWay}"
+                             IsEnabled="{Binding CanChangeHostMode}"
                              GroupName="HostMode"/>
                 <RadioButton Content="{extensions:Localize 'Network_HostModeOnline'}"
                              IsChecked="{Binding IsOnlineMode, Mode=TwoWay}"
+                             IsEnabled="{Binding CanChangeHostMode}"
                              GroupName="HostMode"/>
             </StackPanel>
         </StackPanel>
@@ -33,10 +35,6 @@
             <TextBlock Text="{extensions:Localize 'Network_ShareAddress'}"
                        Classes="bodySmall"
                        FontStyle="Italic"/>
-            <Button Command="{Binding RestartLanServerCommand}"
-                    Content="{extensions:Localize 'Network_RestartServer'}"
-                    HorizontalAlignment="Left"
-                    Margin="0,6,0,0"/>
         </StackPanel>
 
         <StackPanel Classes="formGroup" IsVisible="{Binding IsOnlineMode}">
@@ -45,8 +43,6 @@
                 <SelectableTextBlock Text="{Binding RoomCode}"/>
             </Border>
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,6,0,0">
-                <Button Command="{Binding RestartLanServerCommand}"
-                        Content="{extensions:Localize 'Network_RestartServer'}"/>
                 <Button Command="{Binding CopyRoomCodeCommand}"
                         Content="{extensions:Localize 'Network_CopyRoomCode'}"/>
             </StackPanel>

--- a/src/MakaMek.Core/MakaMek.Core.csproj
+++ b/src/MakaMek.Core/MakaMek.Core.csproj
@@ -21,7 +21,7 @@
       <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
       <PackageReference Include="Sanet.Transport.Rx" Version="1.1.1" />
-      <PackageReference Include="Sanet.Transport.SignalR.Client" Version="1.2.1" />
+      <PackageReference Include="Sanet.Transport.SignalR.Client" Version="1.2.2" />
       <PackageReference Include="System.Reactive" Version="7.0.0" />
     </ItemGroup>
     

--- a/src/MakaMek.Core/Models/Game/GameConnector.cs
+++ b/src/MakaMek.Core/Models/Game/GameConnector.cs
@@ -122,6 +122,7 @@ public class GameConnector : IGameConnector
                 roomCode,
                 joinResult.SessionToken,
                 joinResult.HostId.Value,
+                _relayOptions.Value.ApiKey,
                 cancellationToken);
 
             // Throw if cancelled; the cancellation catch block below is the single

--- a/src/MakaMek.Core/Models/Game/GameManager.cs
+++ b/src/MakaMek.Core/Models/Game/GameManager.cs
@@ -164,6 +164,7 @@ public class GameManager : IGameManager
                 createResult.RoomCode,
                 createResult.SessionToken,
                 createResult.HostId.Value,
+                _relayOptions?.Value.ApiKey ?? string.Empty,
                 cancellationToken);
 
             _commandPublisher.Adapter.AddPublisher(publisher);

--- a/src/MakaMek.Core/Services/Transport/Relay/IRelayPublisherFactory.cs
+++ b/src/MakaMek.Core/Services/Transport/Relay/IRelayPublisherFactory.cs
@@ -16,11 +16,13 @@ public interface IRelayPublisherFactory
     /// <param name="roomCode">Room code the host has created.</param>
     /// <param name="sessionToken">Host session token returned when the room was created.</param>
     /// <param name="expectedHostId">Id of the host this publisher is expected to act for.</param>
+    /// <param name="apiKey">API key required by the MakaMek Hub, if any.</param>
     /// <param name="cancellationToken">Token that cancels publisher creation and connection.</param>
     Task<RelayClientPublisher> CreateAsync(
         string hubUrl,
         string roomCode,
         string sessionToken,
         Guid expectedHostId,
+        string apiKey,
         CancellationToken cancellationToken = default);
 }

--- a/src/MakaMek.Core/Services/Transport/Relay/RelayPublisherFactory.cs
+++ b/src/MakaMek.Core/Services/Transport/Relay/RelayPublisherFactory.cs
@@ -13,6 +13,7 @@ public sealed class RelayPublisherFactory(ILoggerFactory loggerFactory) : IRelay
         string roomCode,
         string sessionToken,
         Guid expectedHostId,
+        string apiKey,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -23,7 +24,8 @@ public sealed class RelayPublisherFactory(ILoggerFactory loggerFactory) : IRelay
             roomCode,
             sessionToken,
             logger,
-            expectedHostId.ToString());
+            expectedHostId.ToString(),
+            apiKey);
 
         // StartAsync does not accept a token, so link one to abandon the publisher
         // promptly if the caller cancels while the connection is being established.

--- a/src/MakaMek.Hub/README.md
+++ b/src/MakaMek.Hub/README.md
@@ -62,8 +62,9 @@ The container listens on `http://localhost:8080` in `Production` mode.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health` | Health check (returns status, service name, version) |
-| GET | `/api/rooms` | List active rooms (requires API key) |
-| POST | `/api/rooms` | Create a room (requires API key) |
-| POST | `/api/rooms/{roomId}/join` | Join a room by code (requires API key) |
-| DELETE | `/api/rooms/{roomId}` | Close a room (requires API key) |
-| WebSocket | `/relay` | SignalR hub for game relay (requires `apiKey` and `sessionToken` query parameters) |
+| POST | `/api/rooms` | Create a room (requires `X-Api-Key` header) |
+| POST | `/api/rooms/{roomCode}/join` | Join a room by code (requires `X-Api-Key` header, rate-limited per IP) |
+| POST | `/api/rooms/{roomCode}/ready` | Mark a room ready to accept joiners (requires `X-Api-Key` + `Session-Token` header, host only) |
+| POST | `/api/rooms/{roomCode}/close` | Close a room (requires `X-Api-Key` + `Session-Token` header, host only) |
+| DELETE | `/api/rooms/{roomCode}/members/{playerId}` | Remove a member (requires `X-Api-Key` + `Session-Token` header, host only) |
+| WebSocket | `/hubs/relay` | SignalR hub for game relay (requires `apiKey` and `sessionToken` query parameters) |

--- a/src/MakaMek.Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Localization/FakeLocalizationService.cs
@@ -456,7 +456,6 @@ public class FakeLocalizationService : ILocalizationService
         ["Network_HostModeOnline"] = "Online",
         ["Network_RoomCode"] = "Room Code",
         ["Network_CopyRoomCode"] = "Copy",
-        ["Network_RestartServer"] = "Restart Server",
         ["Hosting_Starting"] = "Starting hosted game...",
         ["Hosting_RoomReady"] = "Game is running — share the room code above",
         ["Hosting_Failed"] = "Failed to start the hosted game.",

--- a/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
@@ -336,6 +336,7 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
         if (_initCts is not null)
         {
             await _initCts.CancelAsync();
+            if (HasJoinedPlayers) return; // A player joined while cancellation was pending; keep the live lobby
         }
         _initCts?.Dispose();
         _initCts = new CancellationTokenSource();
@@ -468,9 +469,14 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
 
     public override void AttachHandlers()
     {
+        if (HasJoinedPlayers)
+        {
+            base.AttachHandlers();
+            return; // Don't reset hosting state or restart hosting while players are connected
+        }
+
         ResetHostingState();
         base.AttachHandlers();
-        if (HasJoinedPlayers) return; // Don't restart hosting while players are connected
         _initCts?.Cancel();
         _initCts?.Dispose();
         _initCts = new CancellationTokenSource();

--- a/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
@@ -67,7 +67,6 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
         MapConfig = new MapConfigViewModel(mapPreviewRenderer, mapFactory, mapResourceProvider, fileService, logger, dispatcherService, localizationService);
         AddPlayerCommand = new AsyncCommand(() => AddPlayer());
         AddBotCommand = new AsyncCommand(()=>AddPlayer(controlType: PlayerControlType.Bot));
-        RestartLanServerCommand = new AsyncCommand(CancelAndRestartServer);
         CopyRoomCodeCommand = new AsyncCommand(CopyRoomCode, _ => RoomCode != null);
     }
 
@@ -143,6 +142,7 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
                     playerWithStatusUpdate.Player.Status = statusCmd.PlayerStatus;
                     playerWithStatusUpdate.RefreshStatus();
                     NotifyPropertyChanged(nameof(CanStartGame));
+                    NotifyPropertyChanged(nameof(CanChangeHostMode));
                 }
                 break;
             
@@ -157,6 +157,7 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
                         existingPlayerVm.Player.Status = PlayerStatus.Joined;
                         existingPlayerVm.RefreshStatus();
                         NotifyPropertyChanged(nameof(CanStartGame));
+                        NotifyPropertyChanged(nameof(CanChangeHostMode));
                     }
                     // Else: Remote player sending join again? Ignore.
                 }
@@ -235,12 +236,23 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
     private void SetHostMode(HostMode mode)
     {
         if (_hostMode == mode) return; // Reject no-op when unchanged
+        if (HasJoinedPlayers) return; // Reject mode change while players are connected
 
         _hostMode = mode;
         NotifyPropertyChanged(nameof(IsLanMode));
         NotifyPropertyChanged(nameof(IsOnlineMode));
         ClearHostingState();
+        CancelAndRestartServer().SafeFireAndForget(
+            ex => _logger.LogError(ex, "Error restarting server after host mode change"));
     }
+
+    /// <summary>
+    /// Gets whether the host mode can still be changed. Once any player has joined,
+    /// the lobby must not be re-created because it would disconnect the joined players.
+    /// </summary>
+    public bool CanChangeHostMode => !HasJoinedPlayers;
+
+    private bool HasJoinedPlayers => _players.Any(p => p.Player.Status is PlayerStatus.Joined or PlayerStatus.Ready);
 
     /// <summary>
     /// Gets the room code of the online lobby, if hosting online.
@@ -310,23 +322,22 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
     }
 
     /// <summary>
-    /// Restarts hosting for the currently selected mode.
-    /// </summary>
-    public ICommand RestartLanServerCommand { get; }
-
-    /// <summary>
     /// Copies the room code to the clipboard (enabled while an online room exists).
     /// </summary>
     public ICommand CopyRoomCodeCommand { get; }
 
+    /// <summary>
+    /// Restarts hosting for the currently selected mode. No-op while any player has joined.
+    /// </summary>
     public async Task CancelAndRestartServer()
     {
+        if (HasJoinedPlayers) return;
+
         if (_initCts is not null)
         {
             await _initCts.CancelAsync();
         }
         _initCts?.Dispose();
-        IsHosting = false;
         _initCts = new CancellationTokenSource();
 
         try
@@ -343,26 +354,12 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
             }
             if (_initCts.IsCancellationRequested || _isDisposed)
                 return;
-
-            if (HasHostedGameStarted)
-            {
-                await NavigateToBattleMap();
-            }
-            else
-            {
-                HostingError = _gameManager.OnlineError?.Message
-                    ?? _localizationService.GetString("Hosting_Failed");
-            }
         }
         finally
         {
             IsHosting = false;
         }
     }
-
-    private bool HasHostedGameStarted => IsOnlineMode
-        ? _gameManager is { IsOnlineServerRunning: true, RoomCode: not null }
-        : _gameManager.ServerGameId != null;
 
     private Task CopyRoomCode()
     {
@@ -473,6 +470,7 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
     {
         ResetHostingState();
         base.AttachHandlers();
+        if (HasJoinedPlayers) return; // Don't restart hosting while players are connected
         _initCts?.Cancel();
         _initCts?.Dispose();
         _initCts = new CancellationTokenSource();

--- a/tests/MakaMek.Core.Tests/Models/Game/GameConnectorTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/GameConnectorTests.cs
@@ -42,7 +42,7 @@ public class GameConnectorTests : IDisposable
             _logger,
             _relayRoomClient,
             _relayPublisherFactory,
-            Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local" }));
+            Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local", ApiKey = "api-key" }));
     }
 
     private GameConnector CreateSutWithoutRelay() => new(
@@ -61,7 +61,7 @@ public class GameConnectorTests : IDisposable
         _relayRoomClient.JoinAsync(roomCode, playerId, "Player", Arg.Any<CancellationToken>())
             .Returns(RoomJoinResult.Succeeded(roomCode, sessionToken, "Player", playerId, hostId));
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
 
         await sut.JoinOnline(roomCode, playerId, "Player");
@@ -193,7 +193,7 @@ public class GameConnectorTests : IDisposable
         _sut.OnlineError.ShouldBe(error);
         _sut.IsConnected.ShouldBeFalse();
         await _relayPublisherFactory.DidNotReceive().CreateAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
         _transportAdapter.DidNotReceive().AddPublisher(Arg.Any<ITransportPublisher>());
     }
 
@@ -225,7 +225,7 @@ public class GameConnectorTests : IDisposable
         _relayRoomClient.JoinAsync(roomCode, playerId, "Player", Arg.Any<CancellationToken>())
             .Returns(RoomJoinResult.Succeeded(roomCode, sessionToken, "Player", playerId, hostId));
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
 
         // Act
@@ -233,7 +233,7 @@ public class GameConnectorTests : IDisposable
 
         // Assert
         await _relayPublisherFactory.Received(1).CreateAsync(
-            "http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>());
+            "http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>());
         await _transportAdapter.Received(1).ClearPublishers();
         _transportAdapter.Received(1).AddPublisher(publisher);
         _transportAdapter.Received(1).RegisterDisconnectHandler(Arg.Any<Action<ITransportPublisher>>());
@@ -248,7 +248,7 @@ public class GameConnectorTests : IDisposable
         var playerId = Guid.NewGuid();
         _relayRoomClient.JoinAsync("ABCDEF", playerId, "Player", Arg.Any<CancellationToken>())
             .Returns(RoomJoinResult.Succeeded("ABCDEF", "session-token", "Player", playerId, Guid.NewGuid()));
-        _relayPublisherFactory.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("boom"));
 
         // Act
@@ -273,7 +273,7 @@ public class GameConnectorTests : IDisposable
             .Returns(RoomJoinResult.Succeeded(roomCode, sessionToken, "Player", playerId, hostId));
 
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
 
         // Make the adapter throw when adding the publisher to trigger the failure
@@ -304,10 +304,10 @@ public class GameConnectorTests : IDisposable
 
         // Create a publisher that throws when disposed
         var throwingPublisher = Substitute.For<RelayClientPublisher>(
-            "http://hub.local/hubs/relay", roomCode, sessionToken, NullLogger<RelayClientPublisher>.Instance, hostId.ToString());
+            "http://hub.local/hubs/relay", roomCode, sessionToken, NullLogger<RelayClientPublisher>.Instance, hostId.ToString(), "api-key");
         throwingPublisher.When(x => x.DisposeAsync())
             .Throw(new InvalidOperationException("dispose boom"));
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(throwingPublisher));
 
         // Make the adapter throw when adding the publisher to trigger the failure path
@@ -351,9 +351,9 @@ public class GameConnectorTests : IDisposable
             .Returns(RoomJoinResult.Succeeded(roomCode, sessionToken, "Player", playerId, hostId));
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
         using var cts = new CancellationTokenSource();
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
-        _relayPublisherFactory.When(f => f.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>()))
+        _relayPublisherFactory.When(f => f.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>()))
             .Do(_ => cts.Cancel());
 
         // Act & Assert
@@ -379,11 +379,11 @@ public class GameConnectorTests : IDisposable
             .Returns(RoomJoinResult.Succeeded(roomCode, sessionToken, "Player", playerId, hostId));
         using var cts = new CancellationTokenSource();
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
 
         // Cancel after CreateAsync completes
-        _relayPublisherFactory.When(f => f.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>()))
+        _relayPublisherFactory.When(f => f.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>()))
             .Do(_ => cts.Cancel());
 
         // Act & Assert
@@ -407,7 +407,7 @@ public class GameConnectorTests : IDisposable
             _logger,
             _relayRoomClient,
             _relayPublisherFactory,
-            Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local" }));
+            Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local", ApiKey = "api-key" }));
 
         var playerId = Guid.NewGuid();
         const string roomCode = "ABCDEF";
@@ -416,7 +416,7 @@ public class GameConnectorTests : IDisposable
         _relayRoomClient.JoinAsync(roomCode, playerId, "Player", Arg.Any<CancellationToken>())
             .Returns(RoomJoinResult.Succeeded(roomCode, sessionToken, "Player", playerId, hostId));
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
 
         Action<ITransportPublisher>? disconnectHandler = null;
@@ -449,7 +449,7 @@ public class GameConnectorTests : IDisposable
             _logger,
             _relayRoomClient,
             _relayPublisherFactory,
-            Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local" }));
+            Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local", ApiKey = "api-key" }));
 
         var playerId = Guid.NewGuid();
         const string roomCode = "ABCDEF";
@@ -458,7 +458,7 @@ public class GameConnectorTests : IDisposable
         _relayRoomClient.JoinAsync(roomCode, playerId, "Player", Arg.Any<CancellationToken>())
             .Returns(RoomJoinResult.Succeeded(roomCode, sessionToken, "Player", playerId, hostId));
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        _relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
 
         Action<ITransportPublisher>? disconnectHandler = null;

--- a/tests/MakaMek.Core.Tests/Models/Game/GameManagerTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/GameManagerTests.cs
@@ -105,7 +105,7 @@ public class GameManagerTests : IDisposable
         networkHostService,
         relayRoomClient,
         relayPublisherFactory,
-        Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local" }));
+        Options.Create(new RelayClientOptions { BaseUrl = "http://hub.local", ApiKey = "api-key" }));
 
     private static RelayClientPublisher CreateRelayPublisher(string roomCode, string sessionToken, Guid hostId) =>
         new("http://hub.local/hubs/relay", roomCode, sessionToken, NullLogger<RelayClientPublisher>.Instance, hostId.ToString());
@@ -452,7 +452,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.ReadyAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory, networkHostService);
 
@@ -485,7 +485,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
 
@@ -511,7 +511,7 @@ public class GameManagerTests : IDisposable
         var hostId = Guid.NewGuid();
         relayRoomClient.CreateAsync(playerId, "Host", Arg.Any<CancellationToken>())
             .Returns(RoomCreateResult.Succeeded(roomCode, sessionToken, "Host", playerId, hostId));
-        relayPublisherFactory.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Throws(new InvalidOperationException("boom"));
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
@@ -545,7 +545,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .ThrowsAsync(new HttpRequestException("relay unreachable"));
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
 
@@ -573,7 +573,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.ReadyAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
         await sut.InitializeLobbyOnline(playerId, "Host");
@@ -601,7 +601,7 @@ public class GameManagerTests : IDisposable
             .Returns(RoomOperationResult.Succeeded());
         var firstPublisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
         var secondPublisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(firstPublisher), Task.FromResult(secondPublisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
 
@@ -632,7 +632,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
         using var cts = new CancellationTokenSource();
@@ -665,7 +665,7 @@ public class GameManagerTests : IDisposable
             .Returns(RoomOperationResult.Succeeded());
         var firstPublisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
         var secondPublisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(firstPublisher), Task.FromResult(secondPublisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
 
@@ -718,7 +718,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
         await sut.InitializeLobbyOnline(playerId, "Host");
@@ -750,7 +750,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
         await sut.InitializeLobbyOnline(playerId, "Host");
@@ -781,7 +781,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("boom"));
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var logger = Substitute.For<ILogger<GameManager>>();
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory, logger: logger);
@@ -818,7 +818,7 @@ public class GameManagerTests : IDisposable
         relayRoomClient.CloseAsync(roomCode, sessionToken, Arg.Any<CancellationToken>())
             .Returns(RoomOperationResult.Succeeded());
         var publisher = CreateRelayPublisher(roomCode, sessionToken, hostId);
-        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, Arg.Any<CancellationToken>())
+        relayPublisherFactory.CreateAsync("http://hub.local/hubs/relay", roomCode, sessionToken, hostId, "api-key", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(publisher));
         var sut = CreateSutWithRelay(relayRoomClient, relayPublisherFactory);
         await sut.InitializeLobbyOnline(playerId, "Host");

--- a/tests/MakaMek.Core.Tests/Services/Transport/Relay/RelayPublisherFactoryTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Transport/Relay/RelayPublisherFactoryTests.cs
@@ -12,6 +12,7 @@ public class RelayPublisherFactoryTests
 {
     private const string RoomCode = "ABCDEF";
     private const string SessionToken = "session-token";
+    private const string ApiKey = "api-key";
 
     private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(10);
 
@@ -32,7 +33,7 @@ public class RelayPublisherFactoryTests
         await cts.CancelAsync();
 
         var exception = await Should.ThrowAsync<OperationCanceledException>(
-            () => _sut.CreateAsync("http://127.0.0.1:1/hubs/relay", RoomCode, SessionToken, Guid.NewGuid(), cts.Token));
+            () => _sut.CreateAsync("http://127.0.0.1:1/hubs/relay", RoomCode, SessionToken, Guid.NewGuid(), ApiKey, cts.Token));
 
         exception.CancellationToken.ShouldBe(cts.Token);
     }
@@ -47,7 +48,7 @@ public class RelayPublisherFactoryTests
 
         await WithTimeout(
             Should.ThrowAsync<Exception>(
-                () => _sut.CreateAsync($"http://127.0.0.1:{port}/hubs/relay", RoomCode, SessionToken, Guid.NewGuid())));
+                () => _sut.CreateAsync($"http://127.0.0.1:{port}/hubs/relay", RoomCode, SessionToken, Guid.NewGuid(), ApiKey)));
     }
 
     [Fact]
@@ -57,7 +58,7 @@ public class RelayPublisherFactoryTests
         var hubUrl = host.Urls.First().TrimEnd('/') + "/hubs/relay";
 
         var publisher = await WithTimeout(
-            _sut.CreateAsync(hubUrl, RoomCode, SessionToken, Guid.NewGuid()));
+            _sut.CreateAsync(hubUrl, RoomCode, SessionToken, Guid.NewGuid(), ApiKey));
 
         await using var _ = publisher;
         publisher.IsConnected.ShouldBeTrue();

--- a/tests/MakaMek.Core.Tests/Services/Transport/Relay/RelayPublisherFactoryTests.cs
+++ b/tests/MakaMek.Core.Tests/Services/Transport/Relay/RelayPublisherFactoryTests.cs
@@ -54,7 +54,7 @@ public class RelayPublisherFactoryTests
     [Fact]
     public async Task CreateAsync_WhenHubReachable_ReturnsConnectedPublisher()
     {
-        await using var host = await TestRelayHubHost.StartAsync();
+        await using var host = await TestRelayHubHost.StartAsync(ApiKey);
         var hubUrl = host.Urls.First().TrimEnd('/') + "/hubs/relay";
 
         var publisher = await WithTimeout(
@@ -62,6 +62,28 @@ public class RelayPublisherFactoryTests
 
         await using var _ = publisher;
         publisher.IsConnected.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenHubRejectsWrongApiKey_Throws()
+    {
+        await using var host = await TestRelayHubHost.StartAsync(ApiKey);
+        var hubUrl = host.Urls.First().TrimEnd('/') + "/hubs/relay";
+
+        await WithTimeout(
+            Should.ThrowAsync<Exception>(
+                () => _sut.CreateAsync(hubUrl, RoomCode, SessionToken, Guid.NewGuid(), "wrong-key")));
+    }
+
+    [Fact]
+    public async Task CreateAsync_WhenHubRequiresApiKey_AndNoneSupplied_Throws()
+    {
+        await using var host = await TestRelayHubHost.StartAsync(ApiKey);
+        var hubUrl = host.Urls.First().TrimEnd('/') + "/hubs/relay";
+
+        await WithTimeout(
+            Should.ThrowAsync<Exception>(
+                () => _sut.CreateAsync(hubUrl, RoomCode, SessionToken, Guid.NewGuid(), string.Empty)));
     }
 
     private static async Task<T> WithTimeout<T>(Task<T> task)

--- a/tests/MakaMek.Core.Tests/Services/Transport/Relay/TestRelayHubHost.cs
+++ b/tests/MakaMek.Core.Tests/Services/Transport/Relay/TestRelayHubHost.cs
@@ -1,13 +1,15 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Sanet.MakaMek.Core.Tests.Services.Transport.Relay;
 
 /// <summary>
-/// Hub that accepts any connection, standing in for the remote relay hub
-/// while exercising the real SignalR WebSocket handshake.
+/// Hub that stands in for the remote relay hub while exercising the real
+/// SignalR WebSocket handshake, rejecting connections whose apiKey query
+/// parameter does not match the configured key.
 /// </summary>
 public sealed class TestRelayHub : Hub
 {
@@ -15,13 +17,23 @@ public sealed class TestRelayHub : Hub
 
 internal static class TestRelayHubHost
 {
-    public static async Task<WebApplication> StartAsync()
+    public static async Task<WebApplication> StartAsync(string requiredApiKey)
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseUrls("http://127.0.0.1:0");
         builder.Services.AddSignalR();
         var app = builder.Build();
         app.UseWebSockets();
+        app.Use(async (context, next) =>
+        {
+            if (context.Request.Query["apiKey"].ToString() != requiredApiKey)
+            {
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                return;
+            }
+
+            await next(context);
+        });
         app.MapHub<TestRelayHub>("/hubs/relay");
         await app.StartAsync();
         return app;

--- a/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
@@ -908,7 +908,6 @@ public class FakeLocalizationServiceTests
     [InlineData("Network_HostModeOnline", "Online")]
     [InlineData("Network_RoomCode", "Room Code")]
     [InlineData("Network_CopyRoomCode", "Copy")]
-    [InlineData("Network_RestartServer", "Restart Server")]
     [InlineData("Hosting_Starting", "Starting hosted game...")]
     [InlineData("Hosting_RoomReady", "Game is running — share the room code above")]
     [InlineData("Hosting_Failed", "Failed to start the hosted game.")]

--- a/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
@@ -394,7 +394,7 @@ public class StartNewGameViewModelTests
     }
 
     [Fact]
-    public async Task InitializeLobbyAndSubscribe_WhenOnlineModeSucceeds_SetsRoomCodeAndCreatesLocalGame()
+    public async Task SettingOnlineMode_AutoStartsOnlineHosting_SetsRoomCodeAndCreatesLocalGame()
     {
         var gameManager = Substitute.For<IGameManager>();
         gameManager.InitializeLobbyOnline(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -405,9 +405,8 @@ public class StartNewGameViewModelTests
         var commandPublisher = Substitute.For<ICommandPublisher>();
         _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
         var sut = CreateSut(gameManager, commandPublisher);
-        sut.IsOnlineMode = true;
 
-        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+        sut.IsOnlineMode = true;
 
         sut.RoomCode.ShouldBe("ABCDEF");
         sut.HostingError.ShouldBeNull();
@@ -441,26 +440,29 @@ public class StartNewGameViewModelTests
     }
 
     [Fact]
-    public async Task InitializeLobbyAndSubscribe_WhenOnlineModeCancelled_ReturnsWithoutSettingRoomCode()
+    public async Task InitializeLobbyAndSubscribe_WhenOnlineModeCancelled_DoesNotChangeState()
     {
         var gameManager = Substitute.For<IGameManager>();
         gameManager.InitializeLobbyOnline(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.CompletedTask);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
         var commandPublisher = Substitute.For<ICommandPublisher>();
         var sut = CreateSut(gameManager, commandPublisher);
         sut.IsOnlineMode = true;
+        sut.RoomCode.ShouldBe("ABCDEF");
         using var cts = new CancellationTokenSource();
         await cts.CancelAsync();
 
         await sut.InitializeLobbyAndSubscribe(cts.Token);
 
-        sut.RoomCode.ShouldBeNull();
+        sut.RoomCode.ShouldBe("ABCDEF");
         sut.HostingError.ShouldBeNull();
-        commandPublisher.DidNotReceive().Subscribe(Arg.Any<Action<IGameCommand>>());
     }
 
     [Fact]
-    public async Task CancelAndRestartServer_WhenOnlineSucceeds_NavigatesToBattleMap()
+    public async Task CancelAndRestartServer_WhenOnlineSucceeds_SetsRoomCodeAndDoesNotNavigate()
     {
         var gameManager = Substitute.For<IGameManager>();
         gameManager.InitializeLobbyOnline(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -477,7 +479,9 @@ public class StartNewGameViewModelTests
 
         await sut.CancelAndRestartServer();
 
-        await _navigationService.Received(1).NavigateToViewModelAsync(_battleMapViewModel);
+        sut.RoomCode.ShouldBe("ABCDEF");
+        sut.HostingError.ShouldBeNull();
+        await _navigationService.DidNotReceive().NavigateToViewModelAsync(_battleMapViewModel);
     }
 
     [Fact]
@@ -664,9 +668,79 @@ public class StartNewGameViewModelTests
     }
 
     [Fact]
-    public void RestartLanServerCommand_IsNotNull()
+    public void CanChangeHostMode_WhenNoPlayersJoined_IsTrue()
     {
-        _sut.RestartLanServerCommand.ShouldNotBeNull();
+        _sut.CanChangeHostMode.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void CanChangeHostMode_WhenPlayerJoined_IsFalse()
+    {
+        _sut.Players.First().Player.Status = PlayerStatus.Joined;
+
+        _sut.CanChangeHostMode.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task SetHostMode_WhenPlayerJoined_DoesNotChangeMode()
+    {
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.InitializeLobbyOnline(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.AddPlayerCommand!.Execute(null);
+        sut.Players.First().Player.Status = PlayerStatus.Joined;
+
+        sut.IsOnlineMode = true;
+
+        sut.IsOnlineMode.ShouldBeFalse();
+        sut.IsLanMode.ShouldBeTrue();
+        sut.CanChangeHostMode.ShouldBeFalse();
+        await gameManager.DidNotReceive().InitializeLobbyOnline(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelAndRestartServer_WhenPlayerJoined_DoesNotRestart()
+    {
+        var gameManager = Substitute.For<IGameManager>();
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.AddPlayerCommand!.Execute(null);
+        sut.Players.First().Player.Status = PlayerStatus.Ready;
+
+        await sut.CancelAndRestartServer();
+
+        await gameManager.DidNotReceive().InitializeLobby();
+        await gameManager.DidNotReceive().InitializeLobbyOnline(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleServerCommand_RemotePlayerJoin_DisablesHostModeChange()
+    {
+        await _sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+        var playerId = Guid.NewGuid();
+        var joinCommand = new JoinGameCommand
+        {
+            PlayerId = playerId,
+            PlayerName = "RemotePlayer",
+            Units = [MechFactoryTests.CreateDummyMechData()],
+            Tint = "#00FF00",
+            GameOriginId = Guid.NewGuid(),
+            PilotAssignments = []
+        };
+
+        _sut.HandleServerCommand(joinCommand);
+        _sut.HandleServerCommand(new UpdatePlayerStatusCommand
+        {
+            PlayerId = playerId,
+            PlayerStatus = PlayerStatus.Joined,
+            GameOriginId = _serverGameId
+        });
+
+        _sut.CanChangeHostMode.ShouldBeFalse();
     }
 
     [Fact]

--- a/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
@@ -568,6 +568,33 @@ public class StartNewGameViewModelTests
     }
 
     [Fact]
+    public async Task AttachHandlers_WhenPlayerJoinedOnlineRoom_KeepsHostingStateAndRoomCode()
+    {
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.InitializeLobbyOnline(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.IsOnlineMode = true;
+        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+        sut.RoomCode.ShouldBe("ABCDEF");
+
+        sut.AddPlayerCommand!.Execute(null);
+        sut.Players.Last().Player.Status = PlayerStatus.Joined;
+
+        sut.AttachHandlers();
+
+        sut.IsOnlineMode.ShouldBeTrue();
+        sut.IsLanMode.ShouldBeFalse();
+        sut.RoomCode.ShouldBe("ABCDEF");
+        sut.HostingError.ShouldBeNull();
+    }
+
+    [Fact]
     public void HandleServerCommand_JoinGameCommand_AddsRemotePlayer_InvokesNoOpActions()
     {
         var playerId = Guid.NewGuid();
@@ -714,6 +741,61 @@ public class StartNewGameViewModelTests
 
         await gameManager.DidNotReceive().InitializeLobby();
         await gameManager.DidNotReceive().InitializeLobbyOnline(
+            Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CancelAndRestartServer_WhenPlayerJoinsDuringCancellation_DoesNotRestartLobby()
+    {
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.ServerGameId.Returns(_serverGameId);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
+        var sut = CreateSut(gameManager, commandPublisher);
+
+        var playerId = Guid.NewGuid();
+        gameManager.InitializeLobbyOnline(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var ct = callInfo.ArgAt<CancellationToken>(2);
+                if (ct.CanBeCanceled)
+                {
+                    // Simulate a remote player joining while the in-flight init is being cancelled.
+                    ct.Register(() =>
+                    {
+                        sut.HandleServerCommand(new JoinGameCommand
+                        {
+                            PlayerId = playerId,
+                            PlayerName = "RemotePlayer",
+                            Units = [MechFactoryTests.CreateDummyMechData()],
+                            Tint = "#00FF00",
+                            GameOriginId = _serverGameId,
+                            PilotAssignments = []
+                        });
+                        sut.HandleServerCommand(new UpdatePlayerStatusCommand
+                        {
+                            PlayerId = playerId,
+                            PlayerStatus = PlayerStatus.Joined,
+                            GameOriginId = _serverGameId
+                        });
+                    });
+                }
+                return Task.CompletedTask;
+            });
+
+        sut.IsOnlineMode = true;
+        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+        sut.RoomCode.ShouldBe("ABCDEF");
+
+        await sut.CancelAndRestartServer();
+
+        sut.RoomCode.ShouldBe("ABCDEF");
+        sut.HostingError.ShouldBeNull();
+        sut.CanChangeHostMode.ShouldBeFalse();
+        await gameManager.Received(2).InitializeLobbyOnline(
             Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Online relay connections now use the configured API key for authentication.
  * Host-mode changes are now restricted after players join or become ready.
  * Online hosting restarts preserve the current room state without automatic navigation.

* **Bug Fixes**
  * Improved compatibility with the latest relay transport package.

* **Documentation**
  * Updated Hub endpoint and SignalR relay path documentation.

* **Chores**
  * Updated the application version to 0.62.19.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->