### PR TITLE
Fix copy button

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
-        <VersionPrefix>0.62.26</VersionPrefix>
+        <VersionPrefix>0.62.27</VersionPrefix>
         <Version Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</Version>
         <Authors>Anton Makarevich</Authors>
         <Company>Anton Makarevich</Company>

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/DI/CoreServices.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/DI/CoreServices.cs
@@ -88,6 +88,7 @@ public static class CoreServices
                 sp.GetRequiredService<ILogger<EmbeddedMapResourceProvider>>(),
                 new AssemblyResourceStreamProvider("json", typeof(App).Assembly)));
         services.AddSingleton<IFileService, AvaloniaFileService>();
+        services.AddSingleton<IClipboardService, AvaloniaClipboardService>();
 
         services.AddSingleton<IPdfExportService, PdfExportService>();
 

--- a/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/NetworkFragment.axaml
+++ b/src/MakaMek.Avalonia/MakaMek.Avalonia/Views/StartNewGame/Fragments/NetworkFragment.axaml
@@ -45,6 +45,9 @@
             <StackPanel Orientation="Horizontal" Spacing="8" Margin="0,6,0,0">
                 <Button Command="{Binding CopyRoomCodeCommand}"
                         Content="{extensions:Localize 'Network_CopyRoomCode'}"/>
+                <TextBlock Text="{Binding CopyRoomCodeStatusText}"
+                           Classes="bodySmall"
+                           VerticalAlignment="Center"/>
             </StackPanel>
         </StackPanel>
 

--- a/src/MakaMek.Avalonia/MakaMek.Services.Avalonia/AvaloniaClipboardService.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Services.Avalonia/AvaloniaClipboardService.cs
@@ -1,12 +1,20 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Input.Platform;
+using Avalonia.Input;
+using Microsoft.Extensions.Logging;
 
 namespace Sanet.MakaMek.Services.Avalonia;
 
 public class AvaloniaClipboardService : IClipboardService
 {
+    private readonly ILogger<AvaloniaClipboardService> _logger;
+
+    public AvaloniaClipboardService(ILogger<AvaloniaClipboardService> logger)
+    {
+        _logger = logger;
+    }
+
     private TopLevel? GetTopLevel()
     {
         return Application.Current?.ApplicationLifetime switch
@@ -17,18 +25,22 @@ public class AvaloniaClipboardService : IClipboardService
         };
     }
 
-    public async Task SetTextAsync(string text)
+    public async Task<bool> SetText(string text)
     {
         var topLevel = GetTopLevel();
-        if (topLevel?.Clipboard is null) return;
+        if (topLevel?.Clipboard is null) return false;
 
         try
         {
-            await topLevel.Clipboard.SetTextAsync(text);
+            using var transfer = new DataTransfer();
+            transfer.Add(DataTransferItem.CreateText(text));
+            await topLevel.Clipboard.SetDataAsync(transfer);
+            return true;
         }
-        catch
+        catch (Exception ex)
         {
-            // Ignore clipboard failures (unsupported platform, permission denied).
+            _logger.LogWarning(ex, "Failed to copy text to the clipboard");
+            return false;
         }
     }
 }

--- a/src/MakaMek.Avalonia/MakaMek.Services.Avalonia/AvaloniaClipboardService.cs
+++ b/src/MakaMek.Avalonia/MakaMek.Services.Avalonia/AvaloniaClipboardService.cs
@@ -1,0 +1,34 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input.Platform;
+
+namespace Sanet.MakaMek.Services.Avalonia;
+
+public class AvaloniaClipboardService : IClipboardService
+{
+    private TopLevel? GetTopLevel()
+    {
+        return Application.Current?.ApplicationLifetime switch
+        {
+            IClassicDesktopStyleApplicationLifetime desktop => TopLevel.GetTopLevel(desktop.MainWindow),
+            ISingleViewApplicationLifetime singleView => TopLevel.GetTopLevel(singleView.MainView),
+            _ => null
+        };
+    }
+
+    public async Task SetTextAsync(string text)
+    {
+        var topLevel = GetTopLevel();
+        if (topLevel?.Clipboard is null) return;
+
+        try
+        {
+            await topLevel.Clipboard.SetTextAsync(text);
+        }
+        catch
+        {
+            // Ignore clipboard failures (unsupported platform, permission denied).
+        }
+    }
+}

--- a/src/MakaMek.Core/Services/Transport/Relay/RelayHubConfigurationProvider.cs
+++ b/src/MakaMek.Core/Services/Transport/Relay/RelayHubConfigurationProvider.cs
@@ -19,7 +19,7 @@ public sealed class RelayHubConfigurationProvider : IRelayHubConfigurationProvid
     private readonly IFileCachingService _cachingService;
     private readonly ILogger<RelayHubConfigurationProvider> _logger;
     private readonly Dictionary<string, HubConfigData> _hubs = new(StringComparer.Ordinal);
-    private readonly object _gate = new();
+    private readonly Lock _gate = new();
     private readonly SemaphoreSlim _operationGate = new(1, 1);
     private readonly Task _loadTask;
     private string _activeHubId = DemoHubId;
@@ -40,7 +40,7 @@ public sealed class RelayHubConfigurationProvider : IRelayHubConfigurationProvid
             IsBuiltIn: true);
         _hubs[DemoHubId] = demoHub;
 
-        _loadTask = LoadAsync();
+        _loadTask = Load();
     }
 
     public string ActiveHubId
@@ -217,8 +217,8 @@ public sealed class RelayHubConfigurationProvider : IRelayHubConfigurationProvid
         try
         {
             await EnsureLoadedAsync();
-            HubConfigData? previous = null;
-            var wasActive = false;
+            HubConfigData? previous;
+            bool wasActive;
             lock (_gate)
             {
                 if (!_hubs.TryGetValue(id, out var existing))
@@ -302,7 +302,7 @@ public sealed class RelayHubConfigurationProvider : IRelayHubConfigurationProvid
         }
     }
 
-    private async Task LoadAsync()
+    private async Task Load()
     {
         try
         {
@@ -376,7 +376,7 @@ public sealed class RelayHubConfigurationProvider : IRelayHubConfigurationProvid
     /// </summary>
     private sealed class HubConfigurationsState
     {
-        public List<HubConfigData> Hubs { get; set; } = [];
-        public string? ActiveHubId { get; set; }
+        public List<HubConfigData> Hubs { get; init; } = [];
+        public string? ActiveHubId { get; init; }
     }
 }

--- a/src/MakaMek.Localization/FakeLocalizationService.cs
+++ b/src/MakaMek.Localization/FakeLocalizationService.cs
@@ -466,6 +466,8 @@ public class FakeLocalizationService : ILocalizationService
         ["Network_HostModeOnline"] = "Online",
         ["Network_RoomCode"] = "Room Code",
         ["Network_CopyRoomCode"] = "Copy",
+        ["Network_CopyRoomCode_Success"] = "Copied to clipboard",
+        ["Network_CopyRoomCode_Failed"] = "Copy failed",
         ["Hosting_Starting"] = "Starting hosted game...",
         ["Hosting_RoomReady"] = "Game is running — share the room code above",
         ["Hosting_Failed"] = "Failed to start the hosted game.",

--- a/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
@@ -34,6 +34,7 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
 {
     private readonly IGameManager _gameManager;
     private readonly ILocalizationService _localizationService;
+    private readonly IClipboardService _clipboardService;
     private CancellationTokenSource? _initCts;
     private bool _isDisposed;
     private HostMode _hostMode = HostMode.Lan;
@@ -52,7 +53,8 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
         IBotManager botManager,
         ILogger<StartNewGameViewModel> logger,
         ILocalizationService localizationService,
-        IMechFactory mechFactory)
+        IMechFactory mechFactory,
+        IClipboardService clipboardService)
         : base(unitsLoader,
             commandPublisher,
             dispatcherService,
@@ -64,6 +66,7 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
     {
         _gameManager = gameManager;
         _localizationService = localizationService;
+        _clipboardService = clipboardService;
         MapConfig = new MapConfigViewModel(mapPreviewRenderer, mapFactory, mapResourceProvider, fileService, logger, dispatcherService, localizationService);
         AddPlayerCommand = new AsyncCommand(() => AddPlayer());
         AddBotCommand = new AsyncCommand(()=>AddPlayer(controlType: PlayerControlType.Bot));
@@ -361,10 +364,10 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
         }
     }
 
-    private Task CopyRoomCode()
+    private async Task CopyRoomCode()
     {
-        // Clipboard access belongs to the platform layer; a clipboard service can be wired here.
-        return Task.CompletedTask;
+        if (RoomCode == null) return;
+        await _clipboardService.SetTextAsync(RoomCode);
     }
 
     public bool IsNetworkSectionExpanded

--- a/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
+++ b/src/MakaMek.Presentation/ViewModels/StartNewGameViewModel.cs
@@ -316,11 +316,43 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
         }
     }
 
+    /// <summary>
+    /// Gets or sets whether the last room-code copy attempt succeeded. Null before the first attempt.
+    /// </summary>
+    public bool? RoomCodeCopySucceeded
+    {
+        get;
+        private set
+        {
+            if (field == value) return; // Reject no-op when unchanged
+            field = value;
+            NotifyPropertyChanged();
+            NotifyPropertyChanged(nameof(CopyRoomCodeStatusText));
+        }
+    }
+
+    /// <summary>
+    /// Gets the localized status text for the last room-code copy attempt. Empty before the first attempt.
+    /// </summary>
+    public string CopyRoomCodeStatusText
+    {
+        get
+        {
+            return RoomCodeCopySucceeded switch
+            {
+                true => _localizationService.GetString("Network_CopyRoomCode_Success"),
+                false => _localizationService.GetString("Network_CopyRoomCode_Failed"),
+                _ => string.Empty
+            };
+        }
+    }
+
     private void ClearHostingState()
     {
         IsHosting = false;
         RoomCode = null;
         HostingError = null;
+        RoomCodeCopySucceeded = null;
     }
 
     /// <summary>
@@ -367,7 +399,7 @@ public class StartNewGameViewModel : NewGameViewModel, IDisposable
     private async Task CopyRoomCode()
     {
         if (RoomCode == null) return;
-        await _clipboardService.SetTextAsync(RoomCode);
+        RoomCodeCopySucceeded = await _clipboardService.SetText(RoomCode);
     }
 
     public bool IsNetworkSectionExpanded

--- a/src/MakaMek.Services/IClipboardService.cs
+++ b/src/MakaMek.Services/IClipboardService.cs
@@ -8,5 +8,6 @@ public interface IClipboardService
     /// <summary>
     /// Copies the given text to the system clipboard.
     /// </summary>
-    Task SetTextAsync(string text);
+    /// <returns>True if the text was copied to the clipboard, false otherwise.</returns>
+    Task<bool> SetText(string text);
 }

--- a/src/MakaMek.Services/IClipboardService.cs
+++ b/src/MakaMek.Services/IClipboardService.cs
@@ -1,0 +1,12 @@
+namespace Sanet.MakaMek.Services;
+
+/// <summary>
+/// Service for copying text to the system clipboard.
+/// </summary>
+public interface IClipboardService
+{
+    /// <summary>
+    /// Copies the given text to the system clipboard.
+    /// </summary>
+    Task SetTextAsync(string text);
+}

--- a/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
+++ b/tests/MakaMek.Localization.Tests/FakeLocalizationServiceTests.cs
@@ -918,6 +918,8 @@ public class FakeLocalizationServiceTests
     [InlineData("Network_HostModeOnline", "Online")]
     [InlineData("Network_RoomCode", "Room Code")]
     [InlineData("Network_CopyRoomCode", "Copy")]
+    [InlineData("Network_CopyRoomCode_Success", "Copied to clipboard")]
+    [InlineData("Network_CopyRoomCode_Failed", "Copy failed")]
     [InlineData("Hosting_Starting", "Starting hosted game...")]
     [InlineData("Hosting_RoomReady", "Game is running — share the room code above")]
     [InlineData("Hosting_Failed", "Failed to start the hosted game.")]

--- a/tests/MakaMek.Presentation.Tests/ViewModels/MainMenuViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/MainMenuViewModelTests.cs
@@ -85,7 +85,8 @@ public class MainMenuViewModelTests
             Substitute.For<IBotManager>(),
             Substitute.For<ILogger<StartNewGameViewModel>>(),
             _localizationService,
-            Substitute.For<IMechFactory>()
+            Substitute.For<IMechFactory>(),
+            Substitute.For<IClipboardService>()
         );
         _navigationService.GetNewViewModelAsync<StartNewGameViewModel>().Returns(startVm);
 

--- a/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
@@ -60,6 +60,7 @@ public class StartNewGameViewModelTests
     private readonly IMapPreviewRenderer _mapPreviewRenderer = Substitute.For<IMapPreviewRenderer>();
     private readonly IMapResourceProvider _mapResourceProvider = Substitute.For<IMapResourceProvider>();
     private readonly IFileService _fileService = Substitute.For<IFileService>();
+    private readonly IClipboardService _clipboardService = Substitute.For<IClipboardService>();
     private readonly IHashService _hashService = Substitute.For<IHashService>();
     private readonly IBotManager _botManager = Substitute.For<IBotManager>();
     private readonly ILogger<StartNewGameViewModel> _vmLogger = Substitute.For<ILogger<StartNewGameViewModel>>();
@@ -120,7 +121,8 @@ public class StartNewGameViewModelTests
             _botManager,
             _vmLogger,
             _localizationService,
-            _mechFactory);
+            _mechFactory,
+            _clipboardService);
         _sut.AttachHandlers();
         _sut.SetNavigationService(_navigationService);
     }
@@ -843,6 +845,7 @@ public class StartNewGameViewModelTests
 
         sut.CopyRoomCodeCommand.CanExecute(null).ShouldBeTrue();
         Should.NotThrow(() => sut.CopyRoomCodeCommand.Execute(null));
+        await _clipboardService.Received(1).SetTextAsync("ABCDEF");
     }
 
     private StartNewGameViewModel CreateSut(
@@ -861,7 +864,8 @@ public class StartNewGameViewModelTests
         _botManager,
         _vmLogger,
         _localizationService,
-        _mechFactory);
+        _mechFactory,
+        _clipboardService);
 
     [Fact]
     public async Task HandleServerCommand_JoinGameCommand_AddsRemotePlayer()
@@ -1308,7 +1312,8 @@ public class StartNewGameViewModelTests
             _botManager,
             _vmLogger,
             _localizationService,
-            _mechFactory);
+            _mechFactory,
+            _clipboardService);
         sut.AttachHandlers();
 
         // Assert
@@ -1344,7 +1349,8 @@ public class StartNewGameViewModelTests
             _botManager,
             _vmLogger,
             _localizationService,
-            _mechFactory);
+            _mechFactory,
+            _clipboardService);
         sut.AttachHandlers();
 
         // Act
@@ -1375,7 +1381,8 @@ public class StartNewGameViewModelTests
             _botManager,
             _vmLogger,
             _localizationService,
-            _mechFactory);
+            _mechFactory,
+            _clipboardService);
         await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
         sut.AttachHandlers();
         
@@ -1404,7 +1411,8 @@ public class StartNewGameViewModelTests
             _botManager,
             _vmLogger,
             _localizationService,
-            _mechFactory);
+            _mechFactory,
+            _clipboardService);
         await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
         sut.AttachHandlers();
 
@@ -1560,7 +1568,8 @@ public class StartNewGameViewModelTests
             commandPublisher, _dispatcherService,
             _gameFactory, _mapFactory, _cachingService, _mapPreviewRenderer,
             _mapResourceProvider, _fileService, _botManager,
-            _vmLogger, _localizationService, _mechFactory);
+            _vmLogger, _localizationService, _mechFactory,
+            _clipboardService);
 
         sut.AttachHandlers();
         sut.DetachHandlers();
@@ -1585,7 +1594,8 @@ public class StartNewGameViewModelTests
             commandPublisher, _dispatcherService,
             _gameFactory, _mapFactory, _cachingService, _mapPreviewRenderer,
             _mapResourceProvider, _fileService, _botManager,
-            _vmLogger, _localizationService, _mechFactory);
+            _vmLogger, _localizationService, _mechFactory,
+            _clipboardService);
 
         sut.AttachHandlers();
         sut.Dispose();
@@ -1610,7 +1620,8 @@ public class StartNewGameViewModelTests
             commandPublisher, _dispatcherService,
             _gameFactory, _mapFactory, _cachingService, _mapPreviewRenderer,
             _mapResourceProvider, _fileService, _botManager,
-            _vmLogger, _localizationService, _mechFactory);
+            _vmLogger, _localizationService, _mechFactory,
+            _clipboardService);
 
         sut.AttachHandlers();
         sut.AttachHandlers();

--- a/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
+++ b/tests/MakaMek.Presentation.Tests/ViewModels/StartNewGameViewModelTests.cs
@@ -845,7 +845,128 @@ public class StartNewGameViewModelTests
 
         sut.CopyRoomCodeCommand.CanExecute(null).ShouldBeTrue();
         Should.NotThrow(() => sut.CopyRoomCodeCommand.Execute(null));
-        await _clipboardService.Received(1).SetTextAsync("ABCDEF");
+        await _clipboardService.Received(1).SetText("ABCDEF");
+    }
+
+    [Fact]
+    public async Task CopyRoomCodeCommand_WhenCopySucceeds_SetsRoomCodeCopySucceeded()
+    {
+        _clipboardService.SetText("ABCDEF").Returns(true);
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.InitializeLobbyOnline(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.IsOnlineMode = true;
+
+        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+
+        Should.NotThrow(() => sut.CopyRoomCodeCommand.Execute(null));
+
+        sut.RoomCodeCopySucceeded.ShouldBe(true);
+    }
+
+    [Fact]
+    public async Task CopyRoomCodeCommand_WhenCopyFails_SetsRoomCodeCopySucceeded()
+    {
+        _clipboardService.SetText("ABCDEF").Returns(false);
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.InitializeLobbyOnline(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.IsOnlineMode = true;
+
+        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+
+        Should.NotThrow(() => sut.CopyRoomCodeCommand.Execute(null));
+
+        sut.RoomCodeCopySucceeded.ShouldBe(false);
+    }
+
+    [Fact]
+    public void RoomCodeCopySucceeded_WhenNoCopyAttempted_IsNullAndStatusTextEmpty()
+    {
+        _sut.RoomCodeCopySucceeded.ShouldBeNull();
+        _sut.CopyRoomCodeStatusText.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public async Task CopyRoomCodeCommand_WhenCopySucceeds_StatusTextShowsSuccess()
+    {
+        _localizationService.GetString("Network_CopyRoomCode_Success").Returns("Copied to clipboard");
+        _clipboardService.SetText("ABCDEF").Returns(true);
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.InitializeLobbyOnline(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.IsOnlineMode = true;
+
+        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+
+        Should.NotThrow(() => sut.CopyRoomCodeCommand.Execute(null));
+
+        sut.CopyRoomCodeStatusText.ShouldBe("Copied to clipboard");
+    }
+
+    [Fact]
+    public async Task CopyRoomCodeCommand_WhenCopyFails_StatusTextShowsFailure()
+    {
+        _localizationService.GetString("Network_CopyRoomCode_Failed").Returns("Copy failed");
+        _clipboardService.SetText("ABCDEF").Returns(false);
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.InitializeLobbyOnline(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.IsOnlineMode = true;
+
+        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+
+        Should.NotThrow(() => sut.CopyRoomCodeCommand.Execute(null));
+
+        sut.CopyRoomCodeStatusText.ShouldBe("Copy failed");
+    }
+
+    [Fact]
+    public async Task SwitchingHostMode_ResetsRoomCodeCopySucceeded()
+    {
+        _clipboardService.SetText("ABCDEF").Returns(true);
+        var gameManager = Substitute.For<IGameManager>();
+        gameManager.InitializeLobbyOnline(Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+        gameManager.RoomCode.Returns("ABCDEF");
+        gameManager.OnlineError.Returns((RelayClientError?)null);
+        gameManager.IsOnlineServerRunning.Returns(true);
+        var commandPublisher = Substitute.For<ICommandPublisher>();
+        _gameFactory.CreateClientGame(commandPublisher).Returns(_clientGame);
+        var sut = CreateSut(gameManager, commandPublisher);
+        sut.IsOnlineMode = true;
+        await sut.InitializeLobbyAndSubscribe(CancellationToken.None);
+        Should.NotThrow(() => sut.CopyRoomCodeCommand.Execute(null));
+        sut.RoomCodeCopySucceeded.ShouldBe(true);
+
+        sut.IsLanMode = true;
+
+        sut.RoomCodeCopySucceeded.ShouldBeNull();
+        sut.CopyRoomCodeStatusText.ShouldBeEmpty();
     }
 
     private StartNewGameViewModel CreateSut(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Room codes can now be copied directly to the clipboard when starting a network game.
  - Added clear success or failure feedback beside the copy button.
  - Clipboard support works across supported desktop and single-view app configurations.

- **Bug Fixes**
  - Copying a room code now performs the expected clipboard operation instead of completing without action.
  - Copy status resets when hosting state is cleared.

- **Localization**
  - Added localized messages for successful and failed room-code copy attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->