### PR TITLE
Fix standup cost

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.62.23</VersionPrefix>
+        <VersionPrefix>0.62.24</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -492,18 +492,7 @@ public class Mech : Unit
     }
 
     public override bool CanMoveBackward(MovementType type) => type == MovementType.Walk;
-
-    public override bool IsMinimumMovement
-    {
-        get
-        {
-            if (IsProne 
-                && GetMovementPoints(MovementType.Walk) == 1 
-                && StandupAttempts == 0) return true;
-            return false;
-        }
-    }
-
+    
     public bool CanJump
     {
         get
@@ -515,9 +504,7 @@ public class Mech : Unit
             if (StandupAttempts > 0) return false;
 
             // Cannot jump if no functional jump jets are available
-            if (GetMovementPoints(MovementType.Jump) < 1) return false;
-
-            return true;
+            return GetMovementPoints(MovementType.Jump) >= 1;
         }
     }
     
@@ -618,12 +605,14 @@ public class Mech : Unit
 
     public void RegisterStandupAttempt(MovementType? movementType = null)
     {
+        var standupCost = IsMinimumMovement && StandupAttempts == 0
+            ? 1 
+            : StandupCost;
         StandupAttempts++;
         movementType ??= MovementTaken?.MovementType;
         if (Position == null || movementType == null) return; 
         MovementTaken ??= MovementPath.CreateSingleSegmentPath(Position, movementType.Value);
-        var pointsToSpend = Math.Min(GetMovementPoints(MovementType.Walk), StandupCost);
-        MovementTaken = MovementTaken.WithLastSegmentEvent(new SegmentEvent(SegmentEventType.StandupAttempt), new StandUpAttemptMovementCost { Value = pointsToSpend });
+        MovementTaken = MovementTaken.WithLastSegmentEvent(new SegmentEvent(SegmentEventType.StandupAttempt), new StandUpAttemptMovementCost { Value = standupCost });
     }
 
     public void ApplyFall(MechFallCommand fallCommand)

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -24,6 +24,15 @@ public class Mech : Unit
     private const int StandupCost = 2;
 
     public int StandupAttempts { private set; get; }
+
+    /// <summary>
+    /// The actual cost of the next standup attempt, accounting for the minimum movement exception
+    /// </summary>
+    public int EffectiveStandupCost =>
+        IsMinimumMovement 
+        && StandupAttempts == 0 
+            ? 1 
+            : StandupCost;
     public int PossibleTorsoRotation { get; }
     public bool CanFlipArms { get; }
 
@@ -534,8 +543,8 @@ public class Mech : Unit
         var destroyedLegs = _parts.Values.OfType<Leg>().Count(p=> p.IsDestroyed);
         if (destroyedLegs >= 2) return false;
 
-        // Check if the Mech has at least one movement point available
-        if (GetMovementPoints(MovementTaken?.MovementType ?? MovementType.Walk) < StandupCost && !IsMinimumMovement) 
+        // Check if the Mech has at least the effective standup cost worth of movement points
+        if (GetMovementPoints(MovementTaken?.MovementType ?? MovementType.Walk) < EffectiveStandupCost) 
             return false;
 
         if (Pilot?.IsConscious == false) return false;
@@ -606,9 +615,8 @@ public class Mech : Unit
 
     public void RegisterStandupAttempt(MovementType? movementType = null)
     {
-        var standupCost = IsMinimumMovement && StandupAttempts == 0
-            ? 1 
-            : StandupCost;
+        // Must be read before StandupAttempts is incremented
+        var standupCost = EffectiveStandupCost;
         StandupAttempts++;
         movementType ??= MovementTaken?.MovementType;
         if (Position == null || movementType == null) return; 

--- a/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
+++ b/src/MakaMek.Core/Models/Units/Mechs/Mech.cs
@@ -535,7 +535,8 @@ public class Mech : Unit
         if (destroyedLegs >= 2) return false;
 
         // Check if the Mech has at least one movement point available
-        if (GetMovementPoints(MovementType.Walk) < StandupCost && !IsMinimumMovement) return false;
+        if (GetMovementPoints(MovementTaken?.MovementType ?? MovementType.Walk) < StandupCost && !IsMinimumMovement) 
+            return false;
 
         if (Pilot?.IsConscious == false) return false;
 

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -33,7 +33,7 @@ public abstract class Unit : IUnit
     {
         Chassis = chassis;
         Model = model;
-        Name = name;
+        Name = name ?? "";
         Tonnage = tonnage;
         _parts = parts.ToDictionary(p => p.Location, p => p);
         // Set the Unit reference for each part

--- a/src/MakaMek.Core/Models/Units/Unit.cs
+++ b/src/MakaMek.Core/Models/Units/Unit.cs
@@ -23,7 +23,6 @@ public abstract class Unit : IUnit
     protected readonly Dictionary<PartLocation, UnitPart> _parts;
     private readonly Queue<UiEvent> _notifications = new();
     private readonly List<UiEvent> _events = [];
-    private string? _customName;
 
     public Hex? Hex { get; private set; }
 
@@ -34,7 +33,7 @@ public abstract class Unit : IUnit
     {
         Chassis = chassis;
         Model = model;
-        _customName = name;
+        Name = name;
         Tonnage = tonnage;
         _parts = parts.ToDictionary(p => p.Location, p => p);
         // Set the Unit reference for each part
@@ -53,11 +52,13 @@ public abstract class Unit : IUnit
 
     public string Chassis { get; }
     public string Model { get; }
+
     public string Name
     {
-        get => !string.IsNullOrWhiteSpace(_customName) ? _customName : $"{Chassis} {Model}";
-        set => _customName = value;
+        get => !string.IsNullOrWhiteSpace(field) ? field : $"{Chassis} {Model}";
+        set;
     }
+
     public int Tonnage { get; }
 
     public IPlayer? Owner { get; internal set; }
@@ -239,10 +240,12 @@ public abstract class Unit : IUnit
     public abstract bool CanMoveBackward(MovementType type);
 
     /// <summary>
-    /// Determines if the unit is in a minimum movement situation (1 MP available)
+    /// Determines if the unit is in a minimum movement situation (1 MP available at the beginning  of the turn)
     /// </summary>
-    public virtual bool IsMinimumMovement => false;
-
+    public virtual bool IsMinimumMovement =>
+        ModifiedMovement == 1
+        && (MovementTaken == null || MovementTaken.TotalCost == 0);
+    
     // Location and facing
     public virtual HexPosition? Position { get; protected set; }
     public virtual HexDirection? Facing => Position?.Facing;

--- a/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Game/Phases/MovementPhaseTests.cs
@@ -1317,6 +1317,117 @@ public class MovementPhaseTests : GamePhaseTestsBase
     }
 
     [Fact]
+    public void ProcessMoveCommand_WhenRunIntoWaterFallAndStandup_RemainingRunMpReducedByFullStandupCost()
+    {
+        // Reproduces the ticket scenario: the mech runs into depth-1 water, falls, and then stands up.
+        // After a 4 MP run, only 1 walk MP remains, but 4 run MP are still available. The standup cost
+        // (2 MP) must still be fully deducted so that remaining run MP = runMp - preFallCost - standupCost.
+        // Arrange
+        SetMap();
+        _sut.Enter();
+        MockConsciousnessCalculator.MakeConsciousnessRolls(Arg.Any<IPilot>()).Returns([]);
+
+        var unit = Game.PhaseStepState!.Value.ActivePlayer.Units.Single(u => u.Id == _unit1Id) as Mech;
+        unit!.Deploy(new HexPosition(1, 2, HexDirection.Top), null);
+
+        var runMp = unit.GetMovementPoints(MovementType.Run);
+
+        var waterHex = Game.BattleMap!.GetHex(new HexCoordinates(3, 2));
+        waterHex!.AddTerrain(new WaterTerrain(-1));
+
+        // Setup water fall
+        var waterFallData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = true,
+            PilotingSkillRoll = new PilotingSkillRollData
+            {
+                RollContext = new EnteringDeepWaterRollContext(1),
+                DiceResults = [2, 2],
+                IsSuccessful = false,
+                PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+            },
+            FallingDamageData = new FallingDamageData(
+                HexDirection.Top,
+                new HitLocationsData([], 5),
+                new DiceResult(3), HitDirection.Front)
+        };
+
+        MockFallProcessor.ProcessMovementAttempt(
+                unit,
+                Arg.Is<EnteringDeepWaterRollContext>(c => c.WaterDepth == 1),
+                Game,
+                MovementType.Run)
+            .Returns(waterFallData);
+
+        // Setup successful standup
+        var successfulPsrData = new PilotingSkillRollData
+        {
+            RollContext = new PilotingSkillRollContext(PilotingSkillRollType.StandupAttempt),
+            DiceResults = [5, 5],
+            IsSuccessful = true,
+            PsrBreakdown = new PsrBreakdown { BasePilotingSkill = 4, Modifiers = [] }
+        };
+        var successfulStandupData = new FallContextData
+        {
+            UnitId = unit.Id,
+            GameId = Game.Id,
+            IsFalling = false,
+            PilotingSkillRoll = successfulPsrData,
+            LevelsFallen = 0,
+            WasJumping = false
+        };
+        MockFallProcessor.ProcessMovementAttempt(
+                unit,
+                Arg.Is<PilotingSkillRollContext>(c => c.RollType == PilotingSkillRollType.StandupAttempt),
+                Game,
+                MovementType.StandingStill)
+            .Returns(successfulStandupData);
+
+        // Act - Step 1: Run into water (triggers fall + truncation after 2 hexes, cost 4)
+        _sut.HandleCommand(new MoveUnitCommand
+        {
+            MovementType = MovementType.Run,
+            GameOriginId = Game.Id,
+            PlayerId = _player1Id,
+            UnitId = _unit1Id,
+            MovementPath =
+            [
+                new PathSegment(new HexPosition(1, 2, HexDirection.Top), new HexPosition(2, 2, HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 2 }]).ToData(),
+                new PathSegment(new HexPosition(2, 2, HexDirection.Top), new HexPosition(3, 2, HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 2 }]).ToData(),
+                new PathSegment(new HexPosition(3, 2, HexDirection.Top), new HexPosition(4, 2, HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 1 }]).ToData()
+            ]
+        });
+
+        unit.MovementPointsSpent.ShouldBe(4, "Expected cost: 4 (two hexes run into the water)");
+        unit.GetMovementPoints(MovementType.Walk).ShouldBe(1,
+            "Only 1 walk MP remains after running, so the standup cost must not be capped by walk MP");
+        unit.IsProne.ShouldBeTrue("Unit should be prone after falling into the water");
+
+        // Act - Step 2: Successful standup, then continue with Run
+        var standupCommand = new TryStandupCommand
+        {
+            GameOriginId = Game.Id,
+            PlayerId = _player1Id,
+            UnitId = _unit1Id,
+            NewFacing = HexDirection.Bottom,
+            MovementTypeAfterStandup = MovementType.Run
+        };
+        _sut.HandleCommand(standupCommand);
+
+        // Assert - remaining run MP is reduced by both the pre-fall move cost and the full standup cost
+        unit.IsProne.ShouldBeFalse("Standup should succeed");
+        unit.MovementPointsSpent.ShouldBe(6, "Combined cost: 4 (run into water) + 2 (standup)");
+        unit.MovementTaken!.TotalCost.ShouldBe(6, "MovementTaken should include both the run cost and the standup cost");
+        unit.GetMovementPoints(MovementType.Run).ShouldBe(
+            runMp - 4 - 2, "Remaining run MP must equal runMp - preFallCost - standupCost");
+    }
+
+    [Fact]
     public void ProcessMoveCommand_ShouldProcessJumpWaterEntry()
     {
         // Arrange

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -520,6 +520,23 @@ public class MechTests
     }
 
     [Fact]
+    public void ApplyWeaponConfiguration_WhenArmsFlip_ShouldNotThrow()
+    {
+        var parts = CreateBasicPartsData();
+        var sut = new Mech("Test", "TST-1A", 50, parts);
+        sut.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+
+        var configuration = new WeaponConfiguration
+        {
+            Type = WeaponConfigurationType.ArmsFlip,
+            Value = (int)HexDirection.Top
+        };
+
+        // Act & Assert
+        Should.NotThrow(() => sut.ApplyWeaponConfiguration(configuration));
+    }
+
+    [Fact]
     public void HasUsedTorsoTwist_WhenTorsosAlignedWithUnit_ShouldBeFalse()
     {
         // Arrange
@@ -2597,18 +2614,21 @@ public class MechTests
     {
         // Arrange
         var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        var pilot = Substitute.For<IPilot>();
+        pilot.IsConscious.Returns(true);
+        sut.AssignPilot(pilot);
 
         // Destroy both legs
         var leftLeg = sut.Parts[PartLocation.LeftLeg];
-        leftLeg.ApplyDamage(100, HitDirection.Front);
+        leftLeg.ApplyDamage(33, HitDirection.Front);
         var rightLeg = sut.Parts[PartLocation.RightLeg];
-        rightLeg.ApplyDamage(100, HitDirection.Front);
+        rightLeg.ApplyDamage(33, HitDirection.Front);
 
         // Destroy both arms
         var leftArm = sut.Parts[PartLocation.LeftArm];
-        leftArm.ApplyDamage(100, HitDirection.Front);
+        leftArm.ApplyDamage(23, HitDirection.Front);
         var rightArm = sut.Parts[PartLocation.RightArm];
-        rightArm.ApplyDamage(100, HitDirection.Front);
+        rightArm.ApplyDamage(23, HitDirection.Front);
 
         // Act & Assert
         sut.IsImmobile.ShouldBeTrue("A mech with both legs and both arms destroyed should be immobile");
@@ -2625,13 +2645,13 @@ public class MechTests
 
         // Destroy both legs
         var leftLeg = sut.Parts[PartLocation.LeftLeg];
-        leftLeg.ApplyDamage(20, HitDirection.Front);
+        leftLeg.ApplyDamage(33, HitDirection.Front);
         var rightLeg = sut.Parts[PartLocation.RightLeg];
-        rightLeg.ApplyDamage(20, HitDirection.Front);
+        rightLeg.ApplyDamage(33, HitDirection.Front);
 
         // Destroy one arm
         var leftArm = sut.Parts[PartLocation.LeftArm];
-        leftArm.ApplyDamage(20, HitDirection.Front);
+        leftArm.ApplyDamage(23, HitDirection.Front);
 
         // Act & Assert
         sut.IsImmobile.ShouldBeFalse("A mech with both legs but only one arm destroyed should not be immobile");
@@ -2648,9 +2668,9 @@ public class MechTests
 
         // Destroy both legs
         var leftLeg = sut.Parts[PartLocation.LeftLeg];
-        leftLeg.ApplyDamage(20, HitDirection.Front);
+        leftLeg.ApplyDamage(33, HitDirection.Front);
         var rightLeg = sut.Parts[PartLocation.RightLeg];
-        rightLeg.ApplyDamage(20, HitDirection.Front);
+        rightLeg.ApplyDamage(33, HitDirection.Front);
 
         // Act & Assert
         sut.IsImmobile.ShouldBeFalse("A mech with only legs destroyed should not be immobile");
@@ -2667,9 +2687,9 @@ public class MechTests
 
         // Destroy both arms
         var leftArm = sut.Parts[PartLocation.LeftArm];
-        leftArm.ApplyDamage(20, HitDirection.Front);
+        leftArm.ApplyDamage(23, HitDirection.Front);
         var rightArm = sut.Parts[PartLocation.RightArm];
-        rightArm.ApplyDamage(20, HitDirection.Front);
+        rightArm.ApplyDamage(23, HitDirection.Front);
 
         // Act & Assert
         sut.IsImmobile.ShouldBeFalse("A mech with only arms destroyed should not be immobile");
@@ -2680,16 +2700,19 @@ public class MechTests
     {
         // Arrange
         var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData());
+        var pilot = Substitute.For<IPilot>();
+        pilot.IsConscious.Returns(true);
+        sut.AssignPilot(pilot);
 
         // Destroy one leg, blow off another
         var leftLeg = sut.Parts[PartLocation.LeftLeg];
-        leftLeg.ApplyDamage(100, HitDirection.Front);
+        leftLeg.ApplyDamage(33, HitDirection.Front);
         var rightLeg = sut.Parts[PartLocation.RightLeg];
         rightLeg.BlowOff();
 
         // Destroy one arm, blow off another
         var leftArm = sut.Parts[PartLocation.LeftArm];
-        leftArm.ApplyDamage(100, HitDirection.Front);
+        leftArm.ApplyDamage(23, HitDirection.Front);
         var rightArm = sut.Parts[PartLocation.RightArm];
         rightArm.BlowOff();
 

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1920,7 +1920,73 @@ public class MechTests
         // Assert
         canStandup.ShouldBeTrue("Mech should be able to stand up when it has minimum movement");
     }
-        
+
+    [Fact]
+    public void RegisterStandupAttempt_AfterRealMultiHexMove_AddsStandupCostOnTopOfMoveCost()
+    {
+        // Arrange
+        var mech = new Mech("Test", "TST-1A", 50, CreateBasicPartsData(350)); // walk 7 / run 11
+        mech.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        var start = mech.Position!;
+
+        // Real multi-hex move with non-zero segment costs (unlike a same-hex zero-cost segment)
+        mech.Move(new MovementPath(
+            [
+                new PathSegment(start, new HexPosition(new HexCoordinates(1, 0), HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 2 }]),
+                new PathSegment(new HexPosition(new HexCoordinates(1, 0), HexDirection.Top),
+                    new HexPosition(new HexCoordinates(2, 0), HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 2 }])
+            ], MovementType.Run), null);
+
+        mech.GetMovementPoints(MovementType.Walk).ShouldBe(3, "Remaining walk MP after the move");
+        mech.GetMovementPoints(MovementType.Run).ShouldBe(7, "Remaining run MP after the move");
+
+        // Act
+        mech.RegisterStandupAttempt(MovementType.Run);
+
+        // Assert — standup cost (2) is added on top of the move cost (4)
+        mech.MovementPointsSpent.ShouldBe(6, "Combined cost: 4 move + 2 standup");
+        mech.GetMovementPoints(MovementType.Walk).ShouldBe(1, "7 - 4 - 2");
+        mech.GetMovementPoints(MovementType.Run).ShouldBe(5, "11 - 4 - 2");
+        mech.MovementTaken!.TotalCost.ShouldBe(6);
+        mech.MovementTaken.Segments[^1].Costs.OfType<StandUpAttemptMovementCost>()
+            .Single().Value.ShouldBe(2, "Standup should always cost its full 2 MP");
+    }
+
+    [Fact]
+    public void RegisterStandupAttempt_AfterRunMove_WithLowRemainingWalkMp_ChargesFullStandupCost()
+    {
+        // Reproduces the ticket scenario: mech runs into water (cost 6), leaving only 1 walk MP
+        // but still 5 run MP. The standup cost must not be capped by the low remaining walk MP.
+        // Arrange
+        var mech = new Mech("Test", "TST-1A", 50, CreateBasicPartsData(350)); // walk 7 / run 11
+        mech.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        var start = mech.Position!;
+
+        mech.Move(new MovementPath(
+            [
+                new PathSegment(start, new HexPosition(new HexCoordinates(1, 0), HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 3 }]),
+                new PathSegment(new HexPosition(new HexCoordinates(1, 0), HexDirection.Top),
+                    new HexPosition(new HexCoordinates(2, 0), HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 3 }])
+            ], MovementType.Run), null);
+
+        mech.GetMovementPoints(MovementType.Walk).ShouldBe(1, "Low remaining walk MP after running into water");
+        mech.GetMovementPoints(MovementType.Run).ShouldBe(5, "Run MP remaining is still high");
+
+        // Act
+        mech.RegisterStandupAttempt(MovementType.Run);
+
+        // Assert — the full 2 MP standup cost must be deducted from the run pool
+        mech.MovementPointsSpent.ShouldBe(8, "Combined cost: 6 move + 2 standup");
+        mech.GetMovementPoints(MovementType.Walk).ShouldBe(0, "7 - 6 - 2");
+        mech.GetMovementPoints(MovementType.Run).ShouldBe(3, "11 - 6 - 2");
+        mech.MovementTaken!.TotalCost.ShouldBe(8);
+        mech.MovementTaken.Segments[^1].Costs.OfType<StandUpAttemptMovementCost>()
+            .Single().Value.ShouldBe(2, "Standup should always cost its full 2 MP");
+    }
 
     [Fact]
     public void AttemptStandup_WhenCalledMultipleTimes_ShouldIncrementCounterCorrectly()
@@ -2776,6 +2842,33 @@ public class MechTests
         
         // Assert
         result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnFalse_WhenOneMpRemainsAfterMoving()
+    {
+        // The minimum movement exception applies only to a mech with 1 MP available
+        // at the BEGINNING of its turn. A mech that had more MP but spent most of them
+        // (e.g. ran into water and fell) must not qualify for it.
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData(100)); // walk 2
+        sut.SetProne();
+        sut.Deploy(new HexPosition(new HexCoordinates(1, 1), HexDirection.Top), null);
+        var start = sut.Position!;
+        sut.Move(new MovementPath(
+            [
+                new PathSegment(start, new HexPosition(new HexCoordinates(2, 1), HexDirection.Top),
+                    [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 1 }])
+            ], MovementType.Walk), null);
+
+        sut.GetMovementPoints(MovementType.Walk).ShouldBe(1, "Only 1 MP remains after the move");
+
+        // Act
+        var result = sut.IsMinimumMovement;
+
+        // Assert
+        result.ShouldBeFalse(
+            "Minimum movement must not apply to a mech that merely has 1 MP left after spending its movement");
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -1921,6 +1921,43 @@ public class MechTests
         canStandup.ShouldBeTrue("Mech should be able to stand up when it has minimum movement");
     }
 
+    [Theory]
+    [InlineData(false, 0, 2)] // Not minimum movement, no standup attempts yet
+    [InlineData(false, 1, 2)] // Not minimum movement, standup already attempted
+    [InlineData(true, 0, 1)]  // Minimum movement, first standup gets the 1 MP exception
+    [InlineData(true, 1, 2)]  // Minimum movement, but exception applies only to the first attempt
+    public void EffectiveStandupCost_ReturnsExpectedCost(bool isMinimumMovement, int standupAttempts, int expectedCost)
+    {
+        // Arrange
+        var parts = isMinimumMovement ? CreateBasicPartsData(50) : CreateBasicPartsData();
+        var sut = new Mech("Test", "TST-1A", 50, parts);
+        for (var i = 0; i < standupAttempts; i++)
+        {
+            sut.RegisterStandupAttempt(MovementType.Walk);
+        }
+
+        // Act
+        var cost = sut.EffectiveStandupCost;
+
+        // Assert
+        cost.ShouldBe(expectedCost);
+        sut.IsMinimumMovement.ShouldBe(isMinimumMovement);
+    }
+
+    [Fact]
+    public void EffectiveStandupCost_AppliesOneMpExceptionOnlyOnFirstAttempt()
+    {
+        // Arrange
+        var sut = new Mech("Test", "TST-1A", 50, CreateBasicPartsData(50)); // walk 1 MP
+        sut.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        sut.SetProne();
+
+        // Act & Assert
+        sut.EffectiveStandupCost.ShouldBe(1, "first standup attempt with minimum movement costs 1 MP");
+        sut.RegisterStandupAttempt(MovementType.Walk);
+        sut.EffectiveStandupCost.ShouldBe(2, "subsequent standup attempts cost the full 2 MP even with minimum movement");
+    }
+
     [Fact]
     public void RegisterStandupAttempt_AfterRealMultiHexMove_AddsStandupCostOnTopOfMoveCost()
     {

--- a/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/Mechs/MechTests.cs
@@ -520,7 +520,7 @@ public class MechTests
     }
 
     [Fact]
-    public void ApplyWeaponConfiguration_WhenArmsFlip_ShouldNotThrow()
+    public void ApplyWeaponConfiguration_WhenArmsFlipIsNoop_ShouldLeaveStateUnchanged()
     {
         var parts = CreateBasicPartsData();
         var sut = new Mech("Test", "TST-1A", 50, parts);
@@ -532,8 +532,11 @@ public class MechTests
             Value = (int)HexDirection.Top
         };
 
-        // Act & Assert
-        Should.NotThrow(() => sut.ApplyWeaponConfiguration(configuration));
+        // Act
+        sut.ApplyWeaponConfiguration(configuration);
+
+        // Assert
+        sut.Position!.Facing.ShouldBe(HexDirection.Top);
     }
 
     [Fact]
@@ -1948,6 +1951,11 @@ public class MechTests
         // Arrange
         var parts = isMinimumMovement ? CreateBasicPartsData(50) : CreateBasicPartsData();
         var sut = new Mech("Test", "TST-1A", 50, parts);
+        sut.Deploy(new HexPosition(new HexCoordinates(0, 0), HexDirection.Top), null);
+        sut.SetProne();
+
+        sut.IsMinimumMovement.ShouldBe(isMinimumMovement);
+
         for (var i = 0; i < standupAttempts; i++)
         {
             sut.RegisterStandupAttempt(MovementType.Walk);
@@ -1958,7 +1966,6 @@ public class MechTests
 
         // Assert
         cost.ShouldBe(expectedCost);
-        sut.IsMinimumMovement.ShouldBe(isMinimumMovement);
     }
 
     [Fact]

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -354,6 +354,19 @@ public class UnitTests
         // Assert
         result.ShouldBeNull();
     }
+
+    [Fact]
+    public void GetMountedComponentAtLocation_ShouldReturnNull_WhenLocationIsNull()
+    {
+        // Arrange
+        var unit = CreateTestUnit();
+
+        // Act
+        var result = unit.GetMountedComponentAtLocation<Weapon>(null, 0);
+
+        // Assert
+        result.ShouldBeNull();
+    }
     
     [Fact]
     public void DeclareWeaponAttack_ShouldThrowException_WhenNotDeployed()
@@ -1413,6 +1426,37 @@ public class UnitTests
         ammo1.RemainingShots.ShouldBe(3); // Unchanged
         ammo2.RemainingShots.ShouldBe(7); // Reduced by 1
         ammo3.RemainingShots.ShouldBe(5); // Unchanged
+    }
+
+    [Fact]
+    public void FireWeapon_ShouldNotThrow_WhenNoAmmoAvailable()
+    {
+        // Arrange
+        var unit = CreateTestUnit();
+        var ballisticWeapon = new TestWeapon("Ballistic Weapon", 2, WeaponType.Ballistic, MakaMekComponent.ISAmmoAC5);
+        MountWeaponOnUnit(unit, ballisticWeapon, PartLocation.LeftArm, [0, 1]);
+
+        var weaponData = new ComponentData
+        {
+            Name = ballisticWeapon.Name,
+            Type = MakaMekComponent.AC5,
+            Assignments = [new LocationSlotAssignment(PartLocation.LeftArm, 0, 2)]
+        };
+
+        // Act & Assert
+        Should.NotThrow(() => unit.FireWeapon(weaponData));
+    }
+
+    [Fact]
+    public void Deploy_WhenAlreadyDeployed_ShouldThrowException()
+    {
+        // Arrange
+        var unit = CreateTestUnit();
+        var position = new HexPosition(new HexCoordinates(1, 1), HexDirection.Bottom);
+        unit.Deploy(position, null);
+
+        // Act & Assert
+        Should.Throw<InvalidOperationException>(() => unit.Deploy(position, null));
     }
     
     [Fact]

--- a/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
+++ b/tests/MakaMek.Core.Tests/Models/Units/UnitTests.cs
@@ -2563,6 +2563,81 @@ public class UnitTests
     }
 
     [Fact]
+    public void IsMinimumMovement_ShouldReturnTrue_WhenUnitHasExactlyOneMovementPointAndNoMovementTaken()
+    {
+        // Arrange
+        var sut = CreateTestUnit(walkMp: 1);
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnFalse_WhenUnitHasZeroMovementPoints()
+    {
+        // Arrange
+        var sut = CreateTestUnit(walkMp: 0);
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeFalse("Minimum movement requires exactly 1 MP at the beginning of the turn");
+    }
+
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnFalse_WhenUnitHasMultipleMovementPoints()
+    {
+        // Arrange
+        var sut = CreateTestUnit(walkMp: 2);
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeFalse("Minimum movement applies only to a unit with 1 MP at the beginning of the turn");
+    }
+
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnFalse_WhenMovementPointsWereSpent()
+    {
+        // Arrange
+        var sut = CreateTestUnit(walkMp: 1);
+        var deployPosition = new HexPosition(new HexCoordinates(1, 1), HexDirection.Bottom);
+        sut.Deploy(deployPosition, null);
+        sut.Move(new MovementPath([
+            new PathSegment(deployPosition, new HexPosition(new HexCoordinates(2, 1), HexDirection.Bottom),
+                [new TerrainMovementCost { TerrainId = MakaMekTerrains.Clear, Value = 1 }])
+        ], MovementType.Walk), null);
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeFalse("A unit that spent movement points has moved and cannot claim minimum movement");
+    }
+
+    [Fact]
+    public void IsMinimumMovement_ShouldReturnTrue_WhenUnitHasOneMovementPointAndTookZeroCostMovement()
+    {
+        // Arrange - a zero-cost path (e.g. standing still marker) does not count as movement spent
+        var sut = CreateTestUnit(walkMp: 1);
+        var deployPosition = new HexPosition(new HexCoordinates(1, 1), HexDirection.Bottom);
+        sut.Deploy(deployPosition, null);
+        sut.Move(MovementPath.CreateSingleSegmentPath(deployPosition), null);
+        sut.MovementPointsSpent.ShouldBe(0);
+        
+        // Act
+        var result = sut.IsMinimumMovement;
+        
+        // Assert
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
     public void BaseMovement_ShouldBeZero_WhenNoEngine()
     {
         // Arrange


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ’Mech stand-up movement costs, including the first-attempt minimum-movement exception.
  * Ensured stand-up costs are accurately deducted after walking or running.
  * Improved movement-state tracking and jump eligibility calculations.
  * Improved reliability for weapon configuration, ammunition checks, component lookups, and redeployment validation.

* **Tests**
  * Added coverage for movement accounting, stand-up attempts, water-fall recovery, and related unit behavior.

* **Chores**
  * Updated the project version to 0.62.24.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->